### PR TITLE
add iso, vob and mdf to the --no-compression list

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -191,8 +191,8 @@ compression = 1
 # compiled version of the first.
 no_compression_regexp_string = (
     b"(?i).*\\.(gz|z|bz|bz2|tgz|zip|rpm|deb|"
-    b"jpg|jpeg|gif|png|jp2|mp3|ogg|avi|wmv|mpeg|mpg|rm|mov|flac|shn|pgp|"
-    b"gpg|rz|lzh|zoo|lharc|rar|arj|asc)$")
+    b"jpg|jpeg|gif|png|jp2|mp3|mp4|ogg|avi|wmv|mpeg|mpg|rm|mov|flac|shn|pgp|"
+    b"gpg|rz|lzh|zoo|lharc|rar|arj|asc|vob|mdf)$")
 no_compression_regexp = None
 
 # If true, filelists and directory statistics will be split on


### PR DESCRIPTION
Extend the default --no-compression file extension list by some more
common extensions that are used for DVD backups.

As proposed by
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=607257