### PR TITLE
Change directory mode before deleting them

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1173,6 +1173,7 @@ class RPath(RORPath):
 
     def rmdir(self):
         log.Log("Removing directory %s" % self.get_safepath(), 6)
+        self.conn.os.chmod(self.path, 0o700)
         self.conn.os.rmdir(self.path)
         self.data = {'type': None}
 

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -24,10 +24,13 @@ from . import C, metadata, rorpiter, rpath, log
 try:
     from win32security import (
         AdjustTokenPrivileges,
+        DACL_SECURITY_INFORMATION,
         GetTokenInformation,
+        GROUP_SECURITY_INFORMATION,
         INHERIT_ONLY_ACE,
         LookupPrivilegeValue,
         OpenProcessToken,
+        OWNER_SECURITY_INFORMATION,
         SACL_SECURITY_INFORMATION,
         SDDL_REVISION_1,
         SE_BACKUP_NAME,


### PR DESCRIPTION
Apparently, rdiff-backup does not take into account the possibility that folders could not be deletable.
This pull request is about adding a call to os.chmod(), that should render modifiable any directory, before attempting to delete it.

Please note that I only tested this patch under Win32.

A simple use case is with folders with custom icons. When the user sets a custom icon on a folder, Windows also sets the "system" attribute on the folder.

I initially opened PR #39 but then I messed up my repository, so here we are.

The second commit in this PR tries to solve a bug introduced with PR #156, although it is not strictly related to the directory permissions.