### PR TITLE
Fix unstable killtests

### DIFF
--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -118,7 +118,7 @@ class Logger:
                 role = "SERVER"
             else:
                 role = "CLIENT"
-            return "%s  <%s>  %s\n" % (timestamp, role, message)
+            return "%s  <%s-%d>  %s\n" % (timestamp, role, os.getpid(), message)
 
     def __call__(self, message, verbosity):
         """Log message that has verbosity importance


### PR DESCRIPTION
- The issue was a race condition between checking and killing, now
  we kill first and check after (shoot first, ask after...).
- Added also some more output of process PIDs to simplify debugging
- Closes #109 One or more test in tox.ini is unstable [...]