### PR TITLE
Add rdiff dependency for tests to developer documentation

### DIFF
--- a/DEVELOP.adoc
+++ b/DEVELOP.adoc
@@ -7,6 +7,7 @@ Some notes for developers and other people willing to help development.
 - Install:
 * tox
 * libacl-devel (for sys/acl.h)
+* rdiff (with support for -H parameter)
 - unpack the test-files (see note) to a directory `rdiff-backup_testfiles` next to the cloned Git repository
 - run `tox` to use the default `tox.ini`
 - or `tox -c tox_slow.ini` for long tests


### PR DESCRIPTION
rdiff (with -H parameter support) is needed to run tests ([librsynctest.py testDelta](https://github.com/rdiff-backup/rdiff-backup/blob/master/testing/librsynctest.py#L118))