### PR TITLE
Use bytes when setting chars_to_quote in case file doesn't exist in repo

### DIFF
--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -992,7 +992,7 @@ class RestoreSetGlobals(SetGlobals):
             log.Log(
                 "Warning: chars_to_quote file not found,\n"
                 "assuming no quoting in backup repository.", 2)
-            SetConnections.UpdateGlobal("chars_to_quote", "")
+            SetConnections.UpdateGlobal("chars_to_quote", b"")
 
 
 class SingleSetGlobals(RestoreSetGlobals):


### PR DESCRIPTION
Fixes following error:

    [...]
    File .../rdiff_backup/fs_abilities.py, line 769, in set_compatible_timestamps
      if Globals.chars_to_quote.find(b:) > -1:
    TypeError: must be str, not bytes