### PR TITLE
Add env variable RDIFF_BACKUP_VERBOSITY to change verbosity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
-New in v1.3.4 (????/??/??)
+New in v1.3.6 (????/??/??)
 ---------------------------
+
+Add RDIFF_BACKUP_VERBOSITY environment variable (Eric Lavarde)
 
 Add support for Python 3.5 to 3.8, remove support for Python 2.x (Eric Lavarde)
 

--- a/docs/rdiff-backup.1
+++ b/docs/rdiff-backup.1
@@ -522,6 +522,12 @@ hashes stored in the metadata file.
 .B "-V, \-\-version"
 Print the current version and exit
 
+.SH ENVIRONMENT
+.TP
+.BI "RDIFF_BACKUP_VERBOSITY"=[0-9]
+Sets the default verbosity for log file and terminal, can be overwritten
+by the corresponding options "\-v/\-\-verbosity" and "\-\-terminal-verbosity".
+
 .SH RESTORING
 There are two ways to tell rdiff-backup to restore a file or
 directory.  Firstly, you can run rdiff-backup on a mirror file and use

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -23,6 +23,7 @@ import sys
 import traceback
 import types
 import re
+import os  # needed to grab verbosity as environment variable
 from . import Globals, rpath
 
 
@@ -36,7 +37,8 @@ class Logger:
     def __init__(self):
         self.log_file_open = None
         self.log_file_local = None
-        self.verbosity = self.term_verbosity = 3
+        self.verbosity = self.term_verbosity = int(
+            os.getenv('RDIFF_BACKUP_VERBOSITY', '3'))
         # termverbset is true if the term_verbosity has been explicitly set
         self.termverbset = None
 
@@ -109,8 +111,9 @@ class Logger:
         if verbosity < 9:
             return "%s\n" % message
         else:
-            timestamp = datetime.datetime.now().astimezone().strftime(
-                "%F %H:%M:%S.%f %z")
+            timestamp = datetime.datetime.now(
+                datetime.timezone.utc).astimezone().strftime(
+                    "%F %H:%M:%S.%f %z")
             if Globals.server:
                 role = "SERVER"
             else:

--- a/testing/backuptest.py
+++ b/testing/backuptest.py
@@ -1,6 +1,6 @@
 import unittest
 from commontest import MirrorTest, old_inc1_dir, old_inc2_dir, old_inc3_dir, old_inc4_dir
-from rdiff_backup import Globals, SetConnections, user_group, log
+from rdiff_backup import Globals, SetConnections, user_group
 
 
 class RemoteMirrorTest(unittest.TestCase):
@@ -8,7 +8,6 @@ class RemoteMirrorTest(unittest.TestCase):
 
     def setUp(self):
         """Start server"""
-        log.Log.setverbosity(5)
         Globals.change_source_perms = 1
         SetConnections.UpdateGlobal('checkpoint_interval', 3)
         user_group.init_user_mapping()

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -10,7 +10,6 @@ from rdiff_backup import Globals, log, rpath, robust, FilenameMapping, Time, sel
 """Regression tests"""
 
 Globals.exclude_mirror_regexps = [re.compile(b".*/rdiff-backup-data")]
-log.Log.setverbosity(3)
 
 lc = Globals.local_connection
 

--- a/testing/connectiontest.py
+++ b/testing/connectiontest.py
@@ -110,8 +110,6 @@ class PipeConnectionTest(unittest.TestCase):
         (stdin, stdout) = (self.p.stdin, self.p.stdout)
         self.conn = PipeConnection(stdout, stdin)
         Globals.security_level = "override"
-        # self.conn.Log.setverbosity(9)
-        # log.Log.setverbosity(9)
 
     def testBasic(self):
         """Test some basic pipe functions"""

--- a/testing/eas_aclstest.py
+++ b/testing/eas_aclstest.py
@@ -5,7 +5,7 @@ import pwd
 import grp
 from rdiff_backup.eas_acls import AccessControlLists, metadata, ACLExtractor, \
     Record2ACL, ACL2Record, ExtendedAttributes, EAExtractor, EA2Record, Record2EA
-from rdiff_backup import Globals, rpath, user_group, log
+from rdiff_backup import Globals, rpath, user_group
 from commontest import rdiff_backup, abs_test_dir, abs_output_dir, abs_restore_dir, \
     BackupRestoreSeries, CompareRecursive
 
