### PR TITLE
Replace non existing rorp.path through get_safeindexpath()

### DIFF
--- a/src/rdiff_backup/backup.py
+++ b/src/rdiff_backup/backup.py
@@ -791,8 +791,8 @@ class IncrementITRB(PatchITRB):
             self.CCPP.get_rorps(index), self.basis_root_rp, self.inc_root_rp)
         self.base_rp.setdata()
         assert diff_rorp.isdir() or self.base_rp.isdir(), \
-            ("Either %s or %s must be a directory" % (repr(diff_rorp.path),
-             repr(self.base_rp.path)))
+            ("Either %s or %s must be a directory" % (repr(diff_rorp.get_safeindexpath()),
+             repr(self.base_rp.get_safepath())))
         if diff_rorp.isdir():
             inc = increment.Increment(diff_rorp, self.base_rp, inc_prefix)
             if inc and inc.isreg():


### PR DESCRIPTION
Closes #14
Took also the chance to use rpath.get_safepath instead of path.