### PR TITLE
Clean-up the code with pep8 and replace tabs with spaces #60

### DIFF
--- a/src/rdiff_backup/FilenameMapping.py
+++ b/src/rdiff_backup/FilenameMapping.py
@@ -72,8 +72,8 @@ def init_quoting_regexps():
     assert chars_to_quote and isinstance(chars_to_quote, bytes), \
         "Chars to quote are wrong: %a" % chars_to_quote
     try:
-        chars_to_quote_regexp = \
-           re.compile(b"[%b]|%b" % (chars_to_quote, quoting_char), re.S)
+        chars_to_quote_regexp = re.compile(b"[%b]|%b" %
+                                           (chars_to_quote, quoting_char), re.S)
         unquoting_regexp = re.compile(b"%b[0-9]{3}" % quoting_char, re.S)
     except re.error:
         log.Log.FatalError("Error '%s' when processing char quote list %r" %
@@ -83,12 +83,12 @@ def init_quoting_regexps():
 def quote(path):
     """Return quoted version of given path
 
-	Any characters quoted will be replaced by the quoting char and
-	the ascii number of the character.  For instance, "10:11:12"
-	would go to "10;05811;05812" if ":" were quoted and ";" were
-	the quoting character.
+    Any characters quoted will be replaced by the quoting char and
+    the ascii number of the character.  For instance, "10:11:12"
+    would go to "10;05811;05812" if ":" were quoted and ";" were
+    the quoting character.
 
-	"""
+    """
     QuotedPath = chars_to_quote_regexp.sub(quote_single, path)
     if not Globals.escape_dos_devices and not Globals.escape_trailing_spaces:
         return QuotedPath
@@ -99,16 +99,16 @@ def quote(path):
         if len(QuotedPath) and (QuotedPath[-1] == ord(' ')
                                 or QuotedPath[-1] == ord('.')):
             QuotedPath = QuotedPath[:-1] + \
-             b"%b%03d" % (quoting_char, QuotedPath[-1])
+                b"%b%03d" % (quoting_char, QuotedPath[-1])
 
         if not Globals.escape_dos_devices:
             return QuotedPath
 
     # Escape first char of any special DOS device files even if filename has an
     # extension.  Special names are: aux, prn, con, nul, com0-9, and lpt1-9.
-    if not re.search(br"^aux(\..*)*$|^prn(\..*)*$|^con(\..*)*$|^nul(\..*)*$|" \
-         br"^com[0-9](\..*)*$|^lpt[1-9]{1}(\..*)*$", QuotedPath, \
-         re.I):
+    if not re.search(br"^aux(\..*)*$|^prn(\..*)*$|^con(\..*)*$|^nul(\..*)*$|"
+                     br"^com[0-9](\..*)*$|^lpt[1-9]{1}(\..*)*$", QuotedPath,
+                     re.I):
         return QuotedPath
     return b"%b%03d" % (quoting_char, QuotedPath[0]) + QuotedPath[1:]
 
@@ -136,11 +136,11 @@ def unquote_single(match):
 class QuotedRPath(rpath.RPath):
     """RPath where the filename is quoted version of index
 
-	We use QuotedRPaths so we don't need to remember to quote RPaths
-	derived from this one (via append or new_index).  Note that only
-	the index is quoted, not the base.
+    We use QuotedRPaths so we don't need to remember to quote RPaths
+    derived from this one (via append or new_index).  Note that only
+    the index is quoted, not the base.
 
-	"""
+    """
 
     def __init__(self, connection, base, index=(), data=None):
         """Make new QuotedRPath"""
@@ -150,7 +150,8 @@ class QuotedRPath(rpath.RPath):
         # quoted_index (parent class does it on the basis of index)
         if base is not None:
             self.path = self.path_join(self.base, *self.quoted_index)
-            if data is None: self.setdata()
+            if data is None:
+                self.setdata()
 
     def __setstate__(self, rpath_state):
         """Reproduce QuotedRPath from __getstate__ output"""
@@ -162,10 +163,10 @@ class QuotedRPath(rpath.RPath):
     def listdir(self):
         """Return list of unquoted filenames in current directory
 
-		We want them unquoted so that the results can be sorted
-		correctly and append()ed to the current QuotedRPath.
+        We want them unquoted so that the results can be sorted
+        correctly and append()ed to the current QuotedRPath.
 
-		"""
+        """
         return list(map(unquote, self.conn.os.listdir(self.path)))
 
     def isincfile(self):
@@ -180,7 +181,7 @@ class QuotedRPath(rpath.RPath):
         else:
             result = rpath.RPath.isincfile(self)
             if result:
-            	self.inc_basestr = unquote(self.inc_basestr)
+                self.inc_basestr = unquote(self.inc_basestr)
         return result
 
     def get_path(self):
@@ -205,8 +206,8 @@ def get_quoted_sep_base(filename):
 
 def update_quoting(rbdir):
     """Update the quoting of a repository by renaming any
-	files that should be quoted differently.
-	"""
+    files that should be quoted differently.
+    """
 
     def requote(name):
         unquoted_name = unquote(name)

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -273,12 +273,12 @@ def is_not_None(name):
 def set(name, val):
     """Set the value of something in this module
 
-	Use this instead of writing the values directly if the setting
-	matters to remote sides.  This function updates the
-	changed_settings list, so other connections know to copy the
-	changes.
+    Use this instead of writing the values directly if the setting
+    matters to remote sides.  This function updates the
+    changed_settings list, so other connections know to copy the
+    changes.
 
-	"""
+    """
     changed_settings.append(name)
     globals()[name] = val
 

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -259,6 +259,7 @@ remote_tempdir = None
 # and pre-regress
 do_fsync = True
 
+
 def get(name):
     """Return the value of something in this module"""
     return globals()[name]

--- a/src/rdiff_backup/Hardlink.py
+++ b/src/rdiff_backup/Hardlink.py
@@ -69,7 +69,8 @@ def add_rorp(rorp, dest_rorp=None):
             dest_key = None
         elif dest_rorp.getnumlinks() == 1:
             dest_key = "NA"
-        else: dest_key = get_inode_key(dest_rorp)
+        else:
+            dest_key = get_inode_key(dest_rorp)
         digest = rorp.has_sha1() and rorp.get_sha1() or None
         _inode_index[rp_inode_key] = (rorp.index, rorp.getnumlinks(), dest_key,
                                       digest)
@@ -96,11 +97,11 @@ def del_rorp(rorp):
 def rorp_eq(src_rorp, dest_rorp):
     """Compare hardlinked for equality
 
-	Return false if dest_rorp is linked differently, which can happen
-	if dest is linked more than source, or if it is represented by a
-	different inode.
+    Return false if dest_rorp is linked differently, which can happen
+    if dest is linked more than source, or if it is represented by a
+    different inode.
 
-	"""
+    """
     if (not src_rorp.isreg() or not dest_rorp.isreg()
             or src_rorp.getnumlinks() == dest_rorp.getnumlinks() == 1):
         return 1  # Hard links don't apply

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -37,8 +37,7 @@ remote_cmd, remote_schema = None, None
 force = None
 select_opts = []
 select_files = []
-user_mapping_filename, group_mapping_filename, preserve_numerical_ids = \
-        None, None, None
+user_mapping_filename, group_mapping_filename, preserve_numerical_ids = None, None, None
 
 # These are global because they are set while we are trying to figure
 # whether to restore or to backup
@@ -91,8 +90,7 @@ def parse_cmdlineoptions(arglist):
             "restrict-read-only=", "restrict-update-only=", "server",
             "ssh-no-compression", "tempdir=", "terminal-verbosity=",
             "test-server", "use-compatible-timestamps", "user-mapping-file=",
-            "verbosity=", "verify", "verify-at-time=", "version",
-            "no-fsync"
+            "verbosity=", "verify", "verify-at-time=", "version", "no-fsync"
         ])
     except getopt.error as e:
         commandline_error("Bad commandline options: " + str(e))
@@ -246,7 +244,8 @@ def parse_cmdlineoptions(arglist):
         elif opt == "-V" or opt == "--version":
             print("rdiff-backup " + Globals.version)
             sys.exit(0)
-        elif opt == "--no-fsync": Globals.do_fsync = False
+        elif opt == "--no-fsync":
+            Globals.do_fsync = False
         else:
             Log.FatalError("Unknown option %s" % opt)
     Log("Using rdiff-backup version %s" % (Globals.version), 4)
@@ -492,7 +491,7 @@ def check_failed_initial_backup():
         # If we have no current_mirror marker, and the increments directory
         # is empty, we most likely have a failed backup.
         return not mirror_markers and len(error_logs) <= 1 and \
-          len(metadata_mirrors) <= 1
+            len(metadata_mirrors) <= 1
     return False
 
 
@@ -620,15 +619,15 @@ by running two backups in less than a second.  Wait a second and try again.""")
 def backup_touch_curmirror_local(rpin, rpout):
     """Make a file like current_mirror.time.data to record time
 
-	When doing an incremental backup, this should happen before any
-	other writes, and the file should be removed after all writes.
-	That way we can tell whether the previous session aborted if there
-	are two current_mirror files.
+    When doing an incremental backup, this should happen before any
+    other writes, and the file should be removed after all writes.
+    That way we can tell whether the previous session aborted if there
+    are two current_mirror files.
 
-	When doing the initial full backup, the file can be created after
-	everything else is in place.
+    When doing the initial full backup, the file can be created after
+    everything else is in place.
 
-	"""
+    """
     mirrorrp = Globals.rbdir.append(b'.'.join(
         map(os.fsencode, (b"current_mirror", Time.curtimestr, "data"))))
     Log("Writing mirror marker %s" % mirrorrp.get_safepath(), 6)
@@ -656,12 +655,12 @@ def backup_remove_curmirror_local():
 
 def backup_close_statistics(end_time):
     """Close out the tracking of the backup statistics.
-	
-	Moved to run at this point so that only the clock of the system on which
-	rdiff-backup is run is used (set by passing in time.time() from that
-	system). Use at end of session.
+    
+    Moved to run at this point so that only the clock of the system on which
+    rdiff-backup is run is used (set by passing in time.time() from that
+    system). Use at end of session.
 
-	"""
+    """
     assert Globals.rbdir.conn is Globals.local_connection
     if Globals.print_statistics:
         statistics.print_active_stats(end_time)
@@ -673,10 +672,10 @@ def backup_close_statistics(end_time):
 def Restore(src_rp, dest_rp, restore_as_of=None):
     """Main restoring function
 
-	Here src_rp should be the source file (either an increment or
-	mirror file), dest_rp should be the target rp to be written.
+    Here src_rp should be the source file (either an increment or
+    mirror file), dest_rp should be the target rp to be written.
 
-	"""
+    """
     if not restore_root_set and not restore_set_root(src_rp):
         Log.FatalError("Could not find rdiff-backup repository at %s" %
                        src_rp.get_safepath())
@@ -731,14 +730,14 @@ def restore_init_quoting(src_rp):
 def restore_set_select(mirror_rp, target):
     """Set the selection iterator on both side from command line args
 
-	We must set both sides because restore filtering is different from
-	select filtering.  For instance, if a file is excluded it should
-	not be deleted from the target directory.
+    We must set both sides because restore filtering is different from
+    select filtering.  For instance, if a file is excluded it should
+    not be deleted from the target directory.
 
-	The BytesIO stuff is because filelists need to be read and then
-	duplicated, because we need two copies of them now.
+    The BytesIO stuff is because filelists need to be read and then
+    duplicated, because we need two copies of them now.
 
-	"""
+    """
 
     def fp2string(fp):
         buf = fp.read()
@@ -805,17 +804,17 @@ Try restoring from an increment file (the filenames look like
 def restore_set_root(rpin):
     """Set data dir, restore_root and index, or return None if fail
 
-	The idea here is to keep backing up on the path until we find
-	a directory that contains "rdiff-backup-data".  That is the
-	mirror root.  If the path from there starts
-	"rdiff-backup-data/increments*", then the index is the
-	remainder minus that.  Otherwise the index is just the path
-	minus the root.
+    The idea here is to keep backing up on the path until we find
+    a directory that contains "rdiff-backup-data".  That is the
+    mirror root.  If the path from there starts
+    "rdiff-backup-data/increments*", then the index is the
+    remainder minus that.  Otherwise the index is just the path
+    minus the root.
 
-	All this could fail if the increment file is pointed to in a
-	funny way, using symlinks or somesuch.
+    All this could fail if the increment file is pointed to in a
+    funny way, using symlinks or somesuch.
 
-	"""
+    """
     global restore_root, restore_index, restore_root_set
     if rpin.isincfile():
         relpath = rpin.getincbase().path
@@ -825,7 +824,8 @@ def restore_set_root(rpin):
         # For security checking consistency, don't get absolute path
         pathcomps = relpath.split(b'/')
     else:
-        pathcomps = rpath.RORPath.path_join(rpath.RORPath.getcwdb(), relpath).split(b'/')
+        pathcomps = rpath.RORPath.path_join(rpath.RORPath.getcwdb(),
+                                            relpath).split(b'/')
     if not pathcomps[0]:
         min_len_pathcomps = 2  # treat abs paths differently
     else:
@@ -857,9 +857,9 @@ def restore_set_root(rpin):
     if not from_datadir or from_datadir[0] != b"rdiff-backup-data":
         restore_index = from_datadir  # in mirror, not increments
     else:
-        assert (from_datadir[1] == b"increments" or
-                (len(from_datadir) == 2
-                 and from_datadir[1].startswith(b'increments'))), from_datadir
+        assert (from_datadir[1] == b"increments"
+                or (len(from_datadir) == 2
+                    and from_datadir[1].startswith(b'increments'))), from_datadir
         restore_index = from_datadir[2:]
     restore_root_set = 1
     return 1
@@ -882,10 +882,10 @@ def ListIncrements(rp):
 def require_root_set(rp, read_only):
     """Make sure rp is or is in a valid rdiff-backup dest directory.
 
-	Also initializes fs_abilities (read or read/write) and quoting and
-	return quoted rp if necessary.
+    Also initializes fs_abilities (read or read/write) and quoting and
+    return quoted rp if necessary.
 
-	"""
+    """
     if not restore_set_root(rp):
         Log.FatalError(
             "Bad directory %s.\n"
@@ -1000,13 +1000,13 @@ def ListAtTime(rp):
 def Compare(compare_type, src_rp, dest_rp, compare_time=None):
     """Compare metadata in src_rp with metadata of backup session
 
-	Prints to stdout whenever a file in the src_rp directory has
-	different metadata than what is recorded in the metadata for the
-	appropriate session.
+    Prints to stdout whenever a file in the src_rp directory has
+    different metadata than what is recorded in the metadata for the
+    appropriate session.
 
-	Session time is read from restore_timestr if compare_time is None.
+    Session time is read from restore_timestr if compare_time is None.
 
-	"""
+    """
     global return_val
     dest_rp = require_root_set(dest_rp, 1)
     if not compare_time:
@@ -1104,9 +1104,9 @@ information in it.
 def checkdest_if_necessary(dest_rp):
     """Check the destination dir if necessary.
 
-	This can/should be run before an incremental backup.
+    This can/should be run before an incremental backup.
 
-	"""
+    """
     need_check = checkdest_need_check(dest_rp)
     if need_check == 1:
         Log(

--- a/src/rdiff_backup/Rdiff.py
+++ b/src/rdiff_backup/Rdiff.py
@@ -35,12 +35,13 @@ def get_signature(rp, blocksize=None):
 def find_blocksize(file_len):
     """Return a reasonable block size to use on files of length file_len
 
-	If the block size is too big, deltas will be bigger than is
-	necessary.  If the block size is too small, making deltas and
-	patching can take a really long time.
+    If the block size is too big, deltas will be bigger than is
+    necessary.  If the block size is too small, making deltas and
+    patching can take a really long time.
 
-	"""
-    if file_len < 4096: return 64  # set minimum of 64 bytes
+    """
+    if file_len < 4096:
+        return 64  # set minimum of 64 bytes
     else:  # Use square root, rounding to nearest 16
         return int(pow(file_len, 0.5) / 16) * 16
 
@@ -95,14 +96,14 @@ def write_via_tempfile(fp, rp):
 def patch_local(rp_basis, rp_delta, outrp=None, delta_compressed=None):
     """Patch routine that must be run locally, writes to outrp
 
-	This should be run local to rp_basis because it needs to be a real
-	file (librsync may need to seek around in it).  If outrp is None,
-	patch rp_basis instead.
+    This should be run local to rp_basis because it needs to be a real
+    file (librsync may need to seek around in it).  If outrp is None,
+    patch rp_basis instead.
 
-	The return value is the close value of the delta, so it can be
-	used to produce hashes.
+    The return value is the close value of the delta, so it can be
+    used to produce hashes.
 
-	"""
+    """
     assert rp_basis.conn is Globals.local_connection
     if delta_compressed:
         deltafile = rp_delta.open("rb", 1)

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -80,11 +80,11 @@ def reset_restrict_path(rp):
 def set_security_level(action, cmdpairs):
     """If running client, set security level and restrict_path
 
-	To find these settings, we must look at the action to see what is
-	supposed to happen, and then look at the cmdpairs to see what end
-	the client is on.
+    To find these settings, we must look at the action to see what is
+    supposed to happen, and then look at the cmdpairs to see what end
+    the client is on.
 
-	"""
+    """
 
     def islocal(cmdpair):
         return not cmdpair[0]
@@ -98,9 +98,11 @@ def set_security_level(action, cmdpairs):
     def getpath(cmdpair):
         return cmdpair[1]
 
-    if Globals.server: return
+    if Globals.server:
+        return
     cp1 = cmdpairs[0]
-    if len(cmdpairs) > 1: cp2 = cmdpairs[1]
+    if len(cmdpairs) > 1:
+        cp2 = cmdpairs[1]
     else:
         cp2 = cp1
 
@@ -123,7 +125,8 @@ def set_security_level(action, cmdpairs):
             sec_level = "read-only"
             Main.restore_set_root(
                 rpath.RPath(Globals.local_connection, getpath(cp1)))
-            if Main.restore_root: rdir = Main.restore_root.path
+            if Main.restore_root:
+                rdir = Main.restore_root.path
             else:
                 log.Log.FatalError("Invalid restore directory")
         else:
@@ -245,13 +248,14 @@ def raise_violation(reason, request, arglist):
 
 def vet_request(request, arglist):
     """Examine request for security violations"""
-    #if Globals.server: sys.stderr.write(str(request) + "\n")
+    # if Globals.server: sys.stderr.write(str(request) + "\n")
     security_level = Globals.security_level
     if security_level == "override":
         return
     if Globals.restrict_path:
         for arg in arglist:
-            if isinstance(arg, rpath.RPath): _vet_rpath(arg, request, arglist)
+            if isinstance(arg, rpath.RPath):
+                _vet_rpath(arg, request, arglist)
         if request.function_string in file_requests:
             vet_filename(request, arglist)
     if request.function_string in allowed_requests:

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -48,10 +48,10 @@ class SetConnectionsException(Exception):
 def get_cmd_pairs(arglist, remote_schema=None, remote_cmd=None):
     """Map the given file descriptions into command pairs
 
-	Command pairs are tuples cmdpair with length 2.  cmdpair[0] is
-	None iff it describes a local path, and cmdpair[1] is the path.
+    Command pairs are tuples cmdpair with length 2.  cmdpair[0] is
+    None iff it describes a local path, and cmdpair[1] is the path.
 
-	"""
+    """
     global __cmd_schema
     if remote_schema:
         __cmd_schema = remote_schema
@@ -100,12 +100,12 @@ def desc2cmd_pairs(desc_pair):
 def parse_file_desc(file_desc):
     """Parse file description returning pair (host_info, filename)
 
