### PR TITLE
Get rid of C implementation of make_file_dict

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -282,29 +282,10 @@ def make_file_dict(filename):
 	filename over the network, thus avoiding the need to pickle an
 	(incomplete) rpath object.
 	"""
-	if os.name != 'nt':
-		try:
-			return C.make_file_dict(filename)
-		except OSError as error:
-			# Unicode filenames should be processed by the Python version
-			if error.errno != errno.EILSEQ and error.errno != errno.EINVAL:
-				raise
-		except UnicodeEncodeError as error:
-			pass
 
-	return make_file_dict_python(filename)
-
-def make_file_dict_python(filename):
-	"""Create the data dictionary using a Python call to os.lstat
-	
-	We do this on Windows since Python's implementation is much better
-	than the one in cmodule.c    Eventually, we will move to using
-	this on all platforms since CPUs have gotten much faster than
-	they were when it was necessary to write cmodule.c
-	"""
 	try:
 		statblock = os.lstat(filename)
-	except os.error:
+	except (FileNotFoundError, NotADirectoryError):
 		return {'type':None}
 	data = {}
 	mode = statblock[stat.ST_MODE]

--- a/testing/ctest.py
+++ b/testing/ctest.py
@@ -5,22 +5,6 @@ from rdiff_backup.rpath import *
 
 class CTest(unittest.TestCase):
 	"""Test the C module by comparing results to python functions"""
-	def test_make_dict(self):
-		"""Test making stat dictionaries"""
-		rp1 = RPath(Globals.local_connection, "/dev/ttyS1")
-		rp2 = RPath(Globals.local_connection, "./ctest.py")
-		rp3 = RPath(Globals.local_connection, "aestu/aeutoheu/oeu")
-		rp4 = RPath(Globals.local_connection, "testfiles/various_file_types/symbolic_link")
-		rp5 = RPath(Globals.local_connection, "testfiles/various_file_types/fifo")
-
-		for rp in [rp1, rp2, rp3, rp4, rp5]:
-			dict1 = make_file_dict_python(rp.path)
-			dict2 = C.make_file_dict(rp.path)
-			if dict1 != dict2:
-				print("Python dictionary: ", dict1)
-				print("not equal to C dictionary: ", dict2)
-				print("for path ", rp.path)
-				assert 0
 
 	def test_sync(self):
 		"""Test running C.sync"""


### PR DESCRIPTION
- remove the code from cmodule.c
- rename make_file_dict_python to make_file_dict in rpath
- fix issue with wrong exception catching (meaning it shouldn't have
  worked under Windows before)
- remove the corresponding test from ctest
- Closes #101 Rpath test fails on major dev bigger 256

I also did tests before and after using `tox -c tox_slow.ini` and the impact is barely noticeable, and it's even sometimes a little bit faster, so no negative impact on performance.