### PR TITLE
Fix setup.py after 8111745a011e8fb6baec7d003100d40d0578f7d2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(name="rdiff-backup",
 	  scripts = ['rdiff-backup', 'rdiff-backup-statistics'],
 	  data_files = [('share/man/man1', ['rdiff-backup.1', 'rdiff-backup-statistics.1']),
 					('share/doc/rdiff-backup-%s' % (version_string,),
-					 ['CHANGELOG', 'COPYING', 'README', 'FAQ-body.html'])],
+					 ['CHANGELOG', 'COPYING', 'README.md', 'FAQ-body.html'])],
 					**extra_options) # FIXME improve FAQ.html vs. body


### PR DESCRIPTION
README was renamed to README.md