### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@ operation. Closes Ubuntu bug #329722. (Andrew Ferguson)
 
 Don't crash on zlib errors. Closes Debian bug #518531. (Andrew Ferguson)
 
-Make sticky bit warnings quieter while determinating file system abilities.
+Make sticky bit warnings quieter while determining file system abilities.
 Closes Savannah bug #25788. (Andrew Ferguson)
 
 Fix situation where destination file cannot be opened because of an access
@@ -270,7 +270,7 @@ Support for Windows ACLs. (Patch from Josh Nisly and Fred Gansevles)
 Fix user_group.py to run on native Windows, which lacks grp and pwd Python
 modules. (Patch from Fred Gansevles)
 
-Optimize --check-destination and other functions by determinating the increment
+Optimize --check-destination and other functions by determining the increment
 files server-side instead of client-side. (Patch from Josh Nisly)
 
 Actually make rdiff-backup robust to failure to read an ACL because the file
@@ -798,7 +798,7 @@ trying to back up a directory into itself.
 
 Fix for restoring certain directories when not run as root.
 
-Now when determinating group permissions check supplementary groups as
+Now when determining group permissions check supplementary groups as
 well as main group.  (Bug report by Ryan Castle.)
 
 Fixed bug which could cause crash when backing up 3 or more hard

--- a/src/rdiff_backup/backup.py
+++ b/src/rdiff_backup/backup.py
@@ -323,7 +323,7 @@ class CacheCollatedPostProcess:
         if Globals.file_statistics: statistics.FileStats.init()
         self.metawriter = metadata.ManagerObj.GetWriter()
 
-        # the following should map indicies to lists
+        # the following should map indices to lists
         # [source_rorp, dest_rorp, changed_flag, success_flag, increment]
 
         # changed_flag should be true if the rorps are different, and

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -240,7 +240,7 @@ class MirrorStruct:
     def subtract_indices(cls, index, rorp_iter):
         """Subtract index from index of each rorp in rorp_iter
 
-		subtract_indices and add_indicies are necessary because we
+		subtract_indices is necessary because we
 		may not be restoring from the root index.
 
 		"""

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -346,7 +346,7 @@ class CachedRF:
 
 	Thus, when a CachedRF retrieves an RestoreFile, it creates all the
 	RFs of that directory at the same time, and doesn't have to
-	recalculate.  It assumes the indicies will be in order, so the
+	recalculate.  It assumes the indices will be in order, so the
 	cache is deleted if a later index is requested.
 
 	"""
@@ -359,7 +359,7 @@ class CachedRF:
             self.perm_changer = PermissionChanger(root_rf.mirror_rp)
 
     def list_rfs_in_cache(self, index):
-        """Used for debugging, return indicies of cache rfs for printing"""
+        """Used for debugging, return indices of cache rfs for printing"""
         s1 = "-------- Cached RF for %s -------" % (index, )
         s2 = " ".join([str(rf.index) for rf in self.rf_list])
         s3 = "--------------------------"
@@ -376,7 +376,7 @@ class CachedRF:
                     self.perm_changer(index, mir_rorp)
                 return rf
             elif rf.index > index:
-                # Try to add earlier indicies.  But if first is
+                # Try to add earlier indices.  But if first is
                 # already from same directory, or we can't find any
                 # from that directory, then we know it can't be added.
                 if (index[:-1] == rf.index[:-1]
@@ -783,7 +783,7 @@ class PermissionChanger:
         self.add_new(old_index, index)
 
     def restore_old(self, index):
-        """Restore permissions for indicies we are done with"""
+        """Restore permissions for indices we are done with"""
         while self.open_index_list:
             old_index, old_rp, old_perms = self.open_index_list[0]
             if index[:len(old_index)] > old_index: old_rp.chmod(old_perms)

--- a/src/rdiff_backup/rorpiter.py
+++ b/src/rdiff_backup/rorpiter.py
@@ -181,9 +181,9 @@ class IndexedTuple(collections.UserList):
 
 
 def FillInIter(rpiter, rootrp):
-    """Given ordered rpiter and rootrp, fill in missing indicies with rpaths
+    """Given ordered rpiter and rootrp, fill in missing indices with rpaths
 
-	For instance, suppose rpiter contains rpaths with indicies (),
+	For instance, suppose rpiter contains rpaths with indices (),
 	(1,2), (2,5).  Then return iter with rpaths (), (1,), (1,2), (2,),
 	(2,5).  This is used when we need to process directories before or
 	after processing a file in that directory.
@@ -223,7 +223,7 @@ def FillInIter(rpiter, rootrp):
 class IterTreeReducer:
     """Tree style reducer object for iterator
 
-	The indicies of a RORPIter form a tree type structure.  This class
+	The indices of a RORPIter form a tree type structure.  This class
 	can be used on each element of an iter in sequence and the result
 	will be as if the corresponding tree was reduced.  This tries to
 	bridge the gap between the tree nature of directories, and the

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1253,7 +1253,7 @@ class RPath(RORPath):
     def contains_files(self):
         """Returns true if self (or subdir) contains any regular files."""
         log.Log(
-            "Determinating if directory contains files: %s" %
+            "Determining if directory contains files: %s" %
             self.get_safepath(), 7)
         if not self.isdir():
             return False

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -215,7 +215,7 @@ class Select:
         """Filter rorp_iter using Select below, removing excluded rorps"""
 
         def getrpiter(rorp_iter):
