### PR TITLE
Make debug output in verbosity 9 easier to sort in client/server mode

### DIFF
--- a/DEVELOP.adoc
+++ b/DEVELOP.adoc
@@ -133,3 +133,16 @@ PYTHONTRACEMALLOC=1 PATH=$PWD/build/scripts-3.7:$PATH PYTHONPATH=$PWD/build/lib.
 ------------------------------------------------------------------------
 
 This tells you indeed where the file was opened: `Object allocated at (most recent call last)` but it didn't really help me get rid of the warning, hence https://github.com/ericzolf/rdiff-backup/issues/18 until further notice.
+
+=== Debug client / server mode
+
+In order to make sure the debug messages are properly sorted, you need to have the verbosity
+level 9 set-up, mix stdout and stderr, and then use the date/time output to properly sort
+the lines coming both from server and client, while making sure that lines belonging together
+stay together. The result command line might look as follows:
+
+------------------------------------------------------------------------
+rdiff-backup -v9 localhost::/sourcedir /backupdir 2>&1 | awk \
+	'/^2019-09-16/ { if (line) print line; line = $0 } ! /^2019-09-16/ { line = line " ## " $0 }' \
+	| sort | sed 's/ ## /\n/g'
+------------------------------------------------------------------------

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -18,7 +18,7 @@
 # USA
 """Manage logging, displaying and recording messages with required verbosity"""
 
-import time
+import datetime
 import sys
 import traceback
 import types
@@ -109,8 +109,12 @@ class Logger:
         if verbosity < 9:
             return "%s\n" % message
         else:
-            return "%s  %s\n" % (time.asctime(time.localtime(time.time())),
-                                 message)
+            timestamp = datetime.datetime.now().astimezone().strftime("%F %H:%M:%S.%f %z")
+            if Globals.server:
+                role = "SERVER"
+            else:
+                role = "CLIENT"
+            return "%s  <%s>  %s\n" % (timestamp, role, message)
 
     def __call__(self, message, verbosity):
         """Log message that has verbosity importance
@@ -172,7 +176,7 @@ class Logger:
         else:
             result_repr = str(result)
         # shorten the result to a max size of 720 chars with ellipsis if needed
-        result_repr = result_repr[:720] + (result_repr[720:] and '[...]')
+        #result_repr = result_repr[:720] + (result_repr[720:] and '[...]')
         if Globals.server:
             conn_str = "Server"
         else:


### PR DESCRIPTION
While working on issue #115 it appears that debug messages are unsorted
when working in client/server mode, and hence need a sortable date and
clearer affiliation to one or the other side of the communication.
The development doc has been extended to show how to use the new format.