### PR TITLE
Add the --no-tar option to tools/makedist

### DIFF
--- a/tools/makedist
+++ b/tools/makedist
@@ -5,6 +5,8 @@ import os, re, shutil, time, sys, getopt
 PySourceDir = "src/rdiff_backup"
 CSourceDir = "src"
 DistDir = "tools"
+# If True, we leave a .tar.gz. If False, we leave a directory.
+TarRequested = True
 
 # This needs to be done this way as the path is outside the package path.
 import importlib.util
@@ -98,10 +100,9 @@ def VersionedCopy(source, dest, munge_date = 0):
 	fout.write(outbuf)
 	assert not fout.close()
 
-def MakeTar(specfiles):
-	"""Create rdiff-backup tar file"""
+def MakeDir(specfiles):
+	"""Create rdiff-backup distribution directory"""
 	tardir = "rdiff-backup-%s" % Version
-	tarfilename = "rdiff-backup-%s.tar.gz" % Version
 	try:
 		os.lstat(tardir)
 		shutil.rmtree(tardir)
@@ -142,6 +143,11 @@ def MakeTar(specfiles):
 	os.chmod(os.path.join(tardir, "rdiff-backup"), 0o644)
 	CopyMan(os.path.join(tardir, "rdiff-backup.1"), Version)
 	CopyMan(os.path.join(tardir, "rdiff-backup-statistics.1"), Version)
+	return tardir
+
+def MakeTar(tardir):
+	"""Create rdiff-backup tar file and wipe distribution directory"""
+	tarfilename = "%s.tar.gz" % tardir
 	if os.name != 'nt':
 		os.system("tar -cvzf %s %s" % (tarfilename, tardir))
 	else:
@@ -163,19 +169,30 @@ def MakeSpecFile():
 
 def parse_cmdline(arglist):
 	"""Returns action"""
-	global Version
+	global Version, TarRequested
 	def error():
-		print("Syntax: makedist [--html-only] [version_number]")
+		print("Syntax: makedist [--html-only] [--no-tar] [version_number]")
 		sys.exit(1)		
 
-	optlist, args = getopt.getopt(arglist, "", ["html-only"])
-	if len(args) > 1: error()
-	elif len(args) == 1: Version = args[0]
-
-	for opt, arg in optlist:
-		if opt == "--html-only": return "HTML"
-		else: assert 0, "Bad argument"
-	return "All"
+	try:
+		optlist, args = getopt.getopt(arglist, "h", ["help", "html-only", "no-tar"])
+		retval = "All"
+		for opt, arg in optlist:
+			if opt == "--html-only":
+				retval = "HTML"
+			elif opt == "--no-tar":
+				TarRequested = False
+			elif opt in ("-h", "--help"):
+				error()
+		if len(args) > 1:
+			print("Too many arguments")
+			error()
+		elif len(args) == 1:
+			Version = args[0]
+	except getopt.GetoptError as e:
+		print(e)
+		error()
+	return retval
 
 def Main():
 	action = parse_cmdline(sys.argv[1:])
@@ -188,8 +205,12 @@ def Main():
 		print("Processing version " + Version)
 		specfiles = MakeSpecFile()
 		print("Made specfiles ", specfiles)
-		tarfile = MakeTar(specfiles)
-		print("Made tar file " + tarfile)
+		dirName = MakeDir(specfiles)
+		if TarRequested:
+			tarfile = MakeTar(dirName)
+			print("Made tar file " + tarfile)
+		else:
+			print("Made directory " + dirName)
 
 
 if __name__ == "__main__" and '__no_execute__' not in globals():


### PR DESCRIPTION
The script `tools/makedist` can only be used to make a compressed tar archive.
It generates a temporary directory, makes the archive and then wipes it.
It could be useful to avoid the last part, i.e. the script could be used to make a ``plain'' directory with all the source files.

This is an exact replica of PR #139 but the repository, this time, should be fine.