-            """Return rp iter by adding indicies of rorp_iter to self.rpath"""
+            """Return rp iter by adding indices of rorp_iter to self.rpath"""
             for rorp in rorp_iter:
                 yield rpath.RPath(self.rpath.conn, self.rpath.base, rorp.index,
                                   rorp.data)

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -793,7 +793,7 @@ class FinalBugs(PathSetter):
         """Test when no change until middle of a directory
 
         This tests CCPP, to make sure it isn't asked to provide rorps
-        for indicies that are out of the cache.
+        for indices that are out of the cache.
 
         """
         self.delete_tmpdirs()

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -369,8 +369,8 @@ def CompareRecursive(src_rp,
         elif src_rorp.equal_verbose(dest_rorp,
                                     compare_ownership=compare_ownership):
             return 1
-        Log("%s: %s" % (src_rorp.index, Hardlink.get_indicies(src_rorp, 1)), 3)
-        Log("%s: %s" % (dest_rorp.index, Hardlink.get_indicies(dest_rorp, None)), 3)
+        Log("%s: %s" % (src_rorp.index, Hardlink.get_inode_key(src_rorp)), 3)
+        Log("%s: %s" % (dest_rorp.index, Hardlink.get_inode_key(dest_rorp)), 3)
         return None
 
 

--- a/testing/rorpitertest.py
+++ b/testing/rorpitertest.py
@@ -26,29 +26,29 @@ class RORPIterTest(unittest.TestCase):
 
     def testCollateIterators(self):
         """Test basic collating"""
-        indicies = list(map(index, [0, 1, 2, 3]))
+        indices = list(map(index, [0, 1, 2, 3]))
 
-        helper = lambda i: indicies[i]  # noqa: E731 use def instead of lambda
-        makeiter1 = lambda: iter(indicies)  # noqa: E731 use def instead of lambda
+        helper = lambda i: indices[i]  # noqa: E731 use def instead of lambda
+        makeiter1 = lambda: iter(indices)  # noqa: E731 use def instead of lambda
         makeiter2 = lambda: iter(map(helper, [0, 1, 3]))  # noqa: E731 use def instead of lambda
         makeiter3 = lambda: iter(map(helper, [1, 2]))  # noqa: E731 use def instead of lambda
 
         outiter = rorpiter.CollateIterators(makeiter1(), makeiter2())
         assert iter_equal(
             outiter,
-            iter([(indicies[0], indicies[0]), (indicies[1], indicies[1]),
-                  (indicies[2], None), (indicies[3], indicies[3])]))
+            iter([(indices[0], indices[0]), (indices[1], indices[1]),
+                  (indices[2], None), (indices[3], indices[3])]))
 
         assert iter_equal(
             rorpiter.CollateIterators(makeiter1(), makeiter2(), makeiter3()),
-            iter([(indicies[0], indicies[0], None),
-                  (indicies[1], indicies[1], indicies[1]),
-                  (indicies[2], None, indicies[2]),
-                  (indicies[3], indicies[3], None)]))
+            iter([(indices[0], indices[0], None),
+                  (indices[1], indices[1], indices[1]),
+                  (indices[2], None, indices[2]),
+                  (indices[3], indices[3], None)]))
 
         assert iter_equal(rorpiter.CollateIterators(makeiter1(), iter([])),
-                          iter([(i, None) for i in indicies]))
-        assert iter_equal(iter([(i, None) for i in indicies]),
+                          iter([(i, None) for i in indices]))
+        assert iter_equal(iter([(i, None) for i in indices]),
                           rorpiter.CollateIterators(makeiter1(), iter([])))
 
     def compare_no_times(self, src_rp, dest_rp):

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -316,8 +316,8 @@ class ParseArgsTest(unittest.TestCase):
     """Test argument parsing as well as filelist globbing"""
     root = None
 
-    def ParseTest(self, tuplelist, indicies, filelists=[]):
-        """No error if running select on tuple goes over indicies"""
+    def ParseTest(self, tuplelist, indices, filelists=[]):
+        """No error if running select on tuple goes over indices"""
         def tuple_fsencode(filetuple):
             return tuple(map(os.fsencode, filetuple))
 
@@ -328,7 +328,7 @@ class ParseArgsTest(unittest.TestCase):
         self.Select.ParseArgs(tuplelist, self.remake_filelists(filelists))
         assert iter_equal(iter_map(lambda dsrp: dsrp.index,
                                    self.Select.set_iter()),
-                          map(tuple_fsencode, indicies),
+                          map(tuple_fsencode, indices),
                           verbose=1)
 
     def remake_filelists(self, filelist):


### PR DESCRIPTION
Follow-up to #24 

* `termining` wasn't a word and was supposed to be replaced by `terminating`, unfortunately,  `determining` is a word and was collateral damage. This is reverted first
* afaict, `add_indicies` never made it into version control, so, calling it stale is perhaps a bit inaccurrate
* `get_indicies` was removed in 2003... So clearly that codepath is rarely used...
* `indicies` was too much for me to quickly do in my rebase, so I intentionally left it out (since it encompassed researching the above two points).

Sorry about the need for follow-up.