### PR TITLE
Fix self imports in connect and iterfile and fix import format

### DIFF
--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -29,7 +29,8 @@ from .log import Log, LoggerError, ErrorLog
 from . import (
     Globals, Time, SetConnections, robust, rpath,
     manage, backup, connection, restore, FilenameMapping,
-    Security, C, statistics, compare)
+    Security, C, statistics, compare
+)
 
 action = None
 create_full_path = None

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -170,7 +170,7 @@ class LowLevelPipeConnection(Connection):
         log.Log.conn("sending", obj, req_num)
         if type(obj) is bytes:
             self._putbuf(obj, req_num)
-        elif isinstance(obj, connection.Connection):
+        elif isinstance(obj, Connection):
             self._putconn(obj, req_num)
         elif isinstance(obj, FilenameMapping.QuotedRPath):
             self._putqrpath(obj, req_num)
@@ -625,10 +625,10 @@ class VirtualFile:
 from . import (  # noqa: E402,F401
     Globals, Time, Rdiff, Hardlink, FilenameMapping, Security,
     Main, rorpiter, selection, increment, statistics, manage,
-    iterfile, rpath, robust, restore, backup, connection,
+    iterfile, rpath, robust, restore, backup,
     TempFile, SetConnections, librsync, log, regress, fs_abilities,
-    eas_acls, user_group, compare)
-
+    eas_acls, user_group, compare
+)
 try:
     from . import win_acls  # noqa: F401
 except ImportError:

--- a/src/rdiff_backup/iterfile.py
+++ b/src/rdiff_backup/iterfile.py
@@ -354,9 +354,9 @@ class MiscIterToFile(FileWrappingIter):
             if hasattr(currentobj, "read") and hasattr(currentobj, "close"):
                 self.currently_in_file = currentobj
                 self.addfromfile(b"f")
-            elif currentobj is iterfile.MiscIterFlush:
+            elif currentobj is MiscIterFlush:
                 return None
-            elif currentobj is iterfile.MiscIterFlushRepeat:
+            elif currentobj is MiscIterFlushRepeat:
                 self.add_misc(currentobj)
                 return None
             elif isinstance(currentobj, rpath.RORPath):
@@ -474,6 +474,3 @@ class ErrorFile:
 
     def close(self):
         return None
-
-
-from . import iterfile  # noqa: E402

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -831,4 +831,5 @@ class PermissionChanger:
 
 from . import (  # noqa: E402
     Globals, Rdiff, Hardlink, selection, rpath,
-    log, robust, metadata, TempFile, hash, longname)
+    log, robust, metadata, TempFile, hash, longname
+)


### PR DESCRIPTION
- connect.py and iterfile.py were importing themselves, which
  didn't make any sense.
- This was discovered with the new graph generator, and some of the
  additional changes are required to ease parsing.