### PR TITLE
Small Ansible fix to follow redirects during librsync build on Windows

### DIFF
--- a/tools/windows/tasks/get-librsync-tarball.yml
+++ b/tools/windows/tasks/get-librsync-tarball.yml
@@ -6,6 +6,8 @@
   win_get_url:
     dest: "{{ librsync_tarfile }}"
     url: "{{ librsync_src_tarfile }}"
+    # the following option exists only with Ansible >= 2.9
+    follow_redirects: "{{ ansible_version.full is version('2.9', '>=') | ternary('all', omit) }}"
 - name: extract librsync sources
   win_unzip:
     dest: "{{ working_dir }}"


### PR DESCRIPTION
Starting with Ansible 2.9 win_get_url expects an option follow_redirects to follow re-directs.
We need it because GitHub release downloads happen through redirects.