### PR TITLE
Revert and improve versioning procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 .*.swp
 build/
 __pycache__
-src/rdiff_backup.egg-info/
-src/rdiff_backup/Version.py
 
 # tox testing stuff
 .tox*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ MANIFEST
 
 # just ignore files marked local through their name
 *[._]local[._]*
+
+# setup.py installation files
+dist/*.egg
+src/rdiff_backup.egg-info/

--- a/DEVELOP.adoc
+++ b/DEVELOP.adoc
@@ -8,6 +8,7 @@ Some notes for developers and other people willing to help development.
 * tox
 * libacl-devel (for sys/acl.h)
 * rdiff
+* python3-setuptools (for setup.py)
 - unpack the test files previously available from
 https://download-mirror.savannah.gnu.org/releases/rdiff-backup/testfiles.tar.gz and now temporarily available as
 release under https://github.com/ericzolf/rdiff-backup/releases[]:

--- a/DEVELOP.adoc
+++ b/DEVELOP.adoc
@@ -8,7 +8,6 @@ Some notes for developers and other people willing to help development.
 * tox
 * libacl-devel (for sys/acl.h)
 * rdiff
-* python3-setuptools and python3-setuptools_scm (for setup.py)
 - unpack the test files previously available from
 https://download-mirror.savannah.gnu.org/releases/rdiff-backup/testfiles.tar.gz and now temporarily available as
 release under https://github.com/ericzolf/rdiff-backup/releases[]:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
     librsync-dev \
     python3-all-dev \
     python3-pylibacl \
-    python3-pyxattr \
-    python3-setuptools-scm
+    python3-pyxattr
 
 # Build dependencies specific for rdiff-backup development and testing
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 
 import sys, os, getopt
-from setuptools import setup, Extension
+from distutils.core import setup, Extension
 
-# we need to get the version if we want to use it for the docs dir
-from setuptools_scm import get_version
-version_string = get_version()
+version_string = "1.3.4"
 
 if sys.version_info[:2] < (3,5):
 	print("Sorry, rdiff-backup requires version 3.5 or later of Python")
@@ -61,14 +59,11 @@ if os.name == 'nt':
 			})
 
 setup(name="rdiff-backup",
+	  version=version_string,
 	  description="Local/remote mirroring+incremental backup",
 	  author="The rdiff-backup project",
 	  author_email="rdiff-backup-users@nongnu.org",
 	  url="https://rdiff-backup.net/",
-	  use_scm_version={
-	    'write_to': 'src/rdiff_backup/Version.py',
-	  },
-	  setup_requires=['setuptools_scm'],
 	  packages = ['rdiff_backup'],
 	  package_dir={'':'src'},  # tell distutils packages are under src
 	  ext_modules = [Extension("rdiff_backup.C", ["src/cmodule.c"]),

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import sys, os, getopt
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
-version_string = "1.3.4"
+from src.rdiff_backup import Version
+version_string = Version.version
 
 if sys.version_info[:2] < (3,5):
 	print("Sorry, rdiff-backup requires version 3.5 or later of Python")

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -20,9 +20,10 @@
 
 import re
 import os
+from . import Version
 
 # The current version of rdiff-backup
-version = "1.3.4"
+version = Version.version
 
 # If this is set, use this value in seconds as the current time
 # instead of reading it from the clock.

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -21,10 +21,8 @@
 import re
 import os
 
-from . import Version
-
 # The current version of rdiff-backup
-version = Version.version
+version = "1.3.4"
 
 # If this is set, use this value in seconds as the current time
 # instead of reading it from the clock.

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -243,7 +243,7 @@ def parse_cmdlineoptions(arglist):
         elif opt == "--verify-at-time":
             action, restore_timestr = "verify", arg
         elif opt == "-V" or opt == "--version":
-            print("rdiff-backup %s" % Globals.version)
+            print("rdiff-backup " + Globals.version)
             sys.exit(0)
         else:
             Log.FatalError("Unknown option %s" % opt)

--- a/src/rdiff_backup/Version.py
+++ b/src/rdiff_backup/Version.py
@@ -1,0 +1,4 @@
+# coding: utf-8
+
+# rdiff-backup version - modify before release
+version = '1.3.5'

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     pylibacl
 # whitelist_externals =
 commands_pre =
+    rdiff-backup --version
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,8 @@ passenv = RDIFF_TEST_USER RDIFF_TEST_GROUP
 deps =
     pyxattr
     pylibacl
-    setuptools_scm
 # whitelist_externals =
 commands_pre =
-    rdiff-backup --version
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -24,6 +24,7 @@ deps =
     pylibacl
 #whitelist_externals = env
 commands_pre =
+    rdiff-backup --version
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -22,10 +22,8 @@ passenv = SUDO_USER SUDO_UID SUDO_GID RDIFF_TEST_USER RDIFF_TEST_UID RDIFF_TEST_
 deps =
     pyxattr
     pylibacl
-    setuptools_scm
 #whitelist_externals = env
 commands_pre =
-    rdiff-backup --version
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -13,10 +13,8 @@ envlist = py35, py36, py37, py38
 deps =
     pyxattr
     pylibacl
-    setuptools_scm
 # whitelist_externals =
 commands_pre =
-    rdiff-backup --version
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -15,6 +15,7 @@ deps =
     pylibacl
 # whitelist_externals =
 commands_pre =
+    rdiff-backup --version
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =


### PR DESCRIPTION
Revert "Take package and distribution tool from Git"
    
This reverts commit c46e7fb2b498b430a9b0e27fdb8b0e5cb6a1a4ea.
    
It appears that the approach leads to Git structures being owned by
root when calling `sudo ./setup.py install` even when calling just
before `./setup.py build` as non-root, and this is not acceptable.

Instead implement a simpler version.