### PR TITLE
Add lz4 and lzo extensions to no compression list.

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -197,7 +197,7 @@ compression = 1
 no_compression_regexp_string = (
     b"(?i).*\\.(gz|z|bz|bz2|tgz|zip|rpm|deb|"
     b"jpg|jpeg|gif|png|jp2|mp3|mp4|ogg|avi|wmv|mpeg|mpg|rm|mov|flac|shn|pgp|"
-    b"gpg|rz|lzh|zoo|lharc|rar|arj|asc|vob|mdf)$")
+    b"gpg|rz|lz4|lzh|lzo|zoo|lharc|rar|arj|asc|vob|mdf)$")
 no_compression_regexp = None
 
 # If true, filelists and directory statistics will be split on


### PR DESCRIPTION
no_compression_regexp_string seems to be missing a few compressed file extensions.

lzo for example is used by Proxmox to compress VM backups.