### PR TITLE
Fix extended_filename should be utf-8 encoded bytes when appended

### DIFF
--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -223,8 +223,8 @@ class FSAbilities:
 		assert ord_rp.lstat()
 		ord_rp.delete()
 
-		# Try a UTF-8 encoded character, it's a path as string FIXME?
-		extended_filename = 'uni' + chr(225) + chr(132) + chr(137)
+		# Try path with UTF-8 encoded character
+		extended_filename = ('uni' + chr(225) + chr(132) + chr(137)).encode('utf-8')
 		ext_rp = None
 		try:
 			ext_rp = subdir.append(extended_filename)


### PR DESCRIPTION
otherwise python might try to convert it with the default encoding which
could be ascii.

On my test systems i accidentially used python with default encoding 'ascii' which means python cannot convert the string `uniá` to bytes. As the test for extended filenames here is intended to test the filesystem (and not if python has the correct default encoding set) we need to convert the string to utf-8 encoded bytes before we append it to a path)