-	In other words, bescoto@folly.stanford.edu::/usr/bin/ls =>
-	("bescoto@folly.stanford.edu", "/usr/bin/ls").  The
-	complication is to allow for quoting of : by a \.  If the
-	string is not separated by :, then the host_info is None.
+    In other words, bescoto@folly.stanford.edu::/usr/bin/ls =>
+    ("bescoto@folly.stanford.edu", "/usr/bin/ls").  The
+    complication is to allow for quoting of : by a \.  If the
+    string is not separated by :, then the host_info is None.
 
-	"""
+    """
 
     def check_len(i):
         if i >= len(file_desc):
@@ -138,7 +138,7 @@ def parse_file_desc(file_desc):
 
     check_len(i + 1)
 
-    filename = file_desc[i+1:]
+    filename = file_desc[i + 1:]
     # make sure paths under Windows use / instead of \
     if os.path.altsep:  # only Windows has an alternative separator for paths
         filename = filename.replace(os.fsencode(os.path.sep), b'/')
@@ -157,11 +157,11 @@ def fill_schema(host_info):
 def init_connection(remote_cmd):
     """Run remote_cmd, register connection, and then return it
 
-	If remote_cmd is None, then the local connection will be
-	returned.  This also updates some settings on the remote side,
-	like global settings, its connection number, and verbosity.
+    If remote_cmd is None, then the local connection will be
+    returned.  This also updates some settings on the remote side,
+    like global settings, its connection number, and verbosity.
 
-	"""
+    """
     if not remote_cmd:
         return Globals.local_connection
 
@@ -214,7 +214,7 @@ Please make sure that nothing is printed (e.g., by your login shell) when this
 command executes. Try running this command:
 
     %a
-	
+    
 which should only print out the text: rdiff-backup <version>""" %
             (remote_cmd, remote_cmd.replace(b"--server", b"--version")))
 
@@ -281,7 +281,7 @@ def CloseConnections():
     del Globals.connections[1:]  # Only leave local connection
     Globals.connection_dict = {0: Globals.local_connection}
     Globals.backup_reader = Globals.isbackup_reader = \
-       Globals.backup_writer = Globals.isbackup_writer = None
+        Globals.backup_writer = Globals.isbackup_writer = None
 
 
 def TestConnections(rpaths):

--- a/src/rdiff_backup/TempFile.py
+++ b/src/rdiff_backup/TempFile.py
@@ -47,7 +47,7 @@ def new_in_dir(dir_rp):
         tf = dir_rp.append('rdiff-backup.tmp.%d' % _tfindex)
         _tfindex = _tfindex + 1
         if not tf.lstat():
-        	return tf
+            return tf
 
 
 class TempFile(rpath.RPath):
@@ -57,7 +57,7 @@ class TempFile(rpath.RPath):
         """Rename temp file to permanent location, possibly overwriting"""
         if not self.lstat():  # "Moving" empty file, so just delete
             if rp_dest.lstat():
-            	rp_dest.delete()
+                rp_dest.delete()
             remove_listing(self)
             return
 
@@ -75,7 +75,7 @@ class TempFile(rpath.RPath):
             rpath.rename(self, rp_dest)
             self.setdata()
             if self.lstat():
-            	raise OSError("Cannot rename tmp file correctly")
+                raise OSError("Cannot rename tmp file correctly")
         remove_listing(self)
 
     def delete(self):

--- a/src/rdiff_backup/Time.py
+++ b/src/rdiff_backup/Time.py
@@ -80,7 +80,7 @@ def setprevtime_local(timeinseconds, timestr):
 
 def timetostring(timeinseconds):
     """Return w3 datetime compliant listing of timeinseconds, or one in
-	which :'s have been replaced with -'s"""
+    which :'s have been replaced with -'s"""
     if not Globals.use_compatible_timestamps:
         format_string = "%Y-%m-%dT%H:%M:%S"
     else:
@@ -96,10 +96,10 @@ def timetobytes(timeinseconds):
 def stringtotime(timestring):
     """Return time in seconds from w3 timestring
 
-	If there is an error parsing the string, or it doesn't look
-	like a w3 datetime string, return None.
+    If there is an error parsing the string, or it doesn't look
+    like a w3 datetime string, return None.
 
-	"""
+    """
 
     regexp = re.compile('[-:]')
 
@@ -179,7 +179,8 @@ allowed special characters are s, m, h, D, W, M, and Y.  See the man
 page for more information.
 """ % interval_string)
 
-    if len(interval_string) < 2: error()
+    if len(interval_string) < 2:
+        error()
 
     total = 0
     while interval_string:
@@ -197,12 +198,12 @@ page for more information.
 def gettzd(timeinseconds=None):
     """Return w3's timezone identification string.
 
-	Expressed as [+/-]hh:mm.  For instance, PDT is -07:00 during
-	dayling savings and -08:00 otherwise.  Zone coincides with what
-	localtime(), etc., use.  If no argument given, use the current
-	time.
+    Expressed as [+/-]hh:mm.  For instance, PDT is -07:00 during
+    dayling savings and -08:00 otherwise.  Zone coincides with what
+    localtime(), etc., use.  If no argument given, use the current
+    time.
 
-	"""
+    """
     if timeinseconds is None:
         timeinseconds = time.time()
     dst_in_effect = time.daylight and time.localtime(timeinseconds)[8]
@@ -257,10 +258,10 @@ def cmp(time1, time2):
 def time_from_session(session_num, rp=None):
     """Return time in seconds of given backup
 
-	The current mirror is session_num 0, the next oldest increment has
-	number 1, etc.  Requires that the Globals.rbdir directory be set.
+    The current mirror is session_num 0, the next oldest increment has
+    number 1, etc.  Requires that the Globals.rbdir directory be set.
 
-	"""
+    """
     session_times = Globals.rbdir.conn.restore.MirrorStruct \
         .get_increment_times()
     session_times.sort()
@@ -272,10 +273,10 @@ def time_from_session(session_num, rp=None):
 def genstrtotime(timestr, curtime=None, rp=None):
     """Convert a generic time string to a time in seconds
 
-	rp is used when the time is of the form "4B" or similar.  Then the
-	times of the increments of that particular file are used.
+    rp is used when the time is of the form "4B" or similar.  Then the
+    times of the increments of that particular file are used.
 
-	"""
+    """
     if curtime is None:
         curtime = globals()['curtime']
     if timestr == "now":
@@ -316,7 +317,7 @@ the day).""" % timestr)
 
     # Now check for dates like 2001/3/23
     match = _genstr_date_regexp1.search(timestr) or \
-      _genstr_date_regexp2.search(timestr)
+        _genstr_date_regexp2.search(timestr)
     if not match:
         error()
     timestr = "%s-%02d-%02dT00:00:00%s" % (match.group('year'),

--- a/src/rdiff_backup/compare.py
+++ b/src/rdiff_backup/compare.py
@@ -41,11 +41,11 @@ def Compare(src_rp, mirror_rp, inc_rp, compare_time):
 def Compare_hash(src_rp, mirror_rp, inc_rp, compare_time):
     """Compare files at src_rp with repo at compare_time
 
-	Note metadata differences, but also check to see if file data is
-	different.  If two regular files have the same size, hash the
-	source and compare to the hash presumably already present in repo.
+    Note metadata differences, but also check to see if file data is
+    different.  If two regular files have the same size, hash the
+    source and compare to the hash presumably already present in repo.
 
-	"""
+    """
     repo_side = mirror_rp.conn.compare.RepoSide
     data_side = src_rp.conn.compare.DataSide
 
@@ -58,10 +58,10 @@ def Compare_hash(src_rp, mirror_rp, inc_rp, compare_time):
 def Compare_full(src_rp, mirror_rp, inc_rp, compare_time):
     """Compare full data of files at src_rp with repo at compare_time
 
-	Like Compare_hash, but do not rely on hashes, instead copy full
-	data over.
+    Like Compare_hash, but do not rely on hashes, instead copy full
+    data over.
 
-	"""
+    """
     repo_side = mirror_rp.conn.compare.RepoSide
     data_side = src_rp.conn.compare.DataSide
 
@@ -105,7 +105,8 @@ def Verify(mirror_rp, inc_rp, verify_time):
                 (repo_rorp.get_safeindexpath(), computed_hash,
                  repo_rorp.get_sha1()), 2)
     RepoSide.close_rf_cache()
-    if not bad_files: log.Log("Every file verified successfully.", 3)
+    if not bad_files:
+        log.Log("Every file verified successfully.", 3)
     return bad_files
 
 
@@ -126,12 +127,12 @@ def print_reports(report_iter):
 def get_basic_report(src_rp, repo_rorp, comp_data_func=None):
     """Compare src_rp and repo_rorp, return CompareReport
 
-	comp_data_func should be a function that accepts (src_rp,
-	repo_rorp) as arguments, and return 1 if they have the same data,
-	0 otherwise.  If comp_data_func is false, don't compare file data,
-	only metadata.
+    comp_data_func should be a function that accepts (src_rp,
+    repo_rorp) as arguments, and return 1 if they have the same data,
+    0 otherwise.  If comp_data_func is false, don't compare file data,
+    only metadata.
 
-	"""
+    """
     if src_rp:
         index = src_rp.index
     else:
@@ -141,7 +142,8 @@ def get_basic_report(src_rp, repo_rorp, comp_data_func=None):
     elif not src_rp or not src_rp.lstat():
         return CompareReport(index, "deleted")
     elif comp_data_func and src_rp.isreg() and repo_rorp.isreg():
-        if src_rp == repo_rorp: meta_changed = 0
+        if src_rp == repo_rorp:
+            meta_changed = 0
         else:
             meta_changed = 1
         data_changed = comp_data_func(src_rp, repo_rorp)
@@ -179,17 +181,17 @@ class RepoSide(restore.MirrorStruct):
         cls.set_mirror_and_rest_times(compare_time)
         cls.initialize_rf_cache(mirror_rp, inc_rp)
         return cls.subtract_indices(cls.mirror_base.index,
-                                     cls.get_mirror_rorp_iter())
+                                    cls.get_mirror_rorp_iter())
 
     @classmethod
     def attach_files(cls, src_iter, mirror_rp, inc_rp, compare_time):
         """Attach data to all the files that need checking
 
-		Return an iterator of repo rorps that includes all the files
-		that may have changed, and has the fileobj set on all rorps
-		that need it.
+        Return an iterator of repo rorps that includes all the files
+        that may have changed, and has the fileobj set on all rorps
+        that need it.
 
-		"""
+        """
         repo_iter = cls.init_and_get_iter(mirror_rp, inc_rp, compare_time)
         base_index = cls.mirror_base.index
         for src_rorp, mir_rorp in rorpiter.Collate2Iters(src_iter, repo_iter):
@@ -204,7 +206,8 @@ class RepoSide(restore.MirrorStruct):
                     mir_rorp.setfile(fp)
                     mir_rorp.set_attached_filetype('snapshot')
 
-            if mir_rorp: yield mir_rorp
+            if mir_rorp:
+                yield mir_rorp
             else:
                 yield rpath.RORPath(index)  # indicate deleted mir_rorp
 
@@ -274,12 +277,12 @@ class DataSide(backup.SourceStruct):
 class CompareReport:
     """When two files don't match, this tells you how they don't match
 
-	This is necessary because the system that is doing the actual
-	comparing may not be the one printing out the reports.  For speed
-	the compare information can be pipelined back to the client
-	connection as an iter of CompareReports.
+    This is necessary because the system that is doing the actual
+    comparing may not be the one printing out the reports.  For speed
+    the compare information can be pipelined back to the client
+    connection as an iter of CompareReports.
 
-	"""
+    """
     # self.file is added so that CompareReports can masquerade as
     # RORPaths when in an iterator, and thus get pipelined.
     file = None

--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -86,7 +86,7 @@ class ExtendedAttributes:
                 continue
             try:
                 self.attr_dict[attr] = \
-                 rp.conn.xattr.getxattr(rp.path, attr, rp.issym())
+                    rp.conn.xattr.getxattr(rp.path, attr, rp.issym())
             except IOError as exc:
                 # File probably modified while reading, just continue
                 if exc.errno == errno.ENODATA:
@@ -208,7 +208,7 @@ def Record2EA(record):
             ea.set(line)
         else:
             name = line[:eq_pos]
-            assert line[eq_pos+1:eq_pos+3] == b'0s', \
+            assert line[eq_pos + 1:eq_pos + 3] == b'0s', \
                 "Currently only base64 encoding supported"
             encoded_val = line[eq_pos + 3:]
             ea.set(name, base64.b64decode(encoded_val))
@@ -248,11 +248,11 @@ def join_ea_iter(rorp_iter, ea_iter):
 class AccessControlLists:
     """Hold a file's access control list information
 
-	Since posix1e.ACL objects cannot be pickled, and because they lack
-	user/group name information, store everything in self.entry_list
-	and self.default_entry_list.
+    Since posix1e.ACL objects cannot be pickled, and because they lack
+    user/group name information, store everything in self.entry_list
+    and self.default_entry_list.
 
-	"""
+    """
 
     def __init__(self, index, acl_text=None):
         """Initialize object with index and possibly acl_text"""
@@ -317,9 +317,9 @@ class AccessControlLists:
     def text_to_entrytuple(self, text):
         """Return entrytuple given text like 'user:foo:r--'
 
-		See the acl_to_list function for entrytuple documentation.
+        See the acl_to_list function for entrytuple documentation.
 
-		"""
+        """
         typetext, qualifier, permtext = text.split(':')
         if qualifier:
             try:
@@ -381,10 +381,10 @@ class AccessControlLists:
     def __eq__(self, acl):
         """Compare self and other access control list
 
-		Basic acl permissions are considered equal to an empty acl
-		object.
+        Basic acl permissions are considered equal to an empty acl
+        object.
 
-		"""
+        """
         assert isinstance(acl, self.__class__)
         if self.is_basic():
             return acl.is_basic()
@@ -412,11 +412,11 @@ class AccessControlLists:
     def is_basic(self):
         """True if acl can be reduced to standard unix permissions
 
-		Assume that if they are only three entries, they correspond to
-		user, group, and other, and thus don't use any special ACL
-		features.
+        Assume that if they are only three entries, they correspond to
+        user, group, and other, and thus don't use any special ACL
+        features.
 
-		"""
+        """
         if not self.entry_list and not self.default_entry_list:
             return 1
         assert len(self.entry_list) >= 3, self.entry_list
@@ -425,7 +425,7 @@ class AccessControlLists:
     def read_from_rp(self, rp):
         """Set self.ACL from an rpath, or None if not supported"""
         self.entry_list, self.default_entry_list = \
-             rp.conn.eas_acls.get_acl_lists_from_rp(rp)
+            rp.conn.eas_acls.get_acl_lists_from_rp(rp)
 
     def write_to_rp(self, rp, map_names=1):
         """Write current access control list to RPath rp"""
@@ -436,7 +436,8 @@ class AccessControlLists:
 def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
     """Set given rp with ACL that acl_text defines.  rp should be local"""
     assert rp.conn is Globals.local_connection
-    if entry_list: acl = list_to_acl(entry_list, map_names)
+    if entry_list:
+        acl = list_to_acl(entry_list, map_names)
     else:
         acl = posix1e.ACL()
 
@@ -495,23 +496,23 @@ def get_acl_lists_from_rp(rp):
 def acl_to_list(acl):
     """Return list representation of posix1e.ACL object
 
-	ACL objects cannot be pickled, so this representation keeps
-	the structure while adding that option.  Also we insert the
-	username along with the id, because that information will be
-	lost when moved to another system.
+    ACL objects cannot be pickled, so this representation keeps
+    the structure while adding that option.  Also we insert the
+    username along with the id, because that information will be
+    lost when moved to another system.
 
-	The result will be a list of tuples.  Each tuple will have the
-	form (acltype, (uid or gid, uname or gname) or None, permissions
-	as an int).  acltype is encoded as a single character:
+    The result will be a list of tuples.  Each tuple will have the
+    form (acltype, (uid or gid, uname or gname) or None, permissions
+    as an int).  acltype is encoded as a single character:
 
-	U - ACL_USER_OBJ
-	u - ACL_USER
-	G - ACL_GROUP_OBJ
-	g - ACL_GROUP
-	M - ACL_MASK
-	O - ACL_OTHER
+    U - ACL_USER_OBJ
+    u - ACL_USER
+    G - ACL_GROUP_OBJ
+    g - ACL_GROUP
+    M - ACL_MASK
+    O - ACL_OTHER
 
-	"""
+    """
 
     def acltag_to_char(tag):
         if tag == posix1e.ACL_USER_OBJ:
@@ -549,13 +550,13 @@ def acl_to_list(acl):
 def list_to_acl(entry_list, map_names=1):
     """Return posix1e.ACL object from list representation
 
-	If map_names is true, use user_group to update the names for the
-	current system, and drop if not available.  Otherwise just use the
-	same id.
+    If map_names is true, use user_group to update the names for the
+    current system, and drop if not available.  Otherwise just use the
+    same id.
 
-	See the acl_to_list function for the format of an acllist.
+    See the acl_to_list function for the format of an acllist.
 
-	"""
+    """
 
     def char_to_acltag(typechar):
         """Given typechar, query posix1e module for appropriate constant"""
@@ -607,7 +608,8 @@ def list_to_acl(entry_list, map_names=1):
 
         entry = posix1e.Entry(acl)
         entry.tag_type = char_to_acltag(typechar)
-        if id is not None: entry.qualifier = id
+        if id is not None:
+            entry.qualifier = id
         entry.permset.read = perms >> 2
         entry.permset.write = perms >> 1 & 1
         entry.permset.execute = perms & 1
@@ -625,8 +627,7 @@ def acl_compare_rps(rp1, rp2):
 
 def ACL2Record(acl):
     """Convert an AccessControlLists object into a text record"""
-    return b'# file: %b\n%b\n' % \
-     (C.acl_quote(acl.get_indexpath()), os.fsencode(str(acl)))
+    return b'# file: %b\n%b\n' % (C.acl_quote(acl.get_indexpath()), os.fsencode(str(acl)))
 
 
 def Record2ACL(record):
@@ -647,10 +648,10 @@ def Record2ACL(record):
 class ACLExtractor(EAExtractor):
     """Iterate AccessControlLists objects from the ACL information file
 
-	Except for the record_to_object method, we can reuse everything in
-	the EAExtractor class because the file formats are so similar.
+    Except for the record_to_object method, we can reuse everything in
+    the EAExtractor class because the file formats are so similar.
 
-	"""
+    """
     record_to_object = staticmethod(Record2ACL)
 
 
@@ -674,11 +675,12 @@ def join_acl_iter(rorp_iter, acl_iter):
 def rpath_acl_get(rp):
     """Get acls of given rpath rp.
 
-	This overrides a function in the rpath module.
+    This overrides a function in the rpath module.
 
-	"""
+    """
     acl = AccessControlLists(rp.index)
-    if not rp.issym(): acl.read_from_rp(rp)
+    if not rp.issym():
+        acl.read_from_rp(rp)
     return acl
 
 
@@ -696,9 +698,9 @@ rpath.get_blank_acl = rpath_get_blank_acl
 def rpath_ea_get(rp):
     """Get extended attributes of given rpath
 
-	This overrides a function in the rpath module.
+    This overrides a function in the rpath module.
 
-	"""
+    """
     ea = ExtendedAttributes(rp.index)
     if not rp.issock() and not rp.isfifo():
         ea.read_from_rp(rp)

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -117,13 +117,13 @@ class FSAbilities:
     def init_readonly(self, rp):
         """Set variables using fs tested at RPath rp.  Run locally.
 
-		This method does not write to the file system at all, and
-		should be run on the file system when the file system will
-		only need to be read.
+        This method does not write to the file system at all, and
+        should be run on the file system when the file system will
+        only need to be read.
 
