### PR TITLE
Get rid of ugly b'' for bytes when listing repo increments

### DIFF
--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -981,7 +981,7 @@ def ListChangedSince(rp):
     inc_rp = mirror_rp.append_path(b"increments", restore_index)
     for rorp in rp.conn.restore.ListChangedSince(mirror_rp, inc_rp, rest_time):
         # This is a hack, see restore.ListChangedSince for rationale
-        print(rorp.index[0])
+        print(rorp.get_safeindexpath())
 
 
 def ListAtTime(rp):
@@ -994,7 +994,7 @@ def ListAtTime(rp):
     mirror_rp = restore_root.new_index(restore_index)
     inc_rp = mirror_rp.append_path(b"increments", restore_index)
     for rorp in rp.conn.restore.ListAtTime(mirror_rp, inc_rp, rest_time):
-        print(rorp.get_indexpath())
+        print(rorp.get_safeindexpath())
 
 
 def Compare(compare_type, src_rp, dest_rp, compare_time=None):

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -84,8 +84,8 @@ def ListChangedSince(mirror_rp, inc_rp, restore_to_time):
             continue
         else:
             change = "changed"
-        path_desc = (old_rorp and old_rorp.get_indexpath()
-                     or cur_rorp.get_indexpath())
+        path_desc = (old_rorp and old_rorp.get_safeindexpath()
+                     or cur_rorp.get_safeindexpath())
         yield rpath.RORPath(("%-7s %s" % (change, path_desc), ))
     MirrorStruct.close_rf_cache()
 


### PR DESCRIPTION
Impacts output when --list-changed-since or --list-at-time are being used.