### PR TITLE
Add tox config file to generate distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ MANIFEST
 
 # setup.py installation files
 src/rdiff_backup.egg-info/
-
+.eggs/
 
 # Windows build file
 rdiff-backup.spec

--- a/tox_dist.ini
+++ b/tox_dist.ini
@@ -1,0 +1,24 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+# Configuration file for creating binary packages, esp. wheels
+
+[tox]
+envlist = py35, py36, py37, py38
+
+[testenv]
+# make sure those variables are passed down; you should define 
+# either explicitly the RDIFF_TEST_* variables or rely on the current
+# user being correctly identified (which might not happen in a container)
+passenv = RDIFF_TEST_* RDIFF_BACKUP_*
+skip_install = true
+deps =
+    pyxattr
+    pylibacl
+    wheel
+commands_pre =
+    python setup.py clean --all
+commands =
+    python setup.py bdist_wheel


### PR DESCRIPTION
For now can be used to generate wheels for all supported Python versions