### PR TITLE
Extend Tox to include flake8 static Python code analysis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # Use tox_slow.ini for longer running tests.
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py35, py36, py37, py38, flake8
 
 [testenv]
 deps =
@@ -48,3 +48,20 @@ commands =
     python testing/cmdlinetest.py
 # can only work on OS/X TODO later
 #    python testing/resourceforktest.py
+
+[testenv:flake8]
+deps =
+    flake8
+commands =
+    flake8 .
+
+[flake8]
+ignore =
+    E501 # line too long (86 > 79 characters)
+exclude =
+    .git
+    .tox
+    .tox.root
+    __pycache__
+    build
+max-complexity = 40


### PR DESCRIPTION
We want our code to be PEP-8 compliant, right?