### PR TITLE
Fix small issues with distribution using setup.py

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -25,6 +25,8 @@ That's it, you can now run the tests:
 * or `tox -c tox_slow.ini` for long tests
 * or `sudo tox -c tox_root.ini` for the few tests needing root rights
 
+> **NOTE:** if you plan to use `./setup.py bdist_rpm` to create an RPM, you would need rpm-build but be aware that it will currently fail due to a [known bug in setuptools with compressed man pages](https://github.com/pypa/setuptools/issues/1277).
+
 ## How to debug rdiff-backup?
 
 ### Trace back a coredump
@@ -54,9 +56,9 @@ sudo dnf debuginfo-install bzip2-libs-1.0.6-28.fc29.x86_64 glibc-2.28-27.fc29.x8
 Then calling:
 
 ```
-python3 dist/setup.py clean --all  #<1>
-python3-debug dist/setup.py clean --all
-CFLAGS='-Wall -O0 -g' python3-debug dist/setup.py build  #<2>
+python3 ./setup.py clean --all  #<1>
+python3-debug ./setup.py clean --all
+CFLAGS='-Wall -O0 -g' python3-debug ./setup.py build  #<2>
 PATH=$PWD/build/scripts-3.7:$PATH PYTHONPATH=$PWD/build/lib.linux-x86_64-3.7-pydebug/ rdiff-backup -v 10 \
 	/some/dir1 /some/dir2
 [...]

--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ NB: There is no uninstall command provided by the Python distutils system.
 One strategy is to use the python3 setup.py install --record <file> option
 to save a list of the files installed to <file>.
 
-To build from source on Windows, you can use the command:
-
-	python3 setup.py py2exe --single-file
-
+To build from source on Windows, check the [Windows tools](tools/windows)
 to build a single executable file which contains Python, librsync, and
 all required modules.
 
@@ -87,8 +84,13 @@ well as a C compiler (gcc).
 ## TROUBLESHOOTING
 
 If you have everything installed properly, and it still doesn't work,
-see the enclosed FAQ.html, the web page at https://www.nongnu.org/rdiff-backup/
-and/or the mailing list.
+see the enclosed [FAQ.html](FAQ.html), the [rdiff-backup web page](https://rdiff-backup.net/)
+and/or the [rdiff-backup-users mailing list](https://lists.nongnu.org/mailman/listinfo/rdiff-backup-users).
+
+We're also happy to help if you create an issue to our
+[GitHub repo](https://github.com/rdiff-backup/rdiff-backup). The most
+important is probably to explain what happened and attach the output of
+rdiff-backup run with the very verbose option `-v9`.
 
 The FAQ in particular is an important reference, especially if you are
 using smbfs/CIFS, Windows, or have compiled by hand on Mac OS X.

--- a/setup.py
+++ b/setup.py
@@ -1,81 +1,85 @@
 #!/usr/bin/env python3
 
-import sys, os, getopt
+import sys
+import os
+
 from setuptools import setup, Extension
 
 from src.rdiff_backup import Version
+
 version_string = Version.version
 
-if sys.version_info[:2] < (3,5):
-	print("Sorry, rdiff-backup requires version 3.5 or later of Python")
-	sys.exit(1)
+if sys.version_info[:2] < (3, 5):
+    print("Sorry, rdiff-backup requires version 3.5 or later of Python")
+    sys.exit(1)
 
 # Defaults
 lflags_arg = []
-libname = ['rsync']
+libname = ["rsync"]
 incdir_list = libdir_list = None
 extra_options = {}
 
-if os.name == 'posix' or os.name == 'nt':
-	LIBRSYNC_DIR = os.environ.get('LIBRSYNC_DIR', '')
-	LFLAGS = os.environ.get('LFLAGS', [])
-	LIBS = os.environ.get('LIBS', [])
+if os.name == "posix" or os.name == "nt":
+    LIBRSYNC_DIR = os.environ.get("LIBRSYNC_DIR", "")
+    LFLAGS = os.environ.get("LFLAGS", [])
+    LIBS = os.environ.get("LIBS", [])
 
-	# Handle --librsync-dir=[PATH] and --lflags=[FLAGS]
-	args = sys.argv[:]
-	for arg in args:
-		if arg.startswith('--librsync-dir='):
-			LIBRSYNC_DIR = arg.split('=')[1]
-			sys.argv.remove(arg)
-		elif arg.startswith('--lflags='):
-			LFLAGS = arg.split('=')[1].split()
-			sys.argv.remove(arg)
-		elif arg.startswith('--libs='):
-			LIBS = arg.split('=')[1].split()
-			sys.argv.remove(arg)
+    # Handle --librsync-dir=[PATH] and --lflags=[FLAGS]
+    args = sys.argv[:]
+    for arg in args:
+        if arg.startswith("--librsync-dir="):
+            LIBRSYNC_DIR = arg.split("=")[1]
+            sys.argv.remove(arg)
+        elif arg.startswith("--lflags="):
+            LFLAGS = arg.split("=")[1].split()
+            sys.argv.remove(arg)
+        elif arg.startswith("--libs="):
+            LIBS = arg.split("=")[1].split()
+            sys.argv.remove(arg)
 
-		if LFLAGS or LIBS:
-			lflags_arg = LFLAGS + LIBS
+        if LFLAGS or LIBS:
+            lflags_arg = LFLAGS + LIBS
 
-		if LIBRSYNC_DIR:
-			incdir_list = [os.path.join(LIBRSYNC_DIR, 'include')]
-			libdir_list = [os.path.join(LIBRSYNC_DIR, 'lib')]
-		if '-lrsync' in LIBS:
-			libname = []
+        if LIBRSYNC_DIR:
+            incdir_list = [os.path.join(LIBRSYNC_DIR, "include")]
+            libdir_list = [os.path.join(LIBRSYNC_DIR, "lib")]
+        if "-lrsync" in LIBS:
+            libname = []
 
-if os.name == 'nt':
-	try:
-		import py2exe
-	except ImportError:
-		pass
-	else:
-		extra_options = {
-			'console': ['rdiff-backup'],
-		}
-		if '--single-file' in sys.argv[1:]:
-			sys.argv.remove('--single-file')
-			extra_options.update({
-				'options': {'py2exe': {'bundle_files': 1}},
-				'zipfile': None
-			})
-
-setup(name="rdiff-backup",
-	  version=version_string,
-	  description="Local/remote mirroring+incremental backup",
-	  author="The rdiff-backup project",
-	  author_email="rdiff-backup-users@nongnu.org",
-	  url="https://rdiff-backup.net/",
-	  packages = ['rdiff_backup'],
-	  package_dir={'':'src'},  # tell distutils packages are under src
-	  ext_modules = [Extension("rdiff_backup.C", ["src/cmodule.c"]),
-                         Extension("rdiff_backup._librsync", ["src/_librsyncmodule.c"],
-                                           include_dirs=incdir_list,
-                                           library_dirs=libdir_list,
-                                           libraries=libname,
-                                           extra_link_args=lflags_arg)],
-	  scripts = ['rdiff-backup', 'rdiff-backup-statistics'],
-	  data_files = [('share/man/man1', ['rdiff-backup.1', 'rdiff-backup-statistics.1']),
-					('share/doc/rdiff-backup-%s' % (version_string,),
-					 ['CHANGELOG', 'COPYING', 'README.md',
-                                          'FAQ.html', 'examples.html', 'DEVELOP.md'])],
-					**extra_options)
+setup(
+    name="rdiff-backup",
+    version=version_string,
+    description="Local/remote mirroring+incremental backup",
+    author="The rdiff-backup project",
+    author_email="rdiff-backup-users@nongnu.org",
+    url="https://rdiff-backup.net/",
+    packages=["rdiff_backup"],
+    package_dir={"": "src"},  # tell distutils packages are under src
+    ext_modules=[
+        Extension("rdiff_backup.C", ["src/cmodule.c"]),
+        Extension(
+            "rdiff_backup._librsync",
+            ["src/_librsyncmodule.c"],
+            include_dirs=incdir_list,
+            library_dirs=libdir_list,
+            libraries=libname,
+            extra_link_args=lflags_arg,
+        ),
+    ],
+    scripts=["rdiff-backup", "rdiff-backup-statistics"],
+    data_files=[
+        ("share/man/man1", ["rdiff-backup.1", "rdiff-backup-statistics.1"]),
+        (
+            "share/doc/rdiff-backup-%s" % (version_string,),
+            [
+                "CHANGELOG",
+                "COPYING",
+                "README.md",
+                "FAQ.html",
+                "examples.html",
+                "DEVELOP.md",
+            ],
+        ),
+    ],
+    **extra_options
+)


### PR DESCRIPTION
- correct the fact that dist/setup.py has been moved to root dir in
  documentation.
- get rid of py2exe which doesn't work
- improve some links in documentation
- add note around rpm build failing and potential requirements
- make setup.py PEP8 clean
- closes #88