### PR TITLE
Fix regression of local tests on ACLs and uncomment rpath char dev test

### DIFF
--- a/testing/eas_aclstest.py
+++ b/testing/eas_aclstest.py
@@ -272,9 +272,8 @@ user.empty
 class ACLTest(unittest.TestCase):
     """Test access control lists"""
 
-    # @TODO: Use the instrumented testuser here in case tests are run as root
-    current_user = 'testuser' # pwd.getpwuid(os.getuid()).pw_name
-    current_group = 'testuser' # grp.getgrgid(os.getgid()).gr_name
+    current_user = os.getenv('RDIFF_TEST_USER', pwd.getpwuid(os.getuid()).pw_name)
+    current_group = os.getenv('RDIFF_TEST_GROUP', grp.getgrgid(os.getgid()).gr_name)
 
     sample_acl = AccessControlLists((), """user::rwx
 user:root:rwx

--- a/testing/rpathtest.py
+++ b/testing/rpathtest.py
@@ -56,11 +56,11 @@ class CheckTypes(RPathTest):
         assert rpath.RPath(self.lc, self.prefix, ("fifo", )).isfifo()
         assert not rpath.RPath(self.lc, self.prefix, ()).isfifo()
 
-    # @TODO: One cannot really assume tty2 exists everywhere
-    #def testCharDev(self):
-    #    """Char special files identified"""
-    #    assert rpath.RPath(self.lc, "/dev/tty2", ()).ischardev()
-    #    assert not rpath.RPath(self.lc, self.prefix, ("regular_file", )).ischardev()
+    @unittest.skipUnless(os.path.exists('/dev/tty2'), "Test requires /dev/tty2")
+    def testCharDev(self):
+        """Char special files identified"""
+        assert rpath.RPath(self.lc, "/dev/tty2", ()).ischardev()
+        assert not rpath.RPath(self.lc, self.prefix, ("regular_file", )).ischardev()
 
     @unittest.skipUnless(
         os.path.exists('/dev/sda') or os.path.exists('/dev/nvme0n1'),
@@ -302,7 +302,8 @@ class FilenameOps(RPathTest):
                 "%s => %s instead of %s" % (full, result, split)
 
     @unittest.skipUnless(
-        os.path.exists('/dev/sda') or os.path.exists('/dev/nvme0n1'),
+        (os.path.exists('/dev/sda') or os.path.exists('/dev/nvme0n1'))
+        and os.path.exists('/dev/tty2'),
         "Test requires either /dev/sda or /dev/nvme0n1")
     def testGetnums(self):
         """Test getting file numbers"""

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@
 envlist = py35, py36, py37, py38, flake8
 
 [testenv]
+# make sure those variables are passed down; you should define 
+# either explicitly the RDIFF_TEST_* variables or rely on the current
+# user being correctly identified (which might not happen in a container)
+passenv = RDIFF_TEST_USER RDIFF_TEST_GROUP
 deps =
     pyxattr
     pylibacl


### PR DESCRIPTION
This is basically a revert of 5954f6059ff49bcb426daa0eed73d81665c99bad

- User and Group for ACL tests are now gathered optionally from environment
  variables RDIFF_TEST_USER and RDIFF_TEST_GROUP.
- Rpath tests implying existence of /dev/tty2 are skipped if it doesn't exist

Closes #117