### PR TITLE
add --no-fsync support

### DIFF
--- a/rdiff-backup/rdiff_backup/Globals.py
+++ b/rdiff-backup/rdiff_backup/Globals.py
@@ -245,6 +245,12 @@ symlink_perms = None
 # tempfile.tempdir value on remote connections
 remote_tempdir = None
 
+# Fsync everything by default. Use --no-fsync only if you really know what you are doing
+# Not having the data written to disk may render your backup unusable in case of FS failure.
+# Using --no-fsync disables only fsync of files during backup and sync() system call upon backup finish
+# and pre-regress
+do_fsync = True
+
 def get(name):
 	"""Return the value of something in this module"""
 	return globals()[name]

--- a/rdiff-backup/rdiff_backup/Main.py
+++ b/rdiff-backup/rdiff_backup/Main.py
@@ -86,7 +86,8 @@ def parse_cmdlineoptions(arglist):
 		  "restrict-read-only=", "restrict-update-only=", "server",
 		  "ssh-no-compression", "tempdir=", "terminal-verbosity=",
 		  "test-server", "user-mapping-file=", "verbosity=", "verify",
-		  "verify-at-time=", "version"])
+		  "verify-at-time=", "version",
+		  "no-fsync"])
 	except getopt.error, e:
 		commandline_error("Bad commandline options: " + str(e))
 
@@ -206,6 +207,7 @@ def parse_cmdlineoptions(arglist):
 		elif opt == "-V" or opt == "--version":
 			print "rdiff-backup " + Globals.version
 			sys.exit(0)
+		elif opt == "--no-fsync": Globals.do_fsync = False
 		else: Log.FatalError("Unknown option %s" % opt)
 	Log("Using rdiff-backup version %s" % (Globals.version), 4)
 
@@ -534,8 +536,8 @@ def backup_remove_curmirror_local():
 	if curmir_incs[0].getinctime() < curmir_incs[1].getinctime():
 		older_inc = curmir_incs[0]
 	else: older_inc = curmir_incs[1]
-
-	C.sync() # Make sure everything is written before curmirror is removed
+	if Globals.do_fsync:
+		C.sync() # Make sure everything is written before curmirror is removed
 	older_inc.delete()
 
 

--- a/rdiff-backup/rdiff_backup/Main.py
+++ b/rdiff-backup/rdiff_backup/Main.py
@@ -819,7 +819,7 @@ def ListAtTime(rp):
 	mirror_rp = restore_root.new_index(restore_index)
 	inc_rp = mirror_rp.append_path("increments", restore_index)
 	for rorp in rp.conn.restore.ListAtTime(mirror_rp, inc_rp, rest_time):
-		print rorp.get_indexpath()
+		print rorp.get_indexpath() + ('/' if rorp.isdir() else '')
 	
 
 def Compare(compare_type, src_rp, dest_rp, compare_time = None):

--- a/rdiff-backup/rdiff_backup/regress.py
+++ b/rdiff-backup/rdiff_backup/regress.py
@@ -71,7 +71,8 @@ def Regress(mirror_rp):
 	for rf in iterate_meta_rfs(mirror_rp, inc_rpath): ITR(rf.index, rf)
 	ITR.Finish()
 	if former_current_mirror_rp:
-		C.sync() # Sync first, since we are marking dest dir as good now
+		if Globals.do_fsync:
+			C.sync() # Sync first, since we are marking dest dir as good now
 		former_current_mirror_rp.delete()
 
 def set_regress_time():

--- a/rdiff-backup/rdiff_backup/rpath.py
+++ b/rdiff-backup/rdiff_backup/rpath.py
@@ -1284,8 +1284,9 @@ class RPath(RORPath):
 		This can be useful for directories.
 
 		"""
-		if not fp: self.conn.rpath.RPath.fsync_local(self)
-		else: os.fsync(fp.fileno())
+		if Globals.do_fsync:
+			if not fp: self.conn.rpath.RPath.fsync_local(self)
+			else: os.fsync(fp.fileno())
 
 	def fsync_local(self, thunk = None):
 		"""fsync current file, run locally
@@ -1294,6 +1295,7 @@ class RPath(RORPath):
 		the file's file descriptor.
 
 		"""
+		assert Globals.do_fsync
 		assert self.conn is Globals.local_connection
 		try:
 			fd = os.open(self.path, os.O_RDONLY)


### PR DESCRIPTION
Hi.

We are using this patch for simultaneous backups of many servers. The backup server is very busy during the backups and removing fsync() calls reduced the time of completion from 30+ hours to around 6 hours.

I think that this could come in handy to someone else too.
Of course you need to know that the server is sufficiently secured against power outage and/or the backup data is disposable.

Best regards,
Jiri Lunacek