### PR TITLE
Improve check for complete path in include/exclude

### DIFF
--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -630,7 +630,7 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
 		globbing characters are used.
 
 		"""
-        if not filename.startswith(self.prefix):
+        if not filename.startswith(self.prefix + b"/"):
             raise FilePrefixError(filename)
         index = tuple(
             [x for x in filename[len(self.prefix):].split(b"/") if x])


### PR DESCRIPTION
This is a rewrite of #23 and will fix #22 at least for the cases I tested (for the examples, check out #22).
Maybe the same modification should be added also elsewhere inside selection.py?