### PR TITLE
Master fix librsynctest for librsync 0.9.7

### DIFF
--- a/DEVELOP.adoc
+++ b/DEVELOP.adoc
@@ -7,7 +7,7 @@ Some notes for developers and other people willing to help development.
 - Install:
 * tox
 * libacl-devel (for sys/acl.h)
-* rdiff (with support for -H parameter)
+* rdiff
 - unpack the test files previously available from
 https://download-mirror.savannah.gnu.org/releases/rdiff-backup/testfiles.tar.gz and now temporarily available as
 release under https://github.com/ericzolf/rdiff-backup/releases[]:

--- a/testing/librsynctest.py
+++ b/testing/librsynctest.py
@@ -1,4 +1,4 @@
-import unittest, random
+import unittest, random, subprocess
 from commontest import *
 from rdiff_backup import librsync, log
 
@@ -32,8 +32,12 @@ class LibrsyncTest(unittest.TestCase):
 		for i in range(iterations):
 			MakeRandomFile(self.basis.path, file_len)
 			self._clean_file(self.sig)
-			assert not os.system(b"rdiff -b %i -H md4 signature %s %s" %
-								 (blocksize, self.basis.path, self.sig.path))
+			if b'-H' in subprocess.check_output(["rdiff", "--help"]):
+				assert not os.system(b"rdiff -b %i -H md4 signature %b %b" %
+									 (blocksize, self.basis.path, self.sig.path))
+			else:
+				assert not os.system(b"rdiff -b %i signature %b %b" %
+									 (blocksize, self.basis.path, self.sig.path))
 			with self.sig.open("rb") as fp:
 				rdiff_sig = fp.read()
 


### PR DESCRIPTION
This includes https://github.com/rdiff-backup/rdiff-backup/pull/90

Currently the librsynctest.py tests fail on Ubuntu 18.04 LTS because the rdiff command has no -H parameter yet.

This fix checks in the help page of the rdiff command if there is any mention of `-H` and runs the test the old way in case there is no support for `-H`