### PR TITLE
Fix selection of overlapping patterns

### DIFF
--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -194,7 +194,7 @@ class Select:
 
         # are the first elements of the path the same?
         if fileindex[:len(self.prefixindex)] != self.prefixindex:
-                    raise FilePrefixError(filename)
+            raise FilePrefixError(filename)
         return fileindex[len(self.prefixindex):]
 
     def listdir(self, dir_rp):

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -41,6 +41,10 @@ class MatchingTest(unittest.TestCase):
         """Test include selection function made from a regular filename"""
         self.assertRaises(FilePrefixError, self.Select.glob_get_filename_sf,
                           b"foo", 1)
+        self.assertRaises(FilePrefixError, self.Select.glob_get_filename_sf,
+                          b"rdiff-backup_testfiles/sel", 1)
+        self.assertRaises(FilePrefixError, self.Select.glob_get_filename_sf,
+                          b"rdiff-backup_testfiles/selection", 1)
 
         sf2 = self.Select.glob_get_sf(
             "rdiff-backup_testfiles/select/usr/local/bin/", 1)
@@ -55,6 +59,10 @@ class MatchingTest(unittest.TestCase):
         """Test exclude selection function made from a regular filename"""
         self.assertRaises(FilePrefixError, self.Select.glob_get_filename_sf,
                           b"foo", 0)
+        self.assertRaises(FilePrefixError, self.Select.glob_get_filename_sf,
+                          b"rdiff-backup_testfiles/sel", 0)
+        self.assertRaises(FilePrefixError, self.Select.glob_get_filename_sf,
+                          b"rdiff-backup_testfiles/selection", 0)
 
         sf2 = self.Select.glob_get_sf(
             "rdiff-backup_testfiles/select/usr/local/bin/", 0)


### PR DESCRIPTION
- closes #137 (thanks to @ilario for the first steps)
- closes #22
- normally selection patterns not relative to the root path lead to an error,
  but 'selection' was accepted for 'select' because they start alike.
- test accordingly added to testing/selection.py