@@ -13,7 +13,6 @@ user_group.init_user_mapping()
 user_group.init_group_mapping()
 tempdir = rpath.RPath(Globals.local_connection, abs_output_dir)
 restore_dir = rpath.RPath(Globals.local_connection, abs_restore_dir)
-log.Log.setverbosity(3)
 
 
 class EATest(unittest.TestCase):

--- a/testing/hashtest.py
+++ b/testing/hashtest.py
@@ -94,7 +94,7 @@ class HashTest(unittest.TestCase):
         in_rp1, hashlist1, in_rp2, hashlist2 = self.make_dirs()
         Myrm(abs_output_dir)
 
-        rdiff_backup(1, 1, in_rp1.path, abs_output_dir, 10000, b"-v3")
+        rdiff_backup(1, 1, in_rp1.path, abs_output_dir, 10000)
         meta_prefix = rpath.RPath(
             Globals.local_connection,
             os.path.join(abs_output_dir, b"rdiff-backup-data",
@@ -105,7 +105,7 @@ class HashTest(unittest.TestCase):
         hashlist = self.extract_hashs(metadata_rp)
         assert hashlist == hashlist1, (hashlist1, hashlist)
 
-        rdiff_backup(1, 1, in_rp2.path, abs_output_dir, 20000, b"-v3")
+        rdiff_backup(1, 1, in_rp2.path, abs_output_dir, 20000)
         incs = restore.get_inclist(meta_prefix)
         assert len(incs) == 2
         if incs[0].getinctype() == 'snapshot':

--- a/testing/incrementtest.py
+++ b/testing/incrementtest.py
@@ -2,11 +2,10 @@ import unittest
 import os
 import re
 from commontest import old_test_dir, abs_output_dir, MakeOutputDir
-from rdiff_backup import Globals, log, rpath, increment, Time, Rdiff
+from rdiff_backup import Globals, rpath, increment, Time, Rdiff
 
 lc = Globals.local_connection
 Globals.change_source_perms = 1
-log.Log.setverbosity(3)
 
 
 def getrp(ending):

--- a/testing/killtest.py
+++ b/testing/killtest.py
@@ -5,10 +5,8 @@ import sys
 import random
 import time
 from commontest import abs_test_dir, old_test_dir, CompareRecursive, RBBin
-from rdiff_backup import Globals, restore, rpath, Time, log
+from rdiff_backup import Globals, restore, rpath, Time
 """Test consistency by killing rdiff-backup as it is backing up"""
-
-log.Log.setverbosity(3)
 
 
 class Local:
@@ -58,7 +56,7 @@ class ProcessFuncs(unittest.TestCase):
 
     def exec_rb(self, time, wait, *args):
         """Run rdiff-backup return pid.  Wait until done if wait is true"""
-        arglist = [sys.executable, RBBin, '-v3']
+        arglist = [sys.executable, RBBin]
         if time:
             arglist.append("--current-time")
             arglist.append(str(time))

--- a/testing/makerestoretest3
+++ b/testing/makerestoretest3
@@ -6,5 +6,5 @@
 rm -rvf ${PWD}_testfiles/restoretest3
 for i in 1 2 3 4
 do
-	rdiff-backup -v5 --current-time $((i * 10000)) ${PWD}_testfiles/increment${i} ${PWD}_testfiles/restoretest3
+	rdiff-backup --current-time $((i * 10000)) ${PWD}_testfiles/increment${i} ${PWD}_testfiles/restoretest3
 done

--- a/testing/rdifftest.py
+++ b/testing/rdifftest.py
@@ -2,9 +2,7 @@ import unittest
 import random
 import os
 from commontest import abs_test_dir, old_test_dir, abs_output_dir
-from rdiff_backup import Globals, Rdiff, log, rpath
-
-log.Log.setverbosity(7)
+from rdiff_backup import Globals, Rdiff, rpath
 
 
 def MakeRandomFile(path):

--- a/testing/regresstest.py
+++ b/testing/regresstest.py
@@ -8,9 +8,7 @@ import unittest
 import os
 from commontest import abs_output_dir, abs_test_dir, old_test_dir, Myrm, \
     CompareRecursive, rdiff_backup
-from rdiff_backup import regress, Time, log, rpath, Globals
-
-log.Log.setverbosity(3)
+from rdiff_backup import regress, Time, rpath, Globals
 
 
 class RegressTest(unittest.TestCase):
@@ -103,7 +101,7 @@ class RegressTest(unittest.TestCase):
                      False,
                      self.output_rp.path,
                      None,
-                     extra_options=b"-v3 --check-destination-dir")
+                     extra_options=b"--check-destination-dir")
 
     def test_local(self):
         """Run regress test locally"""