-		Only self.acls and self.eas are set.
+        Only self.acls and self.eas are set.
 
-		"""
+        """
         assert rp.conn is Globals.local_connection
         self.root_rp = rp
         self.read_only = 1
@@ -140,11 +140,11 @@ class FSAbilities:
     def init_readwrite(self, rbdir):
         """Set variables using fs tested at rp_base.  Run locally.
 
-		This method creates a temp directory in rp_base and writes to
-		it in order to test various features.  Use on a file system
-		that will be written to.
+        This method creates a temp directory in rp_base and writes to
+        it in order to test various features.  Use on a file system
+        that will be written to.
 
-		"""
+        """
         assert rbdir.conn is Globals.local_connection
         if not rbdir.isdir():
             assert not rbdir.lstat(), (rbdir.path, rbdir.lstat())
@@ -240,7 +240,8 @@ class FSAbilities:
             ext_rp = subdir.append(extended_filename)
             ext_rp.touch()
         except (IOError, OSError):
-            if ext_rp: assert not ext_rp.lstat()
+            if ext_rp:
+                assert not ext_rp.lstat()
             self.extended_filenames = 0
         else:
             assert ext_rp.lstat()
@@ -333,11 +334,11 @@ class FSAbilities:
         def find_letter(subdir):
             """Find a (subdir_rp, dirlist) with a letter in it, or None
 
-			Recurse down the directory, looking for any file that has
-			a letter in it.  Return the pair (rp, [list of filenames])
-			where the list is of the directory containing rp.
+            Recurse down the directory, looking for any file that has
+            a letter in it.  Return the pair (rp, [list of filenames])
+            where the list is of the directory containing rp.
 
-			"""
+            """
             l = robust.listrp(subdir)
             for filename in l:
                 if filename != filename.swapcase():
@@ -346,7 +347,8 @@ class FSAbilities:
                 dir_rp = subdir.append(filename)
                 if dir_rp.isdir():
                     subsearch = find_letter(dir_rp)
-                    if subsearch: return subsearch
+                    if subsearch:
+                        return subsearch
             return None
 
         def test_triple(dir_rp, dirlist, filename):
@@ -440,7 +442,8 @@ class FSAbilities:
             return
 
         try:
