### PR TITLE
Fix Makefile to support current directory name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Currently all steps are run isolated inside a Docker image, but this could
 # be extended to have more options.
-RUN_COMMAND ?= docker run -i -v ${PWD}/..:/build -w /build/rdiff-backup rdiff-backup-dev:debian-sid
+RUN_COMMAND ?= docker run -i -v ${PWD}/..:/build/ -w /build/$(shell basename `pwd`) rdiff-backup-dev:debian-sid
 
 # Define SUDO=sudo if you don't want to run the whole thing as root
 # we set SUDO="sudo -E env PATH=$PATH" if we want to keep the whole environment

--- a/testing/makerestoretest3
+++ b/testing/makerestoretest3
@@ -3,8 +3,10 @@
 # This script will create the testing/restoretest3 directory as it
 # needs to be for one of the tests in restoretest.py to work.
 
-rm -rvf ${PWD}_testfiles/restoretest3
+OLDTESTDIR=$(dirname $0)/../../rdiff-backup_testfiles
+rm -rvf ${OLDTESTDIR}/restoretest3
 for i in 1 2 3 4
 do
-	rdiff-backup --current-time $((i * 10000)) ${PWD}_testfiles/increment${i} ${PWD}_testfiles/restoretest3
+	rdiff-backup --current-time $((i * 10000)) \
+		${OLDTESTDIR}/increment${i} ${OLDTESTDIR}/restoretest3
 done


### PR DESCRIPTION
make fail when the project folder if not named `rdiff-backup`