--- a/testing/restoretest.py
+++ b/testing/restoretest.py
@@ -4,7 +4,6 @@ from commontest import abs_output_dir, old_test_dir, Myrm, MakeOutputDir, \
     InternalRestore, CompareRecursive
 from rdiff_backup import restore, Globals, rpath, TempFile, Time, log, Main
 
-log.Log.setverbosity(3)
 lc = Globals.local_connection
 tempdir = rpath.RPath(Globals.local_connection, abs_output_dir)
 restore_base_rp = rpath.RPath(Globals.local_connection,

--- a/testing/roottest.py
+++ b/testing/roottest.py
@@ -3,7 +3,7 @@ import os
 from commontest import old_test_dir, abs_test_dir, abs_output_dir, Myrm, \
     abs_restore_dir, re_init_rpath_dir, CompareRecursive, BackupRestoreSeries, \
     rdiff_backup
-from rdiff_backup import Globals, log, rpath, Main
+from rdiff_backup import Globals, rpath, Main
 """Root tests - contain tests which need to be run as root.
 
 Some of the quoting here may not work with csh (works on bash).  Also,
@@ -13,8 +13,6 @@ if you aren't me, check out the 'user' global variable.
 
 Globals.set('change_source_perms', None)
 Globals.counter = 0
-verbosity = 1
-log.Log.setverbosity(verbosity)
 
 assert os.getuid() == 0, "Run this test as root!"
 
@@ -282,8 +280,7 @@ class HalfRoot(unittest.TestCase):
         outrp = rpath.RPath(Globals.local_connection, abs_output_dir)
         re_init_rpath_dir(outrp, userid)
         remote_schema = b'su -c "rdiff-backup --server" %s' % (user.encode(), )
-        cmd_schema = (b"rdiff-backup -v%i" % verbosity
-                      + b" --current-time %i --remote-schema '%%s' %b '%b'::%b")
+        cmd_schema = (b"rdiff-backup --current-time %i --remote-schema '%%s' %b '%b'::%b")
 
         cmd1 = cmd_schema % (10000, in_rp1.path, remote_schema, outrp.path)
         Run(cmd1)
@@ -296,8 +293,7 @@ class HalfRoot(unittest.TestCase):
         outrp.setdata()
 
         rout_rp = rpath.RPath(Globals.local_connection, abs_restore_dir)
-        restore_schema = (b"rdiff-backup -v%i" % verbosity
-                          + b" -r %b --remote-schema '%%s' '%b'::%b %b")
+        restore_schema = (b"rdiff-backup -r %b --remote-schema '%%s' '%b'::%b %b")
         Myrm(rout_rp.path)
         cmd3 = restore_schema % (b'10000', remote_schema, outrp.path,
                                  rout_rp.path)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = py35, py36, py37, py38, flake8
 # make sure those variables are passed down; you should define 
 # either explicitly the RDIFF_TEST_* variables or rely on the current
 # user being correctly identified (which might not happen in a container)
-passenv = RDIFF_TEST_USER RDIFF_TEST_GROUP
+passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
     pyxattr
     pylibacl

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -18,7 +18,7 @@ isolated_build_env = .package.root
 # make sure those variables are passed down; you should define them
 # either implicitly through usage of sudo (which defines the SUDO_* variables),
 # or explicitly the RDIFF_* ones:
-passenv = SUDO_USER SUDO_UID SUDO_GID RDIFF_TEST_USER RDIFF_TEST_UID RDIFF_TEST_GID
+passenv = SUDO_USER SUDO_UID SUDO_GID RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
     pyxattr
     pylibacl

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -10,6 +10,7 @@
 envlist = py35, py36, py37, py38
 
 [testenv]
+passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
     pyxattr
     pylibacl


### PR DESCRIPTION
- this was the easiest/only way to centrally change verbosity
  without having to change the code or the configuration
- removed all Log.setverbosity calls in the tests
- man page updated accordingly with ENVIRONMENT section
- update tox ini files to pass along this variable (and any
  one starting likewise)
- Closes #77 [ENH] find a way to easily change the verbosity of
  logging in tests