-            import win32security, pywintypes
+            import win32security
+            import pywintypes
         except ImportError:
             log.Log(
                 "Unable to import win32security module. Windows ACLs\n"
@@ -501,7 +504,7 @@ class FSAbilities:
 
     def set_carbonfile(self):
         """Test for support of the Mac Carbon library.  This library
-		can be used to obtain Finder info (creator/type)."""
+        can be used to obtain Finder info (creator/type)."""
         try:
             import Carbon.File
             import MacOS
@@ -543,11 +546,11 @@ class FSAbilities:
     def set_resource_fork_readonly(self, dir_rp):
         """Test for resource fork support by testing an regular file
 
-		Launches search for regular file in given directory.  If no
-		regular file is found, resource_fork support will be turned
-		off by default.
+        Launches search for regular file in given directory.  If no
+        regular file is found, resource_fork support will be turned
+        off by default.
 
-		"""
+        """
         for rp in selection.Select(dir_rp).set_iter():
             if rp.isreg():
                 try:
@@ -592,28 +595,30 @@ class FSAbilities:
         else:
             sym_dest.setdata()
             assert sym_dest.issym()
-            if sym_dest.getperms() == 0o700: self.symlink_perms = 1
-            else: self.symlink_perms = 0
+            if sym_dest.getperms() == 0o700:
+                self.symlink_perms = 1
+            else:
+                self.symlink_perms = 0
             sym_dest.delete()
         sym_source.delete()
 
     def set_escape_dos_devices(self, subdir):
         """Test if DOS device files can be used as filenames.
 
-		This test must detect if the underlying OS is Windows, whether we are
-		running under Cygwin or natively. Cygwin allows these special files to
-		be stat'd from any directory. Native Windows returns OSError (like
-		non-Cygwin POSIX), but we can check for that using os.name.
+        This test must detect if the underlying OS is Windows, whether we are
+        running under Cygwin or natively. Cygwin allows these special files to
+        be stat'd from any directory. Native Windows returns OSError (like
+        non-Cygwin POSIX), but we can check for that using os.name.
 
-		Note that 'con' and 'aux' have some unusual behaviors as shown below.
+        Note that 'con' and 'aux' have some unusual behaviors as shown below.
 
-		os.lstat() 	 |	con			aux			prn
-		-------------+-------------------------------------
-		Unix		 |	OSError,2	OSError,2	OSError,2
-		Cygwin/NTFS	 |	-success-	-success-	-success-
-		Cygwin/FAT32 |	-success-	-HANGS-
-		Native Win	 |	WinError,2	WinError,87	WinError,87
-		"""
+        os.lstat()   |  con         aux         prn
+        -------------+-------------------------------------
+        Unix         |  OSError,2   OSError,2   OSError,2
+        Cygwin/NTFS  |  -success-   -success-   -success-
+        Cygwin/FAT32 |  -success-   -HANGS-
+        Native Win   |  WinError,2  WinError,87 WinError,87
+        """
         if os.name == "nt":
             self.escape_dos_devices = 1
             return
@@ -628,14 +633,14 @@ class FSAbilities:
             self.escape_dos_devices = 1
 
     def set_escape_trailing_spaces_readwrite(self, testdir):
-        """Windows and Linux/FAT32 will not preserve trailing spaces or periods.
-	
-		Linux/FAT32 behaves inconsistently: It will give an OSError,22 if
-		os.mkdir() is called on a directory name with a space at the end, but
-		will give an IOError("invalid mode") if you attempt to create a filename
-		with a space at the end. However, if a period is placed at the end of
-		the name, Linux/FAT32 is consistent with Cygwin and Native Windows.
-		"""
+        """
+        Windows and Linux/FAT32 will not preserve trailing spaces or periods.
+        Linux/FAT32 behaves inconsistently: It will give an OSError,22 if
+        os.mkdir() is called on a directory name with a space at the end, but
+        will give an IOError("invalid mode") if you attempt to create a filename
+        with a space at the end. However, if a period is placed at the end of
+        the name, Linux/FAT32 is consistent with Cygwin and Native Windows.
+        """
 
         period_rp = testdir.append("foo.")
         assert not period_rp.lstat()
@@ -654,7 +659,7 @@ class FSAbilities:
 
     def set_escape_trailing_spaces_readonly(self, rp):
         """Determine if directory at rp permits filenames with trailing
-		spaces or periods without writing."""
+        spaces or periods without writing."""
 
         def test_period(dir_rp, dirlist):
             """Return 1 if trailing spaces and periods should be escaped"""
@@ -690,11 +695,11 @@ class FSAbilities:
 def get_readonly_fsa(desc_string, rp):
     """Return an fsa with given description_string
 
-	Will be initialized read_only with given RPath rp.  We separate
-	this out into a separate function so the request can be vetted by
-	the security module.
+    Will be initialized read_only with given RPath rp.  We separate
+    this out into a separate function so the request can be vetted by
+    the security module.
 
-	"""
+    """
     if os.name == 'nt':
         log.Log("Hardlinks disabled by default on Windows", 4)
         SetConnections.UpdateGlobal('preserve_hardlinks', 0)
@@ -704,9 +709,9 @@ def get_readonly_fsa(desc_string, rp):
 class SetGlobals:
     """Various functions for setting Globals vars given FSAbilities above
 
-	Container for BackupSetGlobals and RestoreSetGlobals (don't use directly)
+    Container for BackupSetGlobals and RestoreSetGlobals (don't use directly)
 
-	"""
+    """
 
     def __init__(self, in_conn, out_conn, src_fsa, dest_fsa):
         """Just store some variables for use below"""
@@ -789,19 +794,19 @@ class BackupSetGlobals(SetGlobals):
 
     def set_special_escapes(self, rbdir):
         """Escaping DOS devices and trailing periods/spaces works like
-		regular filename escaping. If only the destination requires it,
-		then we do it. Otherwise, it is not necessary, since the files
-		couldn't have been created in the first place. We also record
-		whether we have done it in order to handle the case where a
-		volume which was escaped is later restored by an OS that does
-		not require it.
+        regular filename escaping. If only the destination requires it,
+        then we do it. Otherwise, it is not necessary, since the files
+        couldn't have been created in the first place. We also record
+        whether we have done it in order to handle the case where a
+        volume which was escaped is later restored by an OS that does
+        not require it.
 
         """
 
-        suggested_edd = (self.dest_fsa.escape_dos_devices and not \
-          self.src_fsa.escape_dos_devices)
-        suggested_ets = (self.dest_fsa.escape_trailing_spaces and not \
-          self.src_fsa.escape_trailing_spaces)
+        suggested_edd = (self.dest_fsa.escape_dos_devices
+                         and not self.src_fsa.escape_dos_devices)
+        suggested_ets = (self.dest_fsa.escape_trailing_spaces
+                         and not self.src_fsa.escape_trailing_spaces)
 
         se_rp = rbdir.append("special_escapes")
         if not se_rp.lstat():
@@ -836,16 +841,17 @@ class BackupSetGlobals(SetGlobals):
     def set_chars_to_quote(self, rbdir, force):
         """Set chars_to_quote setting for backup session
 
-		Unlike most other options, the chars_to_quote setting also
-		depends on the current settings in the rdiff-backup-data
-		directory, not just the current fs features.
+        Unlike most other options, the chars_to_quote setting also
+        depends on the current settings in the rdiff-backup-data
+        directory, not just the current fs features.
 
-		"""
+        """
         (ctq, update) = self.compare_ctq_file(rbdir, self.get_ctq_from_fsas(),
                                               force)
 
         SetConnections.UpdateGlobal('chars_to_quote', ctq)
-        if Globals.chars_to_quote: FilenameMapping.set_init_quote_vals()
+        if Globals.chars_to_quote:
+            FilenameMapping.set_init_quote_vals()
         return update
 
     def get_ctq_from_fsas(self):
@@ -927,18 +933,18 @@ class RestoreSetGlobals(SetGlobals):
     def update_triple(self, src_support, dest_support, attr_triple):
         """Update global settings for feature based on fsa results
 
-		This is slightly different from BackupSetGlobals.update_triple
-		because (using the mirror_metadata file) rpaths from the
-		source may have more information than the file system
-		supports.
+        This is slightly different from BackupSetGlobals.update_triple
+        because (using the mirror_metadata file) rpaths from the
+        source may have more information than the file system
+        supports.
 
-		"""
+        """
         active_attr, write_attr, conn_attr = attr_triple
         if Globals.get(active_attr) == 0:
             return  # don't override 0
         for attr in attr_triple:
             SetConnections.UpdateGlobal(attr, None)
-        if not dest_support: 
+        if not dest_support:
             return  # if dest doesn't support, do nothing
         SetConnections.UpdateGlobal(active_attr, 1)
         self.out_conn.Globals.set_local(conn_attr, 1)
@@ -948,7 +954,7 @@ class RestoreSetGlobals(SetGlobals):
 
     def set_special_escapes(self, rbdir):
         """Set escape_dos_devices and escape_trailing_spaces from
-		rdiff-backup-data dir, just like chars_to_quote"""
+        rdiff-backup-data dir, just like chars_to_quote"""
         se_rp = rbdir.append("special_escapes")
         if se_rp.lstat():
             se = se_rp.get_string().split("\n")
@@ -1037,10 +1043,10 @@ class SingleSetGlobals(RestoreSetGlobals):
 def backup_set_globals(rpin, force):
     """Given rps for source filesystem and repository, set fsa globals
 
-	This should be run on the destination connection, because we may
-	need to write a new chars_to_quote file.
+    This should be run on the destination connection, because we may
+    need to write a new chars_to_quote file.
 
-	"""
+    """
     assert Globals.rbdir.conn is Globals.local_connection
     src_fsa = rpin.conn.fs_abilities.get_readonly_fsa('source', rpin)
     log.Log(str(src_fsa), 4)

--- a/src/rdiff_backup/hash.py
+++ b/src/rdiff_backup/hash.py
@@ -25,13 +25,13 @@ from . import Globals
 class FileWrapper:
     """Wrapper around a file-like object
 
-	Only use this with files that will be read through in a single
-	pass and then closed.  (There is no seek().)  When you close it,
-	return value will be a Report.
+    Only use this with files that will be read through in a single
+    pass and then closed.  (There is no seek().)  When you close it,
+    return value will be a Report.
 
-	Currently this just calculates a sha1sum of the datastream.
+    Currently this just calculates a sha1sum of the datastream.
 
-	"""
+    """
 
     def __init__(self, fileobj):
         self.fileobj = fileobj
@@ -58,11 +58,11 @@ class Report:
         # hash values do fit.
         if isinstance(close_val, Report):
             assert close_val.sha1_digest == sha1_digest, \
-             "Hashes from return code %s and given %s don't match" % \
-              (close_val.sha1_digest, sha1_digest)
+                "Hashes from return code %s and given %s don't match" % \
+                (close_val.sha1_digest, sha1_digest)
         else:
             assert not close_val, "Return code %s of type %s isn't null" % \
-              (close_val, type(close_val))
+                (close_val, type(close_val))
         self.sha1_digest = sha1_digest
 
 

--- a/src/rdiff_backup/increment.py
+++ b/src/rdiff_backup/increment.py
@@ -25,14 +25,14 @@ from . import Globals, Time, rpath, Rdiff, log, statistics, robust
 def Increment(new, mirror, incpref):
     """Main file incrementing function, returns inc file created
 
-	new is the file on the active partition,
-	mirror is the mirrored file from the last backup,
-	incpref is the prefix of the increment file.
+    new is the file on the active partition,
+    mirror is the mirrored file from the last backup,
+    incpref is the prefix of the increment file.
 
-	This function basically moves the information about the mirror
-	file to incpref.
+    This function basically moves the information about the mirror
+    file to incpref.
 
-	"""
+    """
     log.Log("Incrementing mirror file %s" % mirror.get_safepath(), 5)
     if ((new and new.isdir()) or mirror.isdir()) and not incpref.lstat():
         incpref.mkdir()
@@ -124,13 +124,13 @@ def makedir(mirrordir, incpref):
 def get_inc(rp, typestr, time=None):
     """Return increment like rp but with time and typestr suffixes
 
-	To avoid any quoting, the returned rpath has empty index, and the
-	whole filename is in the base (which is not quoted).
+    To avoid any quoting, the returned rpath has empty index, and the
+    whole filename is in the base (which is not quoted).
 
-	"""
+    """
     if time is None:
         time = Time.prevtime
-    addtostr = lambda s: b'.'.join(map(os.fsencode,(s, Time.timetostring(time), typestr)))
+    addtostr = lambda s: b'.'.join(map(os.fsencode, (s, Time.timetostring(time), typestr)))
     if rp.index:
         incrp = rp.__class__(rp.conn, rp.base,
                              rp.index[:-1] + (addtostr(rp.index[-1]), ))

--- a/src/rdiff_backup/librsync.py
+++ b/src/rdiff_backup/librsync.py
@@ -33,12 +33,12 @@ blocksize = _librsync.RS_JOB_BLOCKSIZE
 class librsyncError(Exception):
     """Signifies error in internal librsync processing (bad signature, etc.)
 
-	underlying _librsync.librsyncError's are regenerated using this
-	class because the C-created exceptions are by default
-	unPickleable.  There is probably a way to fix this in _librsync,
-	but this scheme was easier.
+    underlying _librsync.librsyncError's are regenerated using this
+    class because the C-created exceptions are by default
+    unPickleable.  There is probably a way to fix this in _librsync,
+    but this scheme was easier.
 
-	"""
+    """
     pass
 
 
@@ -121,10 +121,10 @@ class SigFile(LikeFile):
     def __init__(self, infile, blocksize=_librsync.RS_DEFAULT_BLOCK_LEN):
         """SigFile initializer - takes basis file
 
-		basis file only needs to have read() and close() methods.  It
-		will be closed when we come to the end of the signature.
+        basis file only needs to have read() and close() methods.  It
+        will be closed when we come to the end of the signature.
 
-		"""
+        """
         LikeFile.__init__(self, infile)
         try:
             self.maker = _librsync.new_sigmaker(blocksize)
@@ -138,11 +138,11 @@ class DeltaFile(LikeFile):
     def __init__(self, signature, new_file):
         """DeltaFile initializer - call with signature and new file
 
-		Signature can either be a string or a file with read() and
-		close() methods.  New_file also only needs to have read() and
-		close() methods.  It will be closed when self is closed.
+        Signature can either be a string or a file with read() and
+        close() methods.  New_file also only needs to have read() and
+        close() methods.  It will be closed when self is closed.
 
-		"""
+        """
         LikeFile.__init__(self, new_file)
         if type(signature) is bytes:
             sig_string = signature
@@ -162,11 +162,11 @@ class PatchedFile(LikeFile):
     def __init__(self, basis_file, delta_file):
         """PatchedFile initializer - call with basis delta
 
-		Here basis_file must be a true Python file, because we may
-		need to seek() around in it a lot, and this is done in C.
-		delta_file only needs read() and close() methods.
+        Here basis_file must be a true Python file, because we may
+        need to seek() around in it a lot, and this is done in C.
+        delta_file only needs read() and close() methods.
 
-		"""
+        """
         LikeFile.__init__(self, delta_file)
         if hasattr(basis_file, 'file'):
             self.basis_file = basis_file.file
@@ -189,10 +189,10 @@ class PatchedFile(LikeFile):
 class SigGenerator:
     """Calculate signature.
 
-	Input and output is same as SigFile, but the interface is like md5
-	module, not filelike object
+    Input and output is same as SigFile, but the interface is like md5
+    module, not filelike object
 
-	"""
+    """
 
     def __init__(self, blocksize=_librsync.RS_DEFAULT_BLOCK_LEN):
         """Return new signature instance"""

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -62,10 +62,10 @@ class Logger:
     def open_logfile(self, rpath):
         """Inform all connections of an open logfile.
 
-		rpath.conn will write to the file, and the others will pass
-		write commands off to it.
+        rpath.conn will write to the file, and the others will pass
+        write commands off to it.
 
-		"""
+        """
         assert not self.log_file_open
         rpath.conn.log.Log.open_logfile_local(rpath)
         for conn in Globals.connections:
@@ -109,7 +109,8 @@ class Logger:
         if verbosity < 9:
             return "%s\n" % message
         else:
-            timestamp = datetime.datetime.now().astimezone().strftime("%F %H:%M:%S.%f %z")
+            timestamp = datetime.datetime.now().astimezone().strftime(
+                "%F %H:%M:%S.%f %z")
             if Globals.server:
                 role = "SERVER"
             else:
@@ -119,12 +120,12 @@ class Logger:
     def __call__(self, message, verbosity):
         """Log message that has verbosity importance
 
-		message can be a string, which is logged as-is, or a function,
-		which is then called and should return the string to be
-		logged.  We do it this way in case producing the string would
-		take a significant amount of CPU.
-		
-		"""
+        message can be a string, which is logged as-is, or a function,
+        which is then called and should return the string to be
+        logged.  We do it this way in case producing the string would
+        take a significant amount of CPU.
+        
+        """
         if verbosity > self.verbosity and verbosity > self.term_verbosity:
             return
 
@@ -163,12 +164,12 @@ class Logger:
     def conn(self, direction, result, req_num):
         """Log some data on the connection
 
-		The main worry with this function is that something in here
-		will create more network traffic, which will spiral to
-		infinite regress.  So, for instance, logging must only be done
-		to the terminal, because otherwise the log file may be remote.
+        The main worry with this function is that something in here
+        will create more network traffic, which will spiral to
+        infinite regress.  So, for instance, logging must only be done
+        to the terminal, because otherwise the log file may be remote.
 
-		"""
+        """
         if self.term_verbosity < 9:
             return
         if type(result) is bytes:
@@ -214,11 +215,11 @@ class Logger:
     def exception(self, only_terminal=0, verbosity=5):
         """Log an exception and traceback
 
-		If only_terminal is None, log normally.  If it is 1, then only
-		log to disk if log file is local (self.log_file_open = 1).  If
-		it is 2, don't log to disk at all.
+        If only_terminal is None, log normally.  If it is 1, then only
+        log to disk if log file is local (self.log_file_open = 1).  If
+        it is 2, don't log to disk at all.
 
-		"""
+        """
         assert only_terminal in (0, 1, 2)
         if (only_terminal == 0 or (only_terminal == 1 and self.log_file_open)):
             logging_func = self.__call__
@@ -241,13 +242,13 @@ Log = Logger()
 class ErrorLog:
     """Log each recoverable error in error_log file
 
-	There are three types of recoverable errors:  ListError, which
-	happens trying to list a directory or stat a file, UpdateError,
-	which happen when trying to update a changed file, and
-	SpecialFileError, which happen when a special file cannot be
-	created.  See the error policy file for more info.
+    There are three types of recoverable errors:  ListError, which
+    happens trying to list a directory or stat a file, UpdateError,
+    which happen when trying to update a changed file, and
+    SpecialFileError, which happen when a special file cannot be
+    created.  See the error policy file for more info.
 
-	"""
+    """
     _log_fileobj = None
 
     @classmethod
@@ -262,7 +263,8 @@ class ErrorLog:
         base_rp = Globals.rbdir.append("error_log.%s.data" % (time_string, ))
         if compress:
             cls._log_fileobj = rpath.MaybeGzip(base_rp)
-        else: cls._log_fileobj = base_rp.open("wb", compress=0)
+        else:
+            cls._log_fileobj = base_rp.open("wb", compress=0)
 
     @classmethod
     def isopen(cls):
@@ -295,7 +297,8 @@ class ErrorLog:
         except AttributeError:
             if type(obj) is tuple:
                 return "/".join(obj)
-            else: return repr(obj)
+            else:
+                return repr(obj)
 
     @classmethod
     def write_if_open(cls, error_type, rp, exc):
@@ -311,8 +314,8 @@ class ErrorLog:
     @classmethod
     def get_log_string(cls, error_type, rp, exc):
         """Return log string to put in error log"""
-        assert (error_type == "ListError" or error_type == "UpdateError" or
-                error_type == "SpecialFileError"), "Unknown type " + error_type
+        assert (error_type == "ListError" or error_type == "UpdateError"
+                or error_type == "SpecialFileError"), "Unknown type " + error_type
         tmpstr = "%s %s %s" % (error_type, cls.get_indexpath(rp), str(exc))
         return tmpstr.encode('utf-8')
 

--- a/src/rdiff_backup/longname.py
+++ b/src/rdiff_backup/longname.py
@@ -116,10 +116,10 @@ def get_next_free():
 def check_new_index(base, index, make_dirs=0):
     """Return new rpath with given index, or None if that is too long
 
-	If make_dir is True, make any parent directories to assure that
-	file is really too long, and not just in directories that don't exist.
+    If make_dir is True, make any parent directories to assure that
+    file is really too long, and not just in directories that don't exist.
 
-	"""
+    """
 
     def wrap_call(func, *args):
         try:
@@ -153,11 +153,11 @@ def check_new_index(base, index, make_dirs=0):
 def get_mirror_rp(mirror_base, mirror_rorp):
     """Get the mirror_rp for reading a regular file
 
-	This will just be in the mirror_base, unless rorp has an alt
-	mirror name specified.  Use new_rorp, unless it is None or empty,
-	and mirror_rorp exists.
+    This will just be in the mirror_base, unless rorp has an alt
+    mirror name specified.  Use new_rorp, unless it is None or empty,
+    and mirror_rorp exists.
 
-	"""
+    """
     if mirror_rorp.has_alt_mirror_name():
         return get_long_rp(mirror_rorp.get_alt_mirror_name())
     else:
@@ -171,10 +171,10 @@ def get_mirror_rp(mirror_base, mirror_rorp):
 def get_mirror_inc_rps(rorp_pair, mirror_root, inc_root=None):
     """Get (mirror_rp, inc_rp) pair, possibly making new longname base
 
-	To test inc_rp, pad incbase with 50 random (non-quoted) characters
-	and see if that raises an error.
+    To test inc_rp, pad incbase with 50 random (non-quoted) characters
+    and see if that raises an error.
 
-	"""
+    """
     if not inc_root:  # make fake inc_root if not available
         inc_root = mirror_root.append_path(b'rdiff-backup-data/increments')
 
@@ -304,7 +304,8 @@ def update_rf(rf, rorp, mirror_root):
         update_incs(rf, inc_name)
         return rf
 
-    if not rorp: return rf
+    if not rorp:
+        return rf
     if rf and not rorp.has_alt_mirror_name() and not rorp.has_alt_inc_name():
         return rf  # Most common case
     if rf:

--- a/src/rdiff_backup/manage.py
+++ b/src/rdiff_backup/manage.py
@@ -57,16 +57,16 @@ def get_inc_type(inc):
 def describe_incs_parsable(incs, mirror_time, mirrorrp):
     """Return a string parsable by computer describing the increments
 
-	Each line is a time in seconds of the increment, and then the
-	type of the file.  It will be sorted oldest to newest.  For example:
+    Each line is a time in seconds of the increment, and then the
+    type of the file.  It will be sorted oldest to newest.  For example:
 
-	10000 regular
-	20000 directory
-	30000 special
-	40000 missing
-	50000 regular    <- last will be the current mirror
+    10000 regular
+    20000 directory
+    30000 special
+    40000 missing
+    50000 regular    <- last will be the current mirror
 
-	"""
+    """
     incpairs = [(inc.getinctime(), inc) for inc in incs]
     incpairs.sort()
     result = ["%s %s" % (time, get_inc_type(inc)) for time, inc in incpairs]
@@ -95,11 +95,11 @@ def describe_incs_human(incs, mirror_time, mirrorrp):
 def delete_earlier_than(baserp, time):
     """Deleting increments older than time in directory baserp
 
-	time is in seconds.  It will then delete any empty directories
-	in the tree.  To process the entire backup area, the
-	rdiff-backup-data directory should be the root of the tree.
+    time is in seconds.  It will then delete any empty directories
+    in the tree.  To process the entire backup area, the
+    rdiff-backup-data directory should be the root of the tree.
 
-	"""
+    """
     baserp.conn.manage.delete_earlier_than_local(baserp, time)
 
 
@@ -127,10 +127,10 @@ class IncObj:
     def __init__(self, incrp):
         """IncObj initializer
 
-		incrp is an RPath of a path like increments.TIMESTR.dir
-		standing for the root of the increment.
+        incrp is an RPath of a path like increments.TIMESTR.dir
+        standing for the root of the increment.
 
-		"""
+        """
         if not incrp.isincfile():
             raise ManageException(
                 "%s is not an inc file" % incrp.get_safepath())
@@ -210,8 +210,8 @@ def ListIncrementSizes(mirror_root, index):
         time, size, cum_size = triple
         return "%24s   %13s   %15s" % \
             (Time.timetopretty(time),
-          stat_obj.get_byte_summary_string(size),
-          stat_obj.get_byte_summary_string(cum_size))
+             stat_obj.get_byte_summary_string(size),
+             stat_obj.get_byte_summary_string(cum_size))
 
     mirror_total = get_total(get_mirror_select())
     time_dict = get_time_dict(get_inc_select())

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -28,9 +28,9 @@ reasons for this:
     cannot set uid/gid.  Or the source side may have ACLs and the
     destination side doesn't.
 
-	Hopefully every file system can store binary data.  Storing
-	metadata separately allows us to back up anything (ok, maybe
-	strange filenames are still a problem).
+    Hopefully every file system can store binary data.  Storing
+    metadata separately allows us to back up anything (ok, maybe
+    strange filenames are still a problem).
 
 2)  Metadata can be more quickly read from a file than it can by
     traversing the mirror directory over and over again.  In many
@@ -84,7 +84,7 @@ def carbonfile2string(cfile):
 
 def string2carbonfile(data):
     """Re-constitute CarbonFile data from a string stored by 
-	carbonfile2string."""
+    carbonfile2string."""
     retval = {}
     for component in data.split('|'):
         key, value = component.split(':')
@@ -185,11 +185,11 @@ line_parsing_regexp = re.compile(b"^ *([A-Za-z0-9]+) (.+)$", re.M)
 def Record2RORP(record_string):
     """Given record_string, return RORPath
 
-	For speed reasons, write the RORPath data dictionary directly
-	instead of calling rorpath functions.  Profiling has shown this to
-	be a time critical function.
+    For speed reasons, write the RORPath data dictionary directly
+    instead of calling rorpath functions.  Profiling has shown this to
+    be a time critical function.
 
-	"""
+    """
     data_dict = {}
     for field, data in line_parsing_regexp.findall(record_string):
         field = field.decode('ascii')
@@ -259,11 +259,11 @@ chars_to_quote = re.compile(b"\\n|\\\\")
 def quote_path(path_string):
     """Return quoted version of path_string
 
-	Because newlines are used to separate fields in a record, they are
-	replaced with \n.  Backslashes become \\ and everything else is
-	left the way it is.
+    Because newlines are used to separate fields in a record, they are
+    replaced with \n.  Backslashes become \\ and everything else is
+    left the way it is.
 
-	"""
+    """
 
     def replacement_func(match_obj):
         """This is called on the match obj of any char that needs quoting"""
@@ -360,10 +360,10 @@ class FlatExtractor:
     def skip_to_index(self, index):
         """Scan through the file, set buffer to beginning of index record
 
-		Here we make sure that the buffer always ends in a newline, so
-		we will not be splitting lines in half.
+        Here we make sure that the buffer always ends in a newline, so
+        we will not be splitting lines in half.
 
-		"""
+        """
         assert not self.buf or self.buf.endswith(b"\n")
         while 1:
             self.buf = self.fileobj.read(self.blocksize)
@@ -405,10 +405,10 @@ class FlatExtractor:
     def filename_to_index(self, filename):
         """Translate filename, possibly quoted, into an index tuple
 
-		The filename is the first group matched by
-		regexp_boundary_regexp.
+        The filename is the first group matched by
+        regexp_boundary_regexp.
 
-		"""
+        """
         assert 0  # subclass
 
 
@@ -422,15 +422,15 @@ class RorpExtractor(FlatExtractor):
 class FlatFile:
     """Manage a flat file containing info on various files
 
-	This is used for metadata information, and possibly EAs and ACLs.
-	The main read interface is as an iterator.  The storage format is
-	a flat, probably compressed file, so random access is not
-	recommended.
+    This is used for metadata information, and possibly EAs and ACLs.
+    The main read interface is as an iterator.  The storage format is
+    a flat, probably compressed file, so random access is not
+    recommended.
 
-	Even if the file looks like a text file, it is actually a binary file,
-	so that (especially) paths can be stored as bytes, without issue
-	with encoding / decoding.
-	"""
+    Even if the file looks like a text file, it is actually a binary file,
+    so that (especially) paths can be stored as bytes, without issue
+    with encoding / decoding.
+    """
     rp, fileobj, mode = None, None, None
     _buffering_on = 1  # Buffering may be useful because gzip writes are slow
     _record_buffer, _max_buffer_size = None, 100
@@ -441,10 +441,10 @@ class FlatFile:
     def __init__(self, rp_base, mode, check_path=1, compress=1, callback=None):
         """Open rp (or rp+'.gz') for reading ('r') or writing ('w')
 
-		If callback is available, it will be called on the rp upon
-		closing (because the rp may not be known in advance).
+        If callback is available, it will be called on the rp upon
+        closing (because the rp may not be known in advance).
 
-		"""
+        """
         self.mode = mode
         self.callback = callback
         self._record_buffer = []
@@ -457,7 +457,7 @@ class FlatFile:
             self.fileobj = self.rp.open("rb", compress)
         else:
             assert mode == 'w' or mode == 'wb', \
-              "File opening mode must be one of r, rb, w or wb, and not %s." % mode
+                "File opening mode must be one of r, rb, w or wb, and not %s." % mode
             if compress and check_path and not rp_base.isinccompressed():
 
                 def callback(rp):
@@ -522,7 +522,7 @@ class CombinedWriter:
     def __init__(self, metawriter, eawriter, aclwriter, winaclwriter):
         self.metawriter = metawriter
         self.eawriter, self.aclwriter, self.winaclwriter = \
-          eawriter, aclwriter, winaclwriter # these can be None
+            eawriter, aclwriter, winaclwriter  # these can be None
 
     def write_object(self, rorp):
         """Write information in rorp to all the writers"""
@@ -677,7 +677,7 @@ class Manager:
         """Get a writer object that can write meta and possibly acls/eas"""
         metawriter = self.get_meta_writer(typestr, time)
         if not Globals.eas_active and not Globals.acls_active and \
-          not Globals.win_acls_active:
+           not Globals.win_acls_active:
             return metawriter  # no need for a CombinedWriter
 
         if Globals.eas_active:
@@ -699,19 +699,19 @@ class Manager:
 class PatchDiffMan(Manager):
     """Contains functions for patching and diffing metadata
 
-	To save space, we can record a full list of only the most recent
-	metadata, using the normal rdiff-backup reverse increment
-	strategy.  Instead of using librsync to compute diffs, though, we
-	use our own technique so that the diff files are still
-	hand-editable.
+    To save space, we can record a full list of only the most recent
+    metadata, using the normal rdiff-backup reverse increment
+    strategy.  Instead of using librsync to compute diffs, though, we
+    use our own technique so that the diff files are still
+    hand-editable.
 
-	A mirror_metadata diff has the same format as a mirror_metadata
-	snapshot.  If the record for an index is missing from the diff, it
-	indicates no change from the original.  If it is present it
-	replaces the mirror_metadata entry, unless it has Type None, which
-	indicates the record should be deleted from the original.
+    A mirror_metadata diff has the same format as a mirror_metadata
+    snapshot.  If the record for an index is missing from the diff, it
+    indicates no change from the original.  If it is present it
+    replaces the mirror_metadata entry, unless it has Type None, which
+    indicates the record should be deleted from the original.
 
-	"""
+    """
     max_diff_chain = 9  # After this many diffs, make a new snapshot
 
     def get_diffiter(self, new_iter, old_iter):
@@ -791,11 +791,11 @@ class PatchDiffMan(Manager):
     def iterate_patched_meta(self, meta_iter_list):
         """Return an iter of metadata rorps by combining the given iters
 
-		The iters should be given as a list/tuple in reverse
-		chronological order.  The earliest rorp in each iter will
-		supercede all the later ones.
+        The iters should be given as a list/tuple in reverse
+        chronological order.  The earliest rorp in each iter will
+        supercede all the later ones.
 
-		"""
+        """
         for meta_tuple in rorpiter.CollateIterators(*meta_iter_list):
             for i in range(len(meta_tuple) - 1, -1, -1):
                 if meta_tuple[i]:

--- a/src/rdiff_backup/regress.py
+++ b/src/rdiff_backup/regress.py
@@ -55,12 +55,12 @@ class RegressException(Exception):
 def Regress(mirror_rp):
     """Bring mirror and inc directory back to regress_to_time
 
-	Also affects the rdiff-backup-data directory, so Globals.rbdir
-	should be set.  Regress should only work one step at a time
-	(i.e. don't "regress" through two separate backup sets.  This
-	function should be run locally to the rdiff-backup-data directory.
+    Also affects the rdiff-backup-data directory, so Globals.rbdir
+    should be set.  Regress should only work one step at a time
+    (i.e. don't "regress" through two separate backup sets.  This
+    function should be run locally to the rdiff-backup-data directory.
 
-	"""
+    """
     inc_rpath = Globals.rbdir.append_path(b"increments")
     assert mirror_rp.index == () and inc_rpath.index == ()
     assert mirror_rp.isdir() and inc_rpath.isdir()
@@ -81,10 +81,10 @@ def Regress(mirror_rp):
 def set_regress_time():
     """Set global regress_time to previous successful backup
 
-	If there are two current_mirror increments, then the last one
-	corresponds to a backup session that failed.
+    If there are two current_mirror increments, then the last one
+    corresponds to a backup session that failed.
 
-	"""
+    """
     global regress_time, unsuccessful_backup_time
     manager = metadata.SetManager()
     curmir_incs = manager.sorted_prefix_inclist(b'current_mirror')
@@ -100,10 +100,10 @@ def set_regress_time():
 def set_restore_times():
     """Set _rest_time and _mirror_time in the restore module
 
-	_rest_time (restore time) corresponds to the last successful
-	backup time.  _mirror_time is the unsuccessful backup time.
+    _rest_time (restore time) corresponds to the last successful
+    backup time.  _mirror_time is the unsuccessful backup time.
 
-	"""
+    """
     restore.MirrorStruct._mirror_time = unsuccessful_backup_time
     restore.MirrorStruct._rest_time = regress_time
 
@@ -111,15 +111,15 @@ def set_restore_times():
 def regress_rbdir(meta_manager):
     """Delete the increments in the rdiff-backup-data directory
 
-	Returns the former current mirror rp so we can delete it later.
-	All of the other rp's should be deleted before the actual regress,
-	to clear up disk space the rest of the procedure may need.
+    Returns the former current mirror rp so we can delete it later.
+    All of the other rp's should be deleted before the actual regress,
+    to clear up disk space the rest of the procedure may need.
 
-	Also, in case the previous session failed while diffing the
-	metadata file, either recreate the mirror_metadata snapshot, or
-	delete the extra regress_time diff.
+    Also, in case the previous session failed while diffing the
+    metadata file, either recreate the mirror_metadata snapshot, or
+    delete the extra regress_time diff.
 
-	"""
+    """
     has_meta_diff, has_meta_snap = 0, 0
     for old_rp in meta_manager.timerpmap[regress_time]:
         if old_rp.getincbase_bname() == b'mirror_metadata':
@@ -145,11 +145,11 @@ def regress_rbdir(meta_manager):
 def recreate_meta(meta_manager):
     """Make regress_time mirror_metadata snapshot by patching
 
-	We write to a tempfile first.  Otherwise, in case of a crash, it
-	would seem we would have an intact snapshot and partial diff, not
-	the reverse.
+    We write to a tempfile first.  Otherwise, in case of a crash, it
+    would seem we would have an intact snapshot and partial diff, not
+    the reverse.
 
-	"""
+    """
     temprp = [TempFile.new_in_dir(Globals.rbdir)]
 
     def callback(rp):
@@ -165,16 +165,17 @@ def recreate_meta(meta_manager):
         b"mirror_metadata.%b.snapshot.gz" % Time.timetobytes(regress_time))
     assert not finalrp.lstat(), finalrp
     rpath.rename(temprp[0], finalrp)
-    if Globals.fsync_directories: Globals.rbdir.fsync()
+    if Globals.fsync_directories:
+        Globals.rbdir.fsync()
 
 
 def iterate_raw_rfs(mirror_rp, inc_rp):
     """Iterate all RegressFile objects in mirror/inc directory
 
-	Also changes permissions of unreadable files.  We don't have to
-	change them back later because regress will do that for us.
+    Also changes permissions of unreadable files.  We don't have to
+    change them back later because regress will do that for us.
 
-	"""
+    """
     root_rf = RegressFile(mirror_rp, inc_rp, restore.get_inclist(inc_rp))
 
     def helper(rf):
@@ -206,11 +207,11 @@ def yield_metadata():
 def iterate_meta_rfs(mirror_rp, inc_rp):
     """Yield RegressFile objects with extra metadata information added
 
-	Each RegressFile will have an extra object variable .metadata_rorp
-	which will contain the metadata attributes of the mirror file at
-	regress_time.
+    Each RegressFile will have an extra object variable .metadata_rorp
+    which will contain the metadata attributes of the mirror file at
+    regress_time.
 
-	"""
+    """
     raw_rfs = iterate_raw_rfs(mirror_rp, inc_rp)
     collated = rorpiter.Collate2Iters(raw_rfs, yield_metadata())
     for raw_rf, metadata_rorp in collated:
@@ -228,11 +229,11 @@ def iterate_meta_rfs(mirror_rp, inc_rp):
 class RegressFile(restore.RestoreFile):
     """Like RestoreFile but with metadata
 
-	Hold mirror_rp and related incs, but also put metadata info for
-	the mirror file at regress time in self.metadata_rorp.
-	self.metadata_rorp is not set in this class.
+    Hold mirror_rp and related incs, but also put metadata info for
+    the mirror file at regress time in self.metadata_rorp.
+    self.metadata_rorp is not set in this class.
 
-	"""
+    """
 
     def __init__(self, mirror_rp, inc_rp, inc_list):
         restore.RestoreFile.__init__(self, mirror_rp, inc_rp, inc_list)
@@ -263,20 +264,20 @@ class RegressFile(restore.RestoreFile):
 class RegressITRB(rorpiter.ITRBranch):
     """Turn back state of dest directory (use with IterTreeReducer)
 
-	The arguments to the ITR will be RegressFiles.  There are two main
-	assumptions this procedure makes (besides those mentioned above):
+    The arguments to the ITR will be RegressFiles.  There are two main
+    assumptions this procedure makes (besides those mentioned above):
 
-	1.  The mirror_rp and the metadata_rorp equal_loose correctly iff
-	    they contain the same data.  If this is the case, then the inc
-	    file is unnecessary and we can delete it.
+    1.  The mirror_rp and the metadata_rorp equal_loose correctly iff
+        they contain the same data.  If this is the case, then the inc
+        file is unnecessary and we can delete it.
 
-	2.  If the don't match, then applying the inc file will
-	    successfully get us back to the previous state.
+    2.  If the don't match, then applying the inc file will
+        successfully get us back to the previous state.
 
-	Since the metadata file is required, the two above really only
-	matter for regular files.
+    Since the metadata file is required, the two above really only
+    matter for regular files.
 
-	"""
+    """
 
     def __init__(self):
         """Just initialize some variables to None"""
@@ -309,11 +310,11 @@ class RegressITRB(rorpiter.ITRBranch):
     def restore_orig_regfile(self, rf):
         """Restore original regular file
 
-		This is the trickiest case for avoiding information loss,
-		because we don't want to delete the increment before the
-		mirror is fully written.
+        This is the trickiest case for avoiding information loss,
+        because we don't want to delete the increment before the
+        mirror is fully written.
 
-		"""
+        """
         assert rf.metadata_rorp.isreg()
         if rf.mirror_rp.isreg():
             tf = TempFile.new(rf.mirror_rp)
@@ -377,8 +378,10 @@ def check_pids(curmir_incs):
     def extract_pid(curmir_rp):
         """Return process ID from a current mirror marker, if any"""
         match = pid_re.search(curmir_rp.get_string())
-        if not match: return None
-        else: return int(match.group(1))
+        if not match:
+            return None
+        else:
+            return int(match.group(1))
 
     def pid_running(pid):
         """True if we know if process with pid is currently running"""
@@ -392,7 +395,9 @@ def check_pids(curmir_incs):
                 2)
         except AttributeError:
             assert os.name == 'nt'
-            import win32api, win32con, pywintypes
+            import win32api
+            import win32con
+            import pywintypes
             process = None
             try:
                 process = win32api.OpenProcess(win32con.PROCESS_ALL_ACCESS, 0,

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -64,12 +64,12 @@ def get_inclist(inc_rpath):
 def ListChangedSince(mirror_rp, inc_rp, restore_to_time):
     """List the changed files under mirror_rp since rest time
 
-	Notice the output is an iterator of RORPs.  We do this because we
-	want to give the remote connection the data in buffered
-	increments, and this is done automatically for rorp iterators.
-	Encode the lines in the first element of the rorp's index.
+    Notice the output is an iterator of RORPs.  We do this because we
+    want to give the remote connection the data in buffered
+    increments, and this is done automatically for rorp iterators.
+    Encode the lines in the first element of the rorp's index.
 
-	"""
+    """
     assert mirror_rp.conn is Globals.local_connection, "Run locally only"
     MirrorStruct.set_mirror_and_rest_times(restore_to_time)
     MirrorStruct.initialize_rf_cache(mirror_rp, inc_rp)
@@ -95,9 +95,9 @@ def ListChangedSince(mirror_rp, inc_rp, restore_to_time):
 def ListAtTime(mirror_rp, inc_rp, time):
     """List the files in archive at the given time
 
-	Output is a RORP Iterator with info in index.  See ListChangedSince.
+    Output is a RORP Iterator with info in index.  See ListChangedSince.
 
-	"""
+    """
     assert mirror_rp.conn is Globals.local_connection, "Run locally only"
     MirrorStruct.set_mirror_and_rest_times(time)
     MirrorStruct.initialize_rf_cache(mirror_rp, inc_rp)
@@ -135,17 +135,17 @@ class MirrorStruct:
     def get_rest_time(cls, restore_to_time):
         """Return older time, if restore_to_time is in between two inc times
 
-		There is a slightly tricky reason for doing this: The rest of the
-		code just ignores increments that are older than restore_to_time.
-		But sometimes we want to consider the very next increment older
-		than rest time, because rest_time will be between two increments,
-		and what was actually on the mirror side will correspond to the
-		older one.
+        There is a slightly tricky reason for doing this: The rest of the
+        code just ignores increments that are older than restore_to_time.
+        But sometimes we want to consider the very next increment older
+        than rest time, because rest_time will be between two increments,
+        and what was actually on the mirror side will correspond to the
+        older one.
 
-		So if restore_to_time is inbetween two increments, return the
-		older one.
+        So if restore_to_time is inbetween two increments, return the
+        older one.
 
-		"""
+        """
         inctimes = cls.get_increment_times()
         older_times = [time for time in inctimes if time <= restore_to_time]
         if older_times:
@@ -157,10 +157,10 @@ class MirrorStruct:
     def get_increment_times(cls, rp=None):
         """Return list of times of backups, including current mirror
 
-		Take the total list of times from the increments.<time>.dir
-		file and the mirror_metadata file.  Sorted ascending.
+        Take the total list of times from the increments.<time>.dir
+        file and the mirror_metadata file.  Sorted ascending.
 
-		"""
+        """
         # use dictionary to remove dups
         if not cls._mirror_time:
             d = {cls.get_mirror_time(): None}
@@ -194,13 +194,13 @@ class MirrorStruct:
     def get_mirror_rorp_iter(cls, rest_time=None, require_metadata=None):
         """Return iter of mirror rps at given restore time
 
-		Usually we can use the metadata file, but if this is
-		unavailable, we may have to build it from scratch.
+        Usually we can use the metadata file, but if this is
+        unavailable, we may have to build it from scratch.
 
-		If the cls._select object is set, use it to filter out the
-		unwanted files from the metadata_iter.
+        If the cls._select object is set, use it to filter out the
+        unwanted files from the metadata_iter.
 
-		"""
+        """
         if rest_time is None:
             rest_time = cls._rest_time
 
@@ -240,11 +240,12 @@ class MirrorStruct:
     def subtract_indices(cls, index, rorp_iter):
         """Subtract index from index of each rorp in rorp_iter
 
-		subtract_indices is necessary because we
-		may not be restoring from the root index.
+        subtract_indices is necessary because we
+        may not be restoring from the root index.
 
-		"""
-        if index == (): return rorp_iter
+        """
+        if index == ():
+            return rorp_iter
 
         def get_iter():
             for rorp in rorp_iter:
@@ -258,13 +259,13 @@ class MirrorStruct:
     def get_diffs(cls, target_iter):
         """Given rorp iter of target files, return diffs
 
-		Here the target_iter doesn't contain any actual data, just
-		attribute listings.  Thus any diffs we generate will be
-		snapshots.
+        Here the target_iter doesn't contain any actual data, just
+        attribute listings.  Thus any diffs we generate will be
+        snapshots.
 
-		"""
+        """
         mir_iter = cls.subtract_indices(cls.mirror_base.index,
-                                         cls.get_mirror_rorp_iter())
+                                        cls.get_mirror_rorp_iter())
         collated = rorpiter.Collate2Iters(mir_iter, target_iter)
         return cls.get_diffs_from_collated(collated)
 
@@ -322,12 +323,12 @@ class TargetStruct:
     def patch(cls, target, diff_iter):
         """Patch target with the diffs from the mirror side
 
-		This function and the associated ITRB is similar to the
-		patching code in backup.py, but they have different error
-		correction requirements, so it seemed easier to just repeat it
-		all in this module.
+        This function and the associated ITRB is similar to the
+        patching code in backup.py, but they have different error
+        correction requirements, so it seemed easier to just repeat it
+        all in this module.
 
-		"""
+        """
         ITR = rorpiter.IterTreeReducer(PatchITRB, [target])
         for diff in rorpiter.FillInIter(diff_iter, target):
             log.Log("Processing changed file %s" % diff.get_safeindexpath(), 5)
@@ -339,17 +340,17 @@ class TargetStruct:
 class CachedRF:
     """Store RestoreFile objects until they are needed
 
-	The code above would like to pretend it has random access to RFs,
-	making one for a particular index at will.  However, in general
-	this involves listing and filtering a directory, which can get
-	expensive.
+    The code above would like to pretend it has random access to RFs,
+    making one for a particular index at will.  However, in general
+    this involves listing and filtering a directory, which can get
+    expensive.
 
-	Thus, when a CachedRF retrieves an RestoreFile, it creates all the
-	RFs of that directory at the same time, and doesn't have to
-	recalculate.  It assumes the indices will be in order, so the
-	cache is deleted if a later index is requested.
+    Thus, when a CachedRF retrieves an RestoreFile, it creates all the
+    RFs of that directory at the same time, and doesn't have to
+    recalculate.  It assumes the indices will be in order, so the
+    cache is deleted if a later index is requested.
 
-	"""
+    """
 
     def __init__(self, root_rf):
         """Initialize CachedRF, self.rf_list variable"""
@@ -369,7 +370,8 @@ class CachedRF:
         """Get a RestoreFile for given index, or None"""
         while 1:
             if not self.rf_list:
-                if not self.add_rfs(index, mir_rorp): return None
+                if not self.add_rfs(index, mir_rorp):
+                    return None
             rf = self.rf_list[0]
             if rf.index == index:
                 if Globals.process_uid != 0:
@@ -400,10 +402,10 @@ class CachedRF:
     def add_rfs(self, index, mir_rorp=None):
         """Given index, add the rfs in that same directory
 
-		Returns false if no rfs are available, which usually indicates
-		an error.
+        Returns false if no rfs are available, which usually indicates
+        an error.
 
-		"""
+        """
         if not index:
             return self.root_rf
         if mir_rorp.has_alt_mirror_name():
@@ -429,11 +431,11 @@ class CachedRF:
 class RestoreFile:
     """Hold data about a single mirror file and its related increments
 
-	self.relevant_incs will be set to a list of increments that matter
-	for restoring a regular file.  If the patches are to mirror_rp, it
-	will be the first element in self.relevant.incs
+    self.relevant_incs will be set to a list of increments that matter
+    for restoring a regular file.  If the patches are to mirror_rp, it
+    will be the first element in self.relevant.incs
 
-	"""
+    """
 
     def __init__(self, mirror_rp, inc_rp, inc_list):
         self.index = mirror_rp.index
@@ -454,10 +456,10 @@ class RestoreFile:
     def set_relevant_incs(self):
         """Set self.relevant_incs to increments that matter for restoring
 
-		relevant_incs is sorted newest first.  If mirror_rp matters,
-		it will be (first) in relevant_incs.
+        relevant_incs is sorted newest first.  If mirror_rp matters,
+        it will be (first) in relevant_incs.
 
-		"""
+        """
         self.mirror_rp.inc_type = b'snapshot'
         self.mirror_rp.inc_compressed = 0
         if (not self.inc_list
@@ -481,34 +483,36 @@ class RestoreFile:
     def get_newer_incs(self):
         """Return list of newer incs sorted by time (increasing)
 
-		Also discard increments older than rest_time (rest_time we are
-		assuming is the exact time rdiff-backup was run, so no need to
-		consider the next oldest increment or any of that)
+        Also discard increments older than rest_time (rest_time we are
+        assuming is the exact time rdiff-backup was run, so no need to
+        consider the next oldest increment or any of that)
 
-		"""
+        """
         incpairs = []
         for inc in self.inc_list:
             time = inc.getinctime()
-            if time >= MirrorStruct._rest_time: incpairs.append((time, inc))
+            if time >= MirrorStruct._rest_time:
+                incpairs.append((time, inc))
         incpairs.sort()
         return [pair[1] for pair in incpairs]
 
     def get_attribs(self):
         """Return RORP with restored attributes, but no data
 
-		This should only be necessary if the metadata file is lost for
-		some reason.  Otherwise the file provides all data.  The size
-		will be wrong here, because the attribs may be taken from
-		diff.
+        This should only be necessary if the metadata file is lost for
+        some reason.  Otherwise the file provides all data.  The size
+        will be wrong here, because the attribs may be taken from
+        diff.
 
-		"""
+        """
         last_inc = self.relevant_incs[-1]
         if last_inc.getinctype() == b'missing':
             return rpath.RORPath(self.index)
 
         rorp = last_inc.getRORPath()
         rorp.index = self.index
-        if last_inc.getinctype() == b'dir': rorp.data['type'] = 'dir'
+        if last_inc.getinctype() == b'dir':
+            rorp.data['type'] = 'dir'
         return rorp
 
     def get_restore_fp(self):
@@ -597,10 +601,10 @@ rdiff-backup destination directory, or a bug in rdiff-backup""" %
     def yield_inc_complexes(self, inc_rpath):
         """Yield (sub_inc_rpath, inc_list) IndexedTuples from given inc_rpath
 
-		Finds pairs under directory inc_rpath.  sub_inc_rpath will just be
-		the prefix rp, while the rps in inc_list should actually exist.
+        Finds pairs under directory inc_rpath.  sub_inc_rpath will just be
+        the prefix rp, while the rps in inc_list should actually exist.
 
-		"""
+        """
         if not inc_rpath.isdir():
             return
 
@@ -644,16 +648,16 @@ rdiff-backup destination directory, or a bug in rdiff-backup""" %
 class PatchITRB(rorpiter.ITRBranch):
     """Patch an rpath with the given diff iters (use with IterTreeReducer)
 
-	The main complication here involves directories.  We have to
-	finish processing the directory after what's in the directory, as
-	the directory may have inappropriate permissions to alter the
-	contents or the dir's mtime could change as we change the
-	contents.
+    The main complication here involves directories.  We have to
+    finish processing the directory after what's in the directory, as
+    the directory may have inappropriate permissions to alter the
+    contents or the dir's mtime could change as we change the
+    contents.
 
-	This code was originally taken from backup.py.  However, because
-	of different error correction requirements, it is repeated here.
+    This code was originally taken from backup.py.  However, because
+    of different error correction requirements, it is repeated here.
 
-	"""
+    """
 
     def __init__(self, basis_root_rp):
         """Set basis_root_rp, the base of the tree to be incremented"""
@@ -724,9 +728,9 @@ class PatchITRB(rorpiter.ITRBranch):
     def set_dir_replacement(self, diff_rorp, base_rp):
         """Set self.dir_replacement, which holds data until done with dir
 
-		This is used when base_rp is a dir, and diff_rorp is not.
+        This is used when base_rp is a dir, and diff_rorp is not.
 
-		"""
+        """
         assert diff_rorp.get_attached_filetype() == 'snapshot'
         self.dir_replacement = TempFile.new(base_rp)
         rpath.copy_with_attribs(diff_rorp, self.dir_replacement)
@@ -757,12 +761,12 @@ class PatchITRB(rorpiter.ITRBranch):
 class PermissionChanger:
     """Change the permission of mirror files and directories
 
-	The problem is that mirror files and directories may need their
-	permissions changed in order to be read and listed, and then
-	changed back when we are done.  This class hooks into the CachedRF
-	object to know when an rp is needed.
+    The problem is that mirror files and directories may need their
+    permissions changed in order to be read and listed, and then
+    changed back when we are done.  This class hooks into the CachedRF
+    object to know when an rp is needed.
 
-	"""
+    """
 
     def __init__(self, root_rp):
         self.root_rp = root_rp
@@ -786,7 +790,8 @@ class PermissionChanger:
         """Restore permissions for indices we are done with"""
         while self.open_index_list:
             old_index, old_rp, old_perms = self.open_index_list[0]
-            if index[:len(old_index)] > old_index: old_rp.chmod(old_perms)
+            if index[:len(old_index)] > old_index:
+                old_rp.chmod(old_perms)
             else:
                 break
             del self.open_index_list[0]
@@ -794,8 +799,8 @@ class PermissionChanger:
     def add_new(self, old_index, index):
         """Change permissions of directories between old_index and index"""
         for rp in self.get_new_rp_list(old_index, index):
-            if ((rp.isreg() and not rp.readable()) or
-                (rp.isdir() and not (rp.executable() and rp.readable()))):
+            if ((rp.isreg() and not rp.readable())
+                    or (rp.isdir() and not (rp.executable() and rp.readable()))):
                 old_perms = rp.getperms()
                 self.open_index_list.insert(0, (rp.index, rp, old_perms))
                 if rp.isreg():
@@ -806,10 +811,10 @@ class PermissionChanger:
     def get_new_rp_list(self, old_index, index):
         """Return list of new rp's between old_index and index
 
-		Do this lazily so that the permissions on the outer
-		directories are fixed before we need the inner dirs.
+        Do this lazily so that the permissions on the outer
+        directories are fixed before we need the inner dirs.
 
-		"""
+        """
         for i in range(len(index) - 1, -1, -1):
             if old_index[:i] == index[:i]:
                 common_prefix_len = i

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -27,10 +27,10 @@ from . import librsync, C, rpath, Globals, log, statistics, connection
 def check_common_error(error_handler, function, args=[]):
     """Apply function to args, if error, run error_handler on exception
 
-	This uses the catch_error predicate below to only catch
-	certain exceptions which seems innocent enough.
+    This uses the catch_error predicate below to only catch
+    certain exceptions which seems innocent enough.
 
-	"""
+    """
     try:
         return function(*args)
     except (Exception, KeyboardInterrupt, SystemExit) as exc:
@@ -56,16 +56,17 @@ def catch_error(exc):
     for exception_class in (rpath.SkipFileException, rpath.RPathException,
                             librsync.librsyncError, C.UnknownFileTypeError,
                             zlib.error):
-        if isinstance(exc, exception_class): return 1
-    if (isinstance(exc, EnvironmentError) and
+        if isinstance(exc, exception_class):
+            return 1
+    if (isinstance(exc, EnvironmentError)
             # the invalid mode shows up in backups of /proc for some reason
-        ('invalid mode: rb' in str(exc) or 'Not a gzipped file' in str(exc)
-         or exc.errno in (errno.EPERM, errno.ENOENT, errno.EACCES, errno.EBUSY,
-                          errno.EEXIST, errno.ENOTDIR, errno.EILSEQ,
-                          errno.ENAMETOOLONG, errno.EINTR, errno.ESTALE,
-                          errno.ENOTEMPTY, errno.EIO, errno.ETXTBSY,
-                          errno.ESRCH, errno.EINVAL, errno.EDEADLOCK,
-                          errno.EDEADLK, errno.EOPNOTSUPP, errno.ETIMEDOUT))):
+        and ('invalid mode: rb' in str(exc) or 'Not a gzipped file' in str(exc)
+        or exc.errno in (errno.EPERM, errno.ENOENT, errno.EACCES, errno.EBUSY,
+                         errno.EEXIST, errno.ENOTDIR, errno.EILSEQ,
+                         errno.ENAMETOOLONG, errno.EINTR, errno.ESTALE,
+                         errno.ENOTEMPTY, errno.EIO, errno.ETXTBSY,
+                         errno.ESRCH, errno.EINVAL, errno.EDEADLOCK,
+                         errno.EDEADLK, errno.EOPNOTSUPP, errno.ETIMEDOUT))):
         return 1
     return 0
 
@@ -73,11 +74,11 @@ def catch_error(exc):
 def is_routine_fatal(exc):
     """Return string if exception is non-error unrecoverable, None otherwise
 
-	Used to suppress a stack trace for exceptions like keyboard
-	interrupts or connection drops.  Return value is string to use as
-	an exit message.
+    Used to suppress a stack trace for exceptions like keyboard
+    interrupts or connection drops.  Return value is string to use as
+    an exit message.
 
-	"""
+    """
     if isinstance(exc, KeyboardInterrupt):
         return "User abort"
     elif isinstance(exc, connection.ConnectionError):
@@ -92,11 +93,11 @@ def is_routine_fatal(exc):
 def get_error_handler(error_type):
     """Return error handler function that can be used above
 
-	Function will just log error to the error_log and then return
-	None.  First two arguments must be the exception and then an rp
-	(from which the filename will be extracted).
+    Function will just log error to the error_log and then return
+    None.  First two arguments must be the exception and then an rp
+    (from which the filename will be extracted).
 
-	"""
+    """
 
     def error_handler(exc, rp, *args):
         log.ErrorLog.write_if_open(error_type, rp, exc)
@@ -146,10 +147,10 @@ class TracebackArchive:
     def add(cls, extra_args=[]):
         """Add most recent exception to archived list
 
-		If extra_args are present, convert to strings and add them as
-		extra information to same traceback archive.
+        If extra_args are present, convert to strings and add them as
+        extra information to same traceback archive.
 
-		"""
+        """
         cls._traceback_strings.append(log.Log.exception_to_string(extra_args))
         if len(cls._traceback_strings) > 10:
             cls._traceback_strings = cls._traceback_strings[:10]

--- a/src/rdiff_backup/rorpiter.py
+++ b/src/rdiff_backup/rorpiter.py
@@ -37,11 +37,11 @@ from . import Globals, rpath, iterfile, log
 def CollateIterators(*rorp_iters):
     """Collate RORPath iterators by index
 
-	So it takes two or more iterators of rorps and returns an
-	iterator yielding tuples like (rorp1, rorp2) with the same
-	index.  If one or the other lacks that index, it will be None
+    So it takes two or more iterators of rorps and returns an
+    iterator yielding tuples like (rorp1, rorp2) with the same
+    index.  If one or the other lacks that index, it will be None
 
-	"""
+    """
     # overflow[i] means that iter[i] has been exhausted
     # rorps[i] is None means that it is time to replenish it.
     iter_num = len(rorp_iters)
@@ -86,11 +86,11 @@ def CollateIterators(*rorp_iters):
 def Collate2Iters(riter1, riter2):
     """Special case of CollateIterators with 2 arguments
 
-	This does the same thing but is faster because it doesn't have
-	to consider the >2 iterator case.  Profiler says speed is
-	important here.
+    This does the same thing but is faster because it doesn't have
+    to consider the >2 iterator case.  Profiler says speed is
+    important here.
 
-	"""
+    """
     relem1, relem2 = None, None
     while 1:
         if not relem1:
@@ -128,10 +128,10 @@ def Collate2Iters(riter1, riter2):
 class IndexedTuple(collections.UserList):
     """Like a tuple, but has .index
 
-	This is used by CollateIterator above, and can be passed to the
-	IterTreeReducer.
+    This is used by CollateIterator above, and can be passed to the
+    IterTreeReducer.
 
-	"""
+    """
 
     def __init__(self, index, sequence):
         self.index = index
@@ -183,12 +183,12 @@ class IndexedTuple(collections.UserList):
 def FillInIter(rpiter, rootrp):
     """Given ordered rpiter and rootrp, fill in missing indices with rpaths
 
-	For instance, suppose rpiter contains rpaths with indices (),
-	(1,2), (2,5).  Then return iter with rpaths (), (1,), (1,2), (2,),
-	(2,5).  This is used when we need to process directories before or
-	after processing a file in that directory.
+    For instance, suppose rpiter contains rpaths with indices (),
+    (1,2), (2,5).  Then return iter with rpaths (), (1,), (1,2), (2,),
+    (2,5).  This is used when we need to process directories before or
+    after processing a file in that directory.
 
-	"""
+    """
     # Handle first element as special case
     try:
         first_rp = next(rpiter)
@@ -223,14 +223,14 @@ def FillInIter(rpiter, rootrp):
 class IterTreeReducer:
     """Tree style reducer object for iterator
 
-	The indices of a RORPIter form a tree type structure.  This class
-	can be used on each element of an iter in sequence and the result
-	will be as if the corresponding tree was reduced.  This tries to
-	bridge the gap between the tree nature of directories, and the
-	iterator nature of the connection between hosts and the temporal
-	order in which the files are processed.
+    The indices of a RORPIter form a tree type structure.  This class
+    can be used on each element of an iter in sequence and the result
+    will be as if the corresponding tree was reduced.  This tries to
+    bridge the gap between the tree nature of directories, and the
+    iterator nature of the connection between hosts and the temporal
+    order in which the files are processed.
 
-	"""
+    """
 
     def __init__(self, branch_class, branch_args):
         """ITR initializer"""
@@ -244,12 +244,12 @@ class IterTreeReducer:
     def finish_branches(self, index):
         """Run Finish() on all branches index has passed
 
-		When we pass out of a branch, delete it and process it with
-		the parent.  The innermost branches will be the last in the
-		list.  Return None if we are out of the entire tree, and 1
-		otherwise.
+        When we pass out of a branch, delete it and process it with
+        the parent.  The innermost branches will be the last in the
+        list.  Return None if we are out of the entire tree, and 1
+        otherwise.
 
-		"""
+        """
         branches = self.branches
         while 1:
             to_be_finished = branches[-1]
@@ -285,14 +285,14 @@ class IterTreeReducer:
     def __call__(self, *args):
         """Process args, where args[0] is current position in iterator
 
-		Returns true if args successfully processed, false if index is
-		not in the current tree and thus the final result is
-		available.
+        Returns true if args successfully processed, false if index is
+        not in the current tree and thus the final result is
+        available.
 
-		Also note below we set self.index after doing the necessary
-		start processing, in case there is a crash in the middle.
+        Also note below we set self.index after doing the necessary
+        start processing, in case there is a crash in the middle.
 
-		"""
+        """
         index = args[0]
         if self.index is None:
             self.root_branch.base_index = index
@@ -325,12 +325,12 @@ class IterTreeReducer:
 class ITRBranch:
     """Helper class for IterTreeReducer above
 
-	There are five stub functions below: start_process, end_process,
-	branch_process, can_fast_process, and fast_process.  A class that
-	subclasses this one will probably fill in these functions to do
-	more.
+    There are five stub functions below: start_process, end_process,
+    branch_process, can_fast_process, and fast_process.  A class that
+    subclasses this one will probably fill in these functions to do
+    more.
 
-	"""
+    """
     base_index = index = None
 
     def start_process(self, *args):
@@ -357,15 +357,15 @@ class ITRBranch:
 class CacheIndexable:
     """Cache last few indexed elements in iterator
 
-	This class should be initialized with an iterator yielding
-	.index'd objects.  It looks like it is just the same iterator as
-	the one that initialized it.  Luckily, it does more, caching the
-	last few elements iterated, which can be retrieved using the
-	.get() method.
+    This class should be initialized with an iterator yielding
+    .index'd objects.  It looks like it is just the same iterator as
+    the one that initialized it.  Luckily, it does more, caching the
+    last few elements iterated, which can be retrieved using the
+    .get() method.
 
-	If the index is not in the cache, return None.
+    If the index is not in the cache, return None.
 
-	"""
+    """
 
     def __init__(self, indexed_iter, cache_size=None):
         """Make new CacheIndexable.  Cache_size is max cache length"""
@@ -401,5 +401,5 @@ class CacheIndexable:
             return self.cache_dict[index]
         except KeyError:
             assert index >= self.cache_indices[0], \
-                "Index out of order: "+repr((index, self.cache_indices[0]))
+                "Index out of order: " + repr((index, self.cache_indices[0]))
             return None

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -47,7 +47,8 @@ import codecs
 from . import Globals, Time, log, user_group, C
 
 try:
-    import win32api, win32con
+    import win32api
+    import win32con
 except ImportError:
     pass
 
@@ -55,11 +56,11 @@ except ImportError:
 class SkipFileException(Exception):
     """Signal that the current file should be skipped but then continue
 
-	This exception will often be raised when there is problem reading
-	an individual file, but it makes sense for the rest of the backup
-	to keep going.
+    This exception will often be raised when there is problem reading
+    an individual file, but it makes sense for the rest of the backup
+    to keep going.
 
-	"""
+    """
     pass
 
 
@@ -109,10 +110,10 @@ def move(rpin, rpout):
 def copy(rpin, rpout, compress=0):
     """Copy RPath rpin to rpout.  Works for symlinks, dirs, etc.
 
-	Returns close value of input for regular file, which can be used
-	to pass hashes on.
+    Returns close value of input for regular file, which can be used
+    to pass hashes on.
 
-	"""
+    """
     log.Log("Regular copying %s to %s" % (rpin.index, rpout.get_safepath()), 6)
     if not rpin.lstat():
         if rpout.lstat():
@@ -178,10 +179,10 @@ def copy_reg_file(rpin, rpout, compress=0):
 def cmp(rpin, rpout):
     """True if rpin has the same data as rpout
 
-	cmp does not compare file ownership, permissions, or times, or
-	examine the contents of a directory.
+    cmp does not compare file ownership, permissions, or times, or
+    examine the contents of a directory.
 
-	"""
+    """
     check_for_files(rpin, rpout)
     if rpin.isreg():
         if not rpout.isreg():
@@ -210,10 +211,10 @@ def cmp(rpin, rpout):
 def copy_attribs(rpin, rpout):
     """Change file attributes of rpout to match rpin
 
-	Only changes the chmoddable bits, uid/gid ownership, and
-	timestamps, so both must already exist.
+    Only changes the chmoddable bits, uid/gid ownership, and
+    timestamps, so both must already exist.
 
-	"""
+    """
     log.Log(
         "Copying attributes from %s to %s" % (rpin.index,
                                               rpout.get_safepath()), 7)
@@ -241,11 +242,11 @@ def copy_attribs(rpin, rpout):
 def copy_attribs_inc(rpin, rpout):
     """Change file attributes of rpout to match rpin
 
-	Like above, but used to give increments the same attributes as the
-	originals.  Therefore, don't copy all directory acl and
-	permissions.
+    Like above, but used to give increments the same attributes as the
+    originals.  Therefore, don't copy all directory acl and
+    permissions.
 
-	"""
+    """
     log.Log(
         "Copying inc attrs from %s to %s" % (rpin.index, rpout.get_safepath()),
         7)
@@ -275,10 +276,10 @@ def copy_attribs_inc(rpin, rpout):
 def cmp_attribs(rp1, rp2):
     """True if rp1 has the same file attributes as rp2
 
-	Does not compare file access times.  If not changing
-	ownership, do not check user/group id.
+    Does not compare file access times.  If not changing
+    ownership, do not check user/group id.
 
-	"""
+    """
     check_for_files(rp1, rp2)
     if Globals.change_ownership and rp1.getuidgid() != rp2.getuidgid():
         result = None
@@ -315,7 +316,7 @@ def rename(rp_source, rp_dest):
         rp_dest.delete()
     else:
         if rp_dest.lstat() and rp_source.getinode() == rp_dest.getinode() and \
-          rp_source.getinode() != 0:
+           rp_source.getinode() != 0:
             log.Log(
                 "Warning: Attempt to rename over same inode: %s to %s" %
                 (rp_source.get_safepath(), rp_dest.get_safepath()), 2)
@@ -345,11 +346,11 @@ def rename(rp_source, rp_dest):
 def make_file_dict(filename):
     """Generate the data dictionary for the given RPath
 
-	This is a global function so that os.name can be called locally,
-	thus avoiding network lag and so that we only need to send the
-	filename over the network, thus avoiding the need to pickle an
-	(incomplete) rpath object.
-	"""
+    This is a global function so that os.name can be called locally,
+    thus avoiding network lag and so that we only need to send the
+    filename over the network, thus avoiding the need to pickle an
+    (incomplete) rpath object.
+    """
 
     try:
         statblock = os.lstat(filename)
@@ -405,10 +406,10 @@ def make_file_dict(filename):
 def make_socket_local(rpath):
     """Make a local socket at the given path
 
-	This takes an rpath so that it will be checked by Security.
-	(Miscellaneous strings will not be.)
+    This takes an rpath so that it will be checked by Security.
+    (Miscellaneous strings will not be.)
 
-	"""
+    """
     assert rpath.conn is Globals.local_connection
     rpath.conn.os.mknod(rpath.path, stat.S_IFSOCK)
 
@@ -427,17 +428,20 @@ def open_local_read(rpath):
 
 def get_incfile_info(basename):
     """Returns None or tuple of
-	(is_compressed, timestr, type, and basename)"""
+    (is_compressed, timestr, type, and basename)"""
     dotsplit = basename.split(b'.')
     if dotsplit[-1] == b'gz':
         compressed = 1
-        if len(dotsplit) < 4: return None
+        if len(dotsplit) < 4:
+            return None
         timestring, ext = dotsplit[-3:-1]
     else:
         compressed = None
-        if len(dotsplit) < 3: return None
+        if len(dotsplit) < 3:
+            return None
         timestring, ext = dotsplit[-2:]
-    if Time.bytestotime(timestring) is None: return None
+    if Time.bytestotime(timestring) is None:
+        return None
     if not (ext == b"snapshot" or ext == b"dir" or ext == b"missing"
             or ext == b"diff" or ext == b"data"):
         return None
@@ -450,7 +454,7 @@ def get_incfile_info(basename):
 
 def delete_dir_no_files(rp):
     """Deletes the directory at rp.path if empty. Raises if the
-	directory contains files."""
+    directory contains files."""
     assert rp.isdir()
     if rp.contains_files():
         raise RPathException("Directory contains files.")
@@ -460,17 +464,19 @@ def delete_dir_no_files(rp):
 class RORPath:
     """Read Only RPath - carry information about a path
 
-	These contain information about a file, and possible the file's
-	data, but do not have a connection and cannot be written to or
-	changed.  The advantage of these objects is that they can be
-	communicated by encoding their index and data dictionary.
+    These contain information about a file, and possible the file's
+    data, but do not have a connection and cannot be written to or
+    changed.  The advantage of these objects is that they can be
+    communicated by encoding their index and data dictionary.
 
-	"""
+    """
 
     def __init__(self, index, data=None):
         self.index = tuple(map(os.fsencode, index))
-        if data: self.data = data
-        else: self.data = {'type': None}  # signify empty file
+        if data:
+            self.data = data
+        else:
+            self.data = {'type': None}  # signify empty file
         self.file = None
 
     def zero(self):
@@ -485,7 +491,8 @@ class RORPath:
 
     def __eq__(self, other):
         """True iff the two rorpaths are equivalent"""
-        if self.index != other.index: return None
+        if self.index != other.index:
+            return None
 
         for key in list(self.data.keys()):  # compare dicts key by key
             if self.issym() and key in ('uid', 'gid', 'uname', 'gname'):
@@ -524,18 +531,19 @@ class RORPath:
                     other_val = other.data[key]
                 except KeyError:
                     return None
-                if self.data[key] != other_val: return None
+                if self.data[key] != other_val:
+                    return None
         return 1
 
     def equal_loose(self, other):
         """True iff the two rorpaths are kinda equivalent
 
-		Sometimes because permissions cannot be set, a file cannot be
-		replicated exactly on the remote side.  This function tells
-		you whether the two files are close enough.  self must be the
-		original rpath.
+        Sometimes because permissions cannot be set, a file cannot be
+        replicated exactly on the remote side.  This function tells
+        you whether the two files are close enough.  self must be the
+        original rpath.
 
-		"""
+        """
         for key in list(self.data.keys()):  # compare dicts key by key
             if key in ('uid', 'gid', 'uname', 'gname'):
                 pass
@@ -572,7 +580,8 @@ class RORPath:
         if self.lstat() and not self.issym() and Globals.change_ownership:
             # Now compare ownership.  Symlinks don't have ownership
             try:
-                if user_group.map_rpath(self) != other.getuidgid(): return 0
+                if user_group.map_rpath(self) != other.getuidgid():
+                    return 0
             except KeyError:
                 return 0  # uid/gid might be missing if metadata file is corrupt
 
@@ -654,10 +663,10 @@ class RORPath:
     def __getstate__(self):
         """Return picklable state
 
-		This is necessary in case the RORPath is carrying around a
-		file object, which can't/shouldn't be pickled.
+        This is necessary in case the RORPath is carrying around a
+        file object, which can't/shouldn't be pickled.
 
-		"""
+        """
         return (self.index, self.data)
 
     def __setstate__(self, rorp_state):
@@ -683,7 +692,8 @@ class RORPath:
 
         if os.path.altsep:  # only Windows has an alternative separator for paths
             filenames = tuple(map(abs_drive, filenames))
-            return os.path.join(*filenames).replace(os.fsencode(os.path.sep), b'/')
+            return os.path.join(*filenames).replace(
+                os.fsencode(os.path.sep), b'/')
         else:
             return os.path.join(*filenames)
 
@@ -698,12 +708,12 @@ class RORPath:
     def lstat(self):
         """Returns type of file
 
-		The allowable types are None if the file doesn't exist, 'reg'
-		for a regular file, 'dir' for a directory, 'dev' for a device
-		file, 'fifo' for a fifo, 'sock' for a socket, and 'sym' for a
-		symlink.
-		
-		"""
+        The allowable types are None if the file doesn't exist, 'reg'
+        for a regular file, 'dir' for a directory, 'dev' for a device
+        file, 'fifo' for a fifo, 'sock' for a socket, and 'sym' for a
+        symlink.
+        
+        """
         return self.data['type']
 
     gettype = lstat
@@ -827,17 +837,17 @@ class RORPath:
     def get_safeindex(self):
         """Return index as a tuple of strings with safe decoding
 
-		For instance, if the index is (b"a", b"b"), return ("a", "b")
+        For instance, if the index is (b"a", b"b"), return ("a", "b")
 
-		"""
+        """
         return tuple(map(lambda f: f.decode(errors='replace'), self.index))
 
     def get_indexpath(self):
         """Return path of index portion
 
-		For instance, if the index is ("a", "b"), return "a/b".
+        For instance, if the index is ("a", "b"), return "a/b".
 
-		"""
+        """
         if not self.index:
             return b'.'
         return self.path_join(*self.index)
@@ -845,18 +855,18 @@ class RORPath:
     def get_safeindexpath(self):
         """Return safe path of index even with names throwing UnicodeEncodeError
 
-		For instance, if the index is ("a", "b"), return "'a/b'".
+        For instance, if the index is ("a", "b"), return "'a/b'".
 
-		"""
+        """
         return self.get_indexpath().decode(errors='replace')
 
     def get_attached_filetype(self):
         """If there is a file attached, say what it is
 
-		Currently the choices are 'snapshot' meaning an exact copy of
-		something, and 'diff' for an rdiff style diff.
+        Currently the choices are 'snapshot' meaning an exact copy of
+        something, and 'diff' for an rdiff style diff.
 
-		"""
+        """
         return self.data['filetype']
 
     def set_attached_filetype(self, type):
@@ -866,10 +876,10 @@ class RORPath:
     def isflaglinked(self):
         """True if rorp is a signature/diff for a hardlink file
 
-		This indicates that a file's data need not be transferred
-		because it is hardlinked on the remote side.
+        This indicates that a file's data need not be transferred
+        because it is hardlinked on the remote side.
 
-		"""
+        """
         return 'linked' in self.data
 
     def get_link_flag(self):
@@ -895,8 +905,8 @@ class RORPath:
             while self.file.read(Globals.blocksize):
                 pass
             assert not self.file.close(), \
-              "Error closing file\ndata = %s\nindex = %s\n" % (self.data,
-                           self.get_safeindex())
+                "Error closing file\ndata = %s\nindex = %s\n" % (self.data,
+                                                                 self.get_safeindex())
             self.file_already_open = None
 
     def set_acl(self, acl):
@@ -970,11 +980,11 @@ class RORPath:
     def set_alt_mirror_name(self, filename):
         """Set alternate mirror name to filename
 
-		Instead of writing to the traditional mirror file, store
-		mirror information in filename in the long filename
-		directory.
+        Instead of writing to the traditional mirror file, store
+        mirror information in filename in the long filename
+        directory.
 
-		"""
+        """
         self.data['mirrorname'] = filename
 
     def has_alt_inc_name(self):
@@ -988,11 +998,11 @@ class RORPath:
     def set_alt_inc_name(self, name):
         """Set alternate increment name to name
 
-		If set, increments will be in the long name directory with
-		name as their base.  If the alt mirror name is set, this
-		should be set to the same.
+        If set, increments will be in the long name directory with
+        name as their base.  If the alt mirror name is set, this
+        should be set to the same.
 
-		"""
+        """
         self.data['incname'] = name
 
     def has_sha1(self):
@@ -1011,49 +1021,50 @@ class RORPath:
 class RPath(RORPath):
     """Remote Path class - wrapper around a possibly non-local pathname
 
-	This class contains a dictionary called "data" which should
-	contain all the information about the file sufficient for
-	identification (i.e. if two files have the the same (==) data
-	dictionary, they are the same file).
+    This class contains a dictionary called "data" which should
+    contain all the information about the file sufficient for
+    identification (i.e. if two files have the the same (==) data
+    dictionary, they are the same file).
 
-	"""
+    """
     regex_chars_to_quote = re.compile(b"[\\\\\\\"\\$`]")
 
     def __init__(self, connection, base, index=(), data=None):
         """RPath constructor
 
-		connection = self.conn is the Connection the RPath will use to
-		make system calls, and index is the name of the rpath used for
-		comparison, and should be a tuple consisting of the parts of
-		the rpath after the base split up.  For instance ("foo",
-		"bar") for "foo/bar" (no base), and ("local", "bin") for
-		"/usr/local/bin" if the base is "/usr".
+        connection = self.conn is the Connection the RPath will use to
+        make system calls, and index is the name of the rpath used for
+        comparison, and should be a tuple consisting of the parts of
+        the rpath after the base split up.  For instance ("foo",
+        "bar") for "foo/bar" (no base), and ("local", "bin") for
+        "/usr/local/bin" if the base is "/usr".
 
-		For the root directory "/", the index is empty and the base is
-		"/".
+        For the root directory "/", the index is empty and the base is
+        "/".
 
-		"""
+        """
         super().__init__(index, data)
         self.conn = connection
         if base is not None:
             self.base = os.fsencode(base)  # path is always bytes
             self.path = self.path_join(self.base, *self.index)
-            if data is None: self.setdata()
+            if data is None:
+                self.setdata()
         else:
             self.base = None
 
     def __str__(self):
         return "%s: Path: %s\nIndex: %s\nData: %s" \
-         % (self.__class__.__name__, self.get_safepath(), self.get_safeindex(), self.data)
+            % (self.__class__.__name__, self.get_safepath(), self.get_safeindex(), self.data)
 
     def __getstate__(self):
         """Return picklable state
 
-		The rpath's connection will be encoded as its conn_number.  It
-		and the other information is put in a tuple. Data and any attached
-		file won't be saved.
+        The rpath's connection will be encoded as its conn_number.  It
+        and the other information is put in a tuple. Data and any attached
+        file won't be saved.
 
-		"""
+        """
         return (self.conn.conn_number, self.base, self.index, self.data)
 
     def __setstate__(self, rpath_state):
@@ -1071,10 +1082,10 @@ class RPath(RORPath):
     def check_consistency(self):
         """Raise an error if consistency of rp broken
 
-		This is useful for debugging when the cache and disk get out
-		of sync and you need to find out where it happened.
+        This is useful for debugging when the cache and disk get out
+        of sync and you need to find out where it happened.
 
-		"""
+        """
         temptype = self.data['type']
         self.setdata()
         assert temptype == self.data['type'], \
@@ -1088,7 +1099,7 @@ class RPath(RORPath):
                                permissions & Globals.permission_mask)
         except OSError as e:
             if e.strerror == "Inappropriate file type or format" \
-              and not self.isdir():
+                    and not self.isdir():
                 # Some systems throw this error if try to set sticky bit
                 # on a non-directory. Remove sticky bit and try again.
                 log.Log(
@@ -1246,8 +1257,8 @@ class RPath(RORPath):
 
     def isgroup(self):
         """Return true if process has group of rp"""
-        return ('gid' in self.data and \
-          self.data['gid'] in self.conn.Globals.get('process_groups'))
+        return ('gid' in self.data
+                and self.data['gid'] in self.conn.Globals.get('process_groups'))
 
     def delete(self):
         """Delete file at self.path.  Recursively deletes directories."""
@@ -1298,12 +1309,13 @@ class RPath(RORPath):
     def normalize(self):
         """Return RPath canonical version of self.path
 
-		This just means that redundant /'s will be removed, including
-		the trailing one, even for directories.  ".." components will
-		be retained.
+        This just means that redundant /'s will be removed, including
+        the trailing one, even for directories.  ".." components will
+        be retained.
 
-		"""
-        newpath = self.path_join(b'', *[x for x in self.path.split(b"/") if x and x != b"."])
+        """
+        newpath = self.path_join(
+            b'', *[x for x in self.path.split(b"/") if x and x != b"."])
         if self.path[0:1] == b"/":
             newpath = b"/" + newpath
         elif not newpath:
@@ -1313,15 +1325,15 @@ class RPath(RORPath):
     def dirsplit(self):
         """Returns a tuple of strings (dirname, basename)
 
-		Basename is never '' unless self is root, so it is unlike
-		os.path.basename.  If path is just above root (so dirname is
-		root), then dirname is ''.  In all other cases dirname is not
-		the empty string.  Also, dirsplit depends on the format of
-		self, so basename could be ".." and dirname could be a
-		subdirectory.  For an atomic relative path, dirname will be
-		'.'.
+        Basename is never '' unless self is root, so it is unlike
+        os.path.basename.  If path is just above root (so dirname is
+        root), then dirname is ''.  In all other cases dirname is not
+        the empty string.  Also, dirsplit depends on the format of
+        self, so basename could be ".." and dirname could be a
+        subdirectory.  For an atomic relative path, dirname will be
+        '.'.
 
-		"""
+        """
         normed = self.normalize()
         if normed.path.find(b"/") == -1:
             return (b".", normed.path)
@@ -1335,9 +1347,9 @@ class RPath(RORPath):
     def get_safepath(self, somepath=None):
         """Return safely decoded version of path into the current encoding
 
-		it's meant only for logging and outputting to user
+        it's meant only for logging and outputting to user
 
-		"""
+        """
         if somepath is not None:
             # somepath should never be a string but just to be sure
             # we check before we decode it
@@ -1384,12 +1396,12 @@ class RPath(RORPath):
     def open(self, mode, compress=None):
         """Return open file.  Supports modes "w" and "r".
 
-		If compress is true, data written/read will be gzip
-		compressed/decompressed on the fly.  The extra complications
-		below are for security reasons - try to make the extent of the
-		risk apparent from the remote call.
+        If compress is true, data written/read will be gzip
+        compressed/decompressed on the fly.  The extra complications
+        below are for security reasons - try to make the extent of the
+        risk apparent from the remote call.
 
-		"""
+        """
         if self.conn is Globals.local_connection:
             if compress:
                 return GzipFile(self.path, mode)
@@ -1410,10 +1422,10 @@ class RPath(RORPath):
     def write_from_fileobj(self, fp, compress=None):
         """Reads fp and writes to self.path.  Closes both when done
 
-		If compress is true, fp will be gzip compressed before being
-		written to self.  Returns closing value of fp.
+        If compress is true, fp will be gzip compressed before being
+        written to self.  Returns closing value of fp.
 
-		"""
+        """
         log.Log("Writing file object to %s" % self.get_safepath(), 7)
         assert not self.lstat(), "File %s already exists" % self.path
         outfp = self.open("wb", compress=compress)
@@ -1440,9 +1452,9 @@ class RPath(RORPath):
     def isincfile(self):
         """Return true if path looks like an increment file
 
-		Also sets various inc information used by the *inc* functions.
+        Also sets various inc information used by the *inc* functions.
 
-		"""
+        """
         if self.index:
             basename = self.index[-1]
         else:
@@ -1452,7 +1464,7 @@ class RPath(RORPath):
 
         if inc_info:
             self.inc_compressed, self.inc_timestr, \
-             self.inc_type, self.inc_basestr = inc_info
+                self.inc_type, self.inc_basestr = inc_info
             return 1
         else:
             return None
@@ -1511,10 +1523,10 @@ class RPath(RORPath):
     def fsync(self, fp=None):
         """fsync the current file or directory
 
-		If fp is none, get the file description by opening the file.
-		This can be useful for directories.
+        If fp is none, get the file description by opening the file.
+        This can be useful for directories.
 
-		"""
+        """
         if Globals.do_fsync:
             if not fp:
                 self.conn.rpath.RPath.fsync_local(self)
@@ -1524,10 +1536,10 @@ class RPath(RORPath):
     def fsync_local(self, thunk=None):
         """fsync current file, run locally
 
-		If thunk is given, run it before syncing but after gathering
-		the file's file descriptor.
+        If thunk is given, run it before syncing but after gathering
+        the file's file descriptor.
 
-		"""
+        """
         assert Globals.do_fsync
         assert self.conn is Globals.local_connection
         try:
@@ -1537,8 +1549,7 @@ class RPath(RORPath):
         except OSError as e:
             if 'fd' in locals():
                 os.close(fd)
-            if (e.errno not in (errno.EPERM, errno.EACCES, errno.EBADF)) \
-             or self.isdir():
+            if (e.errno not in (errno.EPERM, errno.EACCES, errno.EBADF)) or self.isdir():
                 raise
 
             # Maybe the system doesn't like read-only fsyncing.
@@ -1593,9 +1604,9 @@ class RPath(RORPath):
     def write_acl(self, acl, map_names=1):
         """Change access control list of rp
 
-		If map_names is true, map the ids in acl by user/group names.
+        If map_names is true, map the ids in acl by user/group names.
 
-		"""
+        """
         acl.write_to_rp(self, map_names)
         self.data['acl'] = acl
 
@@ -1703,15 +1714,15 @@ class RPathFileHook:
 class GzipFile(gzip.GzipFile):
     """Like gzip.GzipFile, except remove destructor
 
-	The default GzipFile's destructor prints out some messy error
-	messages.  Use this class instead to clean those up.
+    The default GzipFile's destructor prints out some messy error
+    messages.  Use this class instead to clean those up.
 
-	"""
+    """
 
     def __init__(self, filename=None, mode=None):
         """ This is needed because we need to write an
-		encoded filename to the file, but use normal
-		unicode with the filename."""
+        encoded filename to the file, but use normal
+        unicode with the filename."""
         if mode and 'b' not in mode:
             mode += 'b'
         fileobj = open(filename, mode or 'rb')
@@ -1730,12 +1741,12 @@ class GzipFile(gzip.GzipFile):
 class MaybeGzip:
     """Represent a file object that may or may not be compressed
 
-	We don't want to compress 0 length files.  This class lets us
-	delay the opening of the file until either the first write (so we
-	know it has data and should be compressed), or close (when there's
-	no data).
+    We don't want to compress 0 length files.  This class lets us
+    delay the opening of the file until either the first write (so we
+    know it has data and should be compressed), or close (when there's
+    no data).
 
-	"""
+    """
 
     def __init__(self, base_rp, callback=None):
         """Return file-like object with filename based on base_rp"""
@@ -1791,10 +1802,10 @@ class MaybeGzip:
 def setdata_local(rpath):
     """Set eas/acls, uid/gid, resource fork in data dictionary
 
-	This is a global function because it must be called locally, since
-	these features may exist or not depending on the connection.
+    This is a global function because it must be called locally, since
+    these features may exist or not depending on the connection.
 
-	"""
+    """
     assert rpath.conn is Globals.local_connection
     reset_perms = False
     if (Globals.process_uid != 0 and not rpath.readable() and rpath.isowner()):
@@ -1814,7 +1825,9 @@ def setdata_local(rpath):
     if Globals.carbonfile_conn and rpath.isreg():
         rpath.data['carbonfile'] = carbonfile_get(rpath)
 
-    if reset_perms: rpath.chmod(rpath.getperms() & ~0o400)
+    if reset_perms:
+        rpath.chmod(rpath.getperms() & ~0o400)
+
 
 def carbonfile_get(rpath):
     """Return carbonfile value for local rpath"""

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -46,37 +46,37 @@ class GlobbingError(SelectError):
 class Select:
     """Iterate appropriate RPaths in given directory
 
-	This class acts as an iterator on account of its next() method.
-	Basically, it just goes through all the files in a directory in
-	order (depth-first) and subjects each file to a bunch of tests
-	(selection functions) in order.  The first test that includes or
-	excludes the file means that the file gets included (iterated) or
-	excluded.  The default is include, so with no tests we would just
-	iterate all the files in the directory in order.
+    This class acts as an iterator on account of its next() method.
+    Basically, it just goes through all the files in a directory in
+    order (depth-first) and subjects each file to a bunch of tests
+    (selection functions) in order.  The first test that includes or
+    excludes the file means that the file gets included (iterated) or
+    excluded.  The default is include, so with no tests we would just
+    iterate all the files in the directory in order.
 
-	The one complication to this is that sometimes we don't know
-	whether or not to include a directory until we examine its
-	contents.  For instance, if we want to include all the **.py
-	files.  If /home/ben/foo.py exists, we should also include /home
-	and /home/ben, but if these directories contain no **.py files,
-	they shouldn't be included.  For this reason, a test may not
-	include or exclude a directory, but merely "scan" it.  If later a
-	file in the directory gets included, so does the directory.
+    The one complication to this is that sometimes we don't know
+    whether or not to include a directory until we examine its
+    contents.  For instance, if we want to include all the **.py
+    files.  If /home/ben/foo.py exists, we should also include /home
+    and /home/ben, but if these directories contain no **.py files,
+    they shouldn't be included.  For this reason, a test may not
+    include or exclude a directory, but merely "scan" it.  If later a
+    file in the directory gets included, so does the directory.
 
-	As mentioned above, each test takes the form of a selection
-	function.  The selection function takes an rpath, and returns:
+    As mentioned above, each test takes the form of a selection
+    function.  The selection function takes an rpath, and returns:
 
-	None - means the test has nothing to say about the related file
-	0 - the file is excluded by the test
-	1 - the file is included
-	2 - the test says the file (must be directory) should be scanned
+    None - means the test has nothing to say about the related file
+    0 - the file is excluded by the test
+    1 - the file is included
+    2 - the test says the file (must be directory) should be scanned
 
-	Also, a selection function f has a variable f.exclude which should
-	be true iff f could potentially exclude some file.  This is used
-	to signal an error if the last function only includes, which would
-	be redundant and presumably isn't what the user intends.
+    Also, a selection function f has a variable f.exclude which should
+    be true iff f could potentially exclude some file.  This is used
+    to signal an error if the last function only includes, which would
+    be redundant and presumably isn't what the user intends.
 
-	"""
+    """
     # This re should not match normal filenames, but usually just globs
     glob_re = re.compile(b"(.*[*?[\\\\]|ignorecase\\:)", re.I | re.S)
 
@@ -90,10 +90,10 @@ class Select:
     def set_iter(self, sel_func=None):
         """Initialize more variables, get ready to iterate
 
-		Selection function sel_func is called on each rpath and is
-		usually self.Select.  Returns self just for convenience.
+        Selection function sel_func is called on each rpath and is
+        usually self.Select.  Returns self just for convenience.
 
-		"""
+        """
         if not sel_func:
             sel_func = self.Select
         self.rpath.setdata()  # this may have changed since Select init
@@ -111,11 +111,11 @@ class Select:
         def diryield(rpath):
             """Generate relevant files in directory rpath
 
-			Returns (rpath, num) where num == 0 means rpath should be
-			generated normally, num == 1 means the rpath is a directory
-			and should be included iff something inside is included.
+            Returns (rpath, num) where num == 0 means rpath should be
+            generated normally, num == 1 means the rpath is a directory
+            and should be included iff something inside is included.
 
-			"""
+            """
             for filename in self.listdir(rpath):
                 new_rpath = robust.check_common_error(
                     error_handler, rpath.append, (filename, ))
@@ -155,14 +155,14 @@ class Select:
     def Iterate(self, rp, rec_func, sel_func):
         """Return iterator yielding rpaths in rpath
 
-		rec_func is usually the same as this function and is what
-		Iterate uses to find files in subdirectories.  It is used in
-		iterate_starting_from.
+        rec_func is usually the same as this function and is what
+        Iterate uses to find files in subdirectories.  It is used in
+        iterate_starting_from.
 
-		sel_func is the selection function to use on the rpaths.  It
-		is usually self.Select.
+        sel_func is the selection function to use on the rpaths.  It
+        is usually self.Select.
 
-		"""
+        """
         s = sel_func(rp)
         if s == 0:
             return
@@ -241,15 +241,15 @@ class Select:
     def ParseArgs(self, argtuples, filelists):
         """Create selection functions based on list of tuples
 
-		The tuples have the form (option string, additional argument)
-		and are created when the initial commandline arguments are
-		read.  The reason for the extra level of processing is that
-		the filelists may only be openable by the main connection, but
-		the selection functions need to be on the backup reader or
-		writer side.  When the initial arguments are parsed the right
-		information is sent over the link.
+        The tuples have the form (option string, additional argument)
+        and are created when the initial commandline arguments are
+        read.  The reason for the extra level of processing is that
+        the filelists may only be openable by the main connection, but
+        the selection functions need to be on the backup reader or
+        writer side.  When the initial arguments are parsed the right
+        information is sent over the link.
 
-		"""
+        """
         filelists_index = 0
         try:
             for opt, arg in argtuples:
@@ -357,16 +357,16 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def filelist_get_sf(self, filelist_fp, inc_default, filelist_name):
         """Return selection function by reading list of files
 
-		The format of the filelist is documented in the man page.
-		filelist_fp should be an (open) file object.
-		inc_default should be true if this is an include list,
-		false for an exclude list.
-		filelist_name is just a string used for logging.
+        The format of the filelist is documented in the man page.
+        filelist_fp should be an (open) file object.
+        inc_default should be true if this is an include list,
+        false for an exclude list.
+        filelist_name is just a string used for logging.
 
-		"""
+        """
         log.Log("Reading filelist %s" % filelist_name, 4)
         tuple_list, something_excluded = \
-           self.filelist_read(filelist_fp, inc_default, filelist_name)
+            self.filelist_read(filelist_fp, inc_default, filelist_name)
         log.Log("Sorting filelist %s" % filelist_name, 4)
         tuple_list.sort()
         i = [0]  # We have to put index in list because of stupid scoping rules
@@ -375,8 +375,7 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
             while 1:
                 if i[0] >= len(tuple_list):
                     return None
-                include, move_on = \
-                   self.filelist_pair_match(rp, tuple_list[i[0]])
+                include, move_on = self.filelist_pair_match(rp, tuple_list[i[0]])
                 if move_on:
                     i[0] += 1
                     if include is None:
@@ -422,12 +421,12 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def filelist_parse_line(self, line, include):
         """Parse a single line of a filelist, returning a pair
 
-		pair will be of form (index, include), where index is another
-		tuple, and include is 1 if the line specifies that we are
-		including a file.  The default is given as an argument.
-		prefix is the string that the index is relative to.
+        pair will be of form (index, include), where index is another
+        tuple, and include is 1 if the line specifies that we are
+        including a file.  The default is given as an argument.
+        prefix is the string that the index is relative to.
 
-		"""
+        """
         if line[:2] == b"+ ":  # Check for "+ "/"- " syntax
             include = 1
             line = line[2:]
@@ -444,14 +443,14 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def filelist_pair_match(self, rp, pair):
         """Matches a filelist tuple against a rpath
 
-		Returns a pair (include, move_on).  include is None if the
-		tuple doesn't match either way, and 0/1 if the tuple excludes
-		or includes the rpath.
+        Returns a pair (include, move_on).  include is None if the
+        tuple doesn't match either way, and 0/1 if the tuple excludes
+        or includes the rpath.
 
-		move_on is true if the tuple cannot match a later index, and
-		so we should move on to the next tuple in the index.
+        move_on is true if the tuple cannot match a later index, and
+        so we should move on to the next tuple in the index.
 
-		"""
+        """
         index, include = pair
         if include == 1:
             if index < rp.index:
@@ -475,12 +474,12 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def filelist_globbing_get_sfs(self, filelist_fp, inc_default, list_name):
         """Return list of selection functions by reading fileobj
 
-		filelist_fp should be an open file object
-		inc_default is true iff this is an include list
-		list_name is just the name of the list, used for logging
-		See the man page on --[include/exclude]-globbing-filelist
+        filelist_fp should be an open file object
+        inc_default is true iff this is an include list
+        list_name is just the name of the list, used for logging
+        See the man page on --[include/exclude]-globbing-filelist
 
-		"""
+        """
         log.Log("Reading globbing filelist %s" % list_name, 4)
         separator = Globals.null_separator and b"\0" or b"\n"
         for line in filelist_fp.read().split(separator):
@@ -533,7 +532,7 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
 
         def sel_func(rp):
             if rp.isdir() and rp.readable() and \
-              rp.append(presence_filename).lstat():
+               rp.append(presence_filename).lstat():
                 return include
             return None
 
@@ -543,11 +542,11 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
 
     def gen_get_sf(self, pred, include, name):
         """Returns a selection function that uses pred to test
-		
-		RPath is matched if pred returns true on it.  Name is a string
-		summarizing the test to the user.
+        
+        RPath is matched if pred returns true on it.  Name is a string
+        summarizing the test to the user.
 
-		"""
+        """
 
         def sel_func(rp):
             if pred(rp):
@@ -624,12 +623,12 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def glob_get_filename_sf(self, filename, include):
         """Get a selection function given a normal filename
 
-		Some of the parsing is better explained in
-		filelist_parse_line.  The reason this is split from normal
-		globbing is things are a lot less complicated if no special
-		globbing characters are used.
+        Some of the parsing is better explained in
+        filelist_parse_line.  The reason this is split from normal
+        globbing is things are a lot less complicated if no special
+        globbing characters are used.
 
-		"""
+        """
         if not filename.startswith(self.prefix):
             raise FilePrefixError(filename)
         index = tuple(
@@ -663,18 +662,18 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def glob_get_normal_sf(self, glob_str, include):
         """Return selection function based on glob_str
 
-		The basic idea is to turn glob_str into a regular expression,
-		and just use the normal regular expression.  There is a
-		complication because the selection function should return '2'
-		(scan) for directories which may contain a file which matches
-		the glob_str.  So we break up the glob string into parts, and
-		any file which matches an initial sequence of glob parts gets
-		scanned.
+        The basic idea is to turn glob_str into a regular expression,
+        and just use the normal regular expression.  There is a
+        complication because the selection function should return '2'
+        (scan) for directories which may contain a file which matches
+        the glob_str.  So we break up the glob string into parts, and
+        any file which matches an initial sequence of glob parts gets
+        scanned.
 
-		Thanks to Donovan Baarda who provided some code which did some
-		things similar to this.
+        Thanks to Donovan Baarda who provided some code which did some
+        things similar to this.
 
-		"""
+        """
         if glob_str.lower().startswith(b"ignorecase:"):
             re_comp = lambda r: re.compile(r, re.I | re.S)
             glob_str = glob_str[len(b"ignorecase:"):]
@@ -716,7 +715,8 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def glob_get_prefix_res(self, glob_str):
         """Return list of regexps equivalent to prefixes of glob_str"""
         glob_parts = glob_str.split(b"/")
-        if b"" in glob_parts[1:-1]:  # "" OK if comes first or last, as in /foo/
+        if b"" in glob_parts[1:
+                             -1]:  # "" OK if comes first or last, as in /foo/
             raise GlobbingError(
                 "Consecutive '/'s found in globbing string %a" % glob_str)
 
@@ -731,14 +731,14 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
     def glob_to_re(self, pat):
         """Returned regular expression equivalent to shell glob pat
 
-		Currently only the ?, *, [], and ** expressions are supported.
-		Ranges like [a-z] are also currently unsupported.  These special
-		characters can be quoted by prepending them with a backslash.
+        Currently only the ?, *, [], and ** expressions are supported.
+        Ranges like [a-z] are also currently unsupported.  These special
+        characters can be quoted by prepending them with a backslash.
 
-		This function taken with minor modifications from efnmatch.py
-		by Donovan Baarda.
+        This function taken with minor modifications from efnmatch.py
+        by Donovan Baarda.
 
-		"""
+        """
         i, n, res = 0, len(pat), ''
         # trying to analyze bytes would be quite complicated hence back to str
         str_pat = os.fsdecode(pat)
@@ -782,11 +782,11 @@ class FilterIter:
     def __init__(self, select, rorp_iter):
         """Constructor
 
-		Input is the Select object to use and the iter of rorps to be
-		filtered.  The rorps will be converted to rps using the Select
-		base.
+        Input is the Select object to use and the iter of rorps to be
+        filtered.  The rorps will be converted to rps using the Select
+        base.
 
-		"""
+        """
         self.rorp_iter = rorp_iter
         self.base_rp = select.rpath
         self.stored_rorps = []
@@ -818,20 +818,20 @@ class FilterIter:
 class FilterIterITRB(rorpiter.ITRBranch):
     """ITRBranch used in above FilterIter class
 
-	The reason this is necessary is because for directories sometimes
-	we don't know whether a rorp is excluded until we see what is in
-	the directory.
+    The reason this is necessary is because for directories sometimes
+    we don't know whether a rorp is excluded until we see what is in
+    the directory.
 
-	"""
+    """
 
     def __init__(self, select, rorp_cache):
         """Initialize FilterIterITRB.  Called by IterTreeReducer.
 
-		select should be the relevant Select object used to test the
-		rps.  rorp_cache is the list rps should be appended to if they
-		aren't excluded.
+        select should be the relevant Select object used to test the
+        rps.  rorp_cache is the list rps should be appended to if they
+        aren't excluded.
 
-		"""
+        """
         self.select, self.rorp_cache = select, rorp_cache
         self.branch_excluded = None
         self.base_queue = None  # holds branch base while examining contents

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -83,10 +83,10 @@ class StatsObj:
     def get_total_dest_size_change(self):
         """Return total destination size change
 
-		This represents the total change in the size of the
-		rdiff-backup destination directory.
+        This represents the total change in the size of the
+        rdiff-backup destination directory.
 
-		"""
+        """
         addvals = [
             self.NewFileSize, self.ChangedSourceSize, self.IncrementFileSize
         ]
@@ -476,10 +476,10 @@ class FileStats:
     def write_buffer(cls):
         """Write buffer to file because buffer is full
 
-		The buffer part is necessary because the GzipFile.write()
-		method seems fairly slow.
+        The buffer part is necessary because the GzipFile.write()
+        method seems fairly slow.
 
-		"""
+        """
         assert cls.line_buffer and cls._fileobj
         cls.line_buffer.append(b'')  # have join add _line_sep to end also
         cls._fileobj.write(cls._line_sep.join(cls.line_buffer))

--- a/src/rdiff_backup/user_group.py
+++ b/src/rdiff_backup/user_group.py
@@ -30,11 +30,13 @@ objects should only be used on the destination.
 """
 
 try:
-    import grp, pwd
+    import grp
+    import pwd
 except ImportError:
     pass
 
-from . import log, Globals
+from . import log
+from . import Globals
 
 ############ "Private" section - don't use outside user_group ###########
 
@@ -102,11 +104,11 @@ class Map:
     def map_acl(self, id, name=None):
         """Like get_id, but use this for ACLs.  Return id or None
 
-		Unlike ordinary user/group ownership, ACLs are not required
-		and can be dropped.  If we cannot map the name over, return
-		None.
+        Unlike ordinary user/group ownership, ACLs are not required
+        and can be dropped.  If we cannot map the name over, return
+        None.
 
-		"""
+        """
         if not name:
             return id
         return self.name2id(name)
@@ -115,19 +117,19 @@ class Map:
 class DefinedMap(Map):
     """Map names and ids on source side to appropriate ids on dest side
 
-	Like map, but initialize with user-defined mapping string, which
-	supersedes Map.
+    Like map, but initialize with user-defined mapping string, which
+    supersedes Map.
 
-	"""
+    """
 
     def __init__(self, is_user, mapping_string):
         """Initialize object with given mapping string
 
-		The mapping_string should consist of a number of lines, each which
-		should have the form "source_id_or_name:dest_id_or_name".  Do user
-		mapping unless user is false, then do group.
+        The mapping_string should consist of a number of lines, each which
+        should have the form "source_id_or_name:dest_id_or_name".  Do user
+        mapping unless user is false, then do group.
 
-		"""
+        """
         Map.__init__(self, is_user)
         self.name_mapping_dict = {}
         self.id_mapping_dict = {}
@@ -138,8 +140,8 @@ class DefinedMap(Map):
                 continue
             comps = line.split(':')
             if not len(comps) == 2:
-                log.Log.FatalError("Error parsing mapping file, bad line: " +
-                                   line)
+                log.Log.FatalError("Error parsing mapping file, bad line: "
+                                   + line)
             old, new = comps
 
             try:
@@ -155,8 +157,8 @@ class DefinedMap(Map):
             try:
                 return self.name2id(id_or_name)
             except KeyError:
-                log.Log.FatalError("Cannot get id for user or group name " +
-                                   id_or_name)
+                log.Log.FatalError("Cannot get id for user or group name "
+                                   + id_or_name)
 
     def __call__(self, id, name=None):
         """Return new id given old id and name"""
@@ -224,10 +226,10 @@ def gid2gname(gid):
 def init_user_mapping(mapping_string=None, numerical_ids=None):
     """Initialize user mapping with given mapping string
 
-	If numerical_ids is set, just keep the same uid.  If either
-	argument is None, default to preserving uname where possible.
+    If numerical_ids is set, just keep the same uid.  If either
+    argument is None, default to preserving uname where possible.
 
-	"""
+    """
     global UserMap
     if numerical_ids:
         UserMap = NumericalMap()
@@ -240,10 +242,10 @@ def init_user_mapping(mapping_string=None, numerical_ids=None):
 def init_group_mapping(mapping_string=None, numerical_ids=None):
     """Initialize group mapping with given mapping string
 
-	If numerical_ids is set, just keep the same gid.  If either
-	argument is None, default to preserving gname where possible.
+    If numerical_ids is set, just keep the same gid.  If either
+    argument is None, default to preserving gname where possible.
 
-	"""
+    """
     global GroupMap
     if numerical_ids:
         GroupMap = NumericalMap()
@@ -256,10 +258,10 @@ def init_group_mapping(mapping_string=None, numerical_ids=None):
 def map_rpath(rp):
     """Return mapped (newuid, newgid) from rpath's initial info
 
-	This is the main function exported by the user_group module.  Note
-	that it is connection specific.
+    This is the main function exported by the user_group module.  Note
+    that it is connection specific.
 
-	"""
+    """
     uid, gid = rp.getuidgid()
     uname, gname = rp.getuname(), rp.getgname()
     return (UserMap(uid, uname), GroupMap(gid, gname))

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -52,8 +52,8 @@ class ACL:
             return
 
         try:
-            sd = rp.conn.win32security. \
-              GetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
+            sd = rp.conn.win32security.GetNamedSecurityInfo(os.fsdecode(rp.path),
+                                                            SE_FILE_OBJECT, ACL.flags)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to read ACL from %s: %s" % (repr(rp.path),
@@ -87,15 +87,14 @@ class ACL:
 
         if not sd.GetSecurityDescriptorDacl():
             sd.SetSecurityDescriptorDacl(0, None, 0)
-        if (ACL.flags & SACL_SECURITY_INFORMATION) and not \
-          sd.GetSecurityDescriptorSacl():
+        if (ACL.flags & SACL_SECURITY_INFORMATION) and not sd.GetSecurityDescriptorSacl():
             sd.SetSecurityDescriptorSacl(0, None, 0)
 
         try:
             self.__acl = \
-             rp.conn.win32security. \
-              ConvertSecurityDescriptorToStringSecurityDescriptor(sd,
-              SDDL_REVISION_1, ACL.flags)
+                rp.conn.win32security.ConvertSecurityDescriptorToStringSecurityDescriptor(sd,
+                                                                                          SDDL_REVISION_1,
+                                                                                          ACL.flags)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to convert ACL from %s to string: %s" % (repr(
@@ -108,7 +107,7 @@ class ACL:
         # I'll just clear all acl-s from rp.path
         try:
             sd = rp.conn.win32security. \
-              GetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
+                GetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to read ACL from %s for clearing: %s" % (repr(
@@ -136,11 +135,14 @@ class ACL:
 
         try:
             rp.conn.win32security. \
-             SetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags,
-             sd.GetSecurityDescriptorOwner(),sd.GetSecurityDescriptorGroup(),
-             sd.GetSecurityDescriptorDacl(),
-             (ACL.flags & SACL_SECURITY_INFORMATION) and
-              sd.GetSecurityDescriptorSacl() or None)
+                SetNamedSecurityInfo(os.fsdecode(rp.path),
+                                     SE_FILE_OBJECT,
+                                     ACL.flags,
+                                     sd.GetSecurityDescriptorOwner(),
+                                     sd.GetSecurityDescriptorGroup(),
+                                     sd.GetSecurityDescriptorDacl(),
+                                     (ACL.flags & SACL_SECURITY_INFORMATION)
+                                     and sd.GetSecurityDescriptorSacl() or None)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to set ACL on %s after clearing: %s" % (repr(
@@ -152,8 +154,9 @@ class ACL:
 
         try:
             sd = rp.conn.win32security. \
-             ConvertStringSecurityDescriptorToSecurityDescriptor(
-              os.fsdecode(self.__acl), SDDL_REVISION_1)
+                ConvertStringSecurityDescriptorToSecurityDescriptor(
+                    os.fsdecode(self.__acl),
+                    SDDL_REVISION_1)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to convert string %s to ACL: %s" % (repr(
@@ -162,19 +165,19 @@ class ACL:
         # Enable next block of code for dirs after we have a mechanism in
         # backup.py (and similar) to do a first pass to see if a directory
         # has SE_DACL_PROTECTED. In that case, we will need to
-        #		1) dest_rorp.write_win_acl(source_rorp.get_win_acl())
-        #				--> And clear existing dest_rorp one while doing so
-        #		2) Check if backup user has Admin privs to write dest_rorp
-        #				--> May need to use Win32 AccessCheck() API
-        #		3) If not, add Admin write privs to dest_rorp and add dir
-        #				to dir_perms_list-equivalent
-        #		4) THEN, allow the pre_process() function to finish and the
-        #				files be copied over. Those files which wish to
-        #				will now inherit the correct ACE objects.
-        #		5) If dir was on dir_perms_list-equivalent, drop the write
-        #				write permission we added.
-        #		6) When copy_attribs is called in end_process, make sure
-        #				that the write_win_acl() call isn't made this time
+        #       1) dest_rorp.write_win_acl(source_rorp.get_win_acl())
+        #               --> And clear existing dest_rorp one while doing so
+        #       2) Check if backup user has Admin privs to write dest_rorp
+        #               --> May need to use Win32 AccessCheck() API
+        #       3) If not, add Admin write privs to dest_rorp and add dir
+        #               to dir_perms_list-equivalent
+        #       4) THEN, allow the pre_process() function to finish and the
+        #               files be copied over. Those files which wish to
+        #               will now inherit the correct ACE objects.
+        #       5) If dir was on dir_perms_list-equivalent, drop the write
+        #               write permission we added.
+        #       6) When copy_attribs is called in end_process, make sure
+        #               that the write_win_acl() call isn't made this time
         # The reason we will need to do this is because otherwise, the files
         # which are created during step 4 will reference the ACE entries
         # which we clear during step 6. We need to clear them *before* the
@@ -187,11 +190,13 @@ class ACL:
 
         try:
             rp.conn.win32security. \
-             SetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags,
-             sd.GetSecurityDescriptorOwner(),sd.GetSecurityDescriptorGroup(),
-             sd.GetSecurityDescriptorDacl(),
-             (ACL.flags & SACL_SECURITY_INFORMATION) and
-              sd.GetSecurityDescriptorSacl() or None)
+                SetNamedSecurityInfo(os.fsdecode(rp.path),
+                                     SE_FILE_OBJECT, ACL.flags,
+                                     sd.GetSecurityDescriptorOwner(),
+                                     sd.GetSecurityDescriptorGroup(),
+                                     sd.GetSecurityDescriptorDacl(),
+                                     (ACL.flags & SACL_SECURITY_INFORMATION)
+                                     and sd.GetSecurityDescriptorSacl() or None)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to set ACL on %s: %s" % (repr(rp.path), exc),
@@ -199,7 +204,7 @@ class ACL:
 
     def __bytes__(self):
         return b'# file: %b\n%b\n' % \
-           (C.acl_quote(self.get_indexpath()), self.__acl)
+            (C.acl_quote(self.get_indexpath()), self.__acl)
 
     def __str__(self):
         return os.fsdecode(self.__bytes__())


### PR DESCRIPTION
Clean-up the code with pep8 and replace tabs with spaces #60

I **don't** fix any issue on the code, only the format and replace tabs

**Need to check some warnings as:**
```
src/rdiff_backup/win_acls.py:305:13: E731 do not assign a lambda expression, use a def
src/rdiff_backup/TempFile.py:45:13: F821 undefined name 'Log'
src/rdiff_backup/TempFile.py:61:13: F821 undefined name 'remove_listing'
src/rdiff_backup/TempFile.py:79:9: F821 undefined name 'remove_listing'
src/rdiff_backup/TempFile.py:83:9: F821 undefined name 'remove_listing'
src/rdiff_backup/statistics.py:133:33: F821 undefined name 'stat_file_attrs'
src/rdiff_backup/statistics.py:135:37: F821 undefined name 'stat_file_attrs'
src/rdiff_backup/statistics.py:136:52: F821 undefined name 'stat_file_attrs'
src/rdiff_backup/statistics.py:245:16: E713 test for membership should be 'not in'
src/rdiff_backup/statistics.py:306:13: F821 undefined name 'StatObj'

```





