### PR TITLE
Improve Windows compilation of rdiff-backup

### DIFF
--- a/tools/windows/group_vars/all/librsync.yml
+++ b/tools/windows/group_vars/all/librsync.yml
@@ -1,6 +1,6 @@
 ---
 # Always needed, the version of librsync
-librsync_version: 2.0.2
+librsync_version: 2.2.1
 # where to grab the librsync tarball from
 librsync_src_tarfile: https://github.com/librsync/librsync/releases/download/v{{ librsync_version }}/librsync-{{ librsync_version }}.tar.gz
 

--- a/tools/windows/playbook-build-rdiff-backup.yml
+++ b/tools/windows/playbook-build-rdiff-backup.yml
@@ -15,34 +15,43 @@
         "{{ rdiffbackup_dir }}"
       args:
         creates: "{{ rdiffbackup_dir }}"
-    - name: build rdiff-backup
+    - name: build rdiff-backup and package it as wheel
       win_command: >
-        python.exe setup.py build --librsync-dir="{{ librsync_install_dir }}"
+        python.exe setup.py bdist_wheel --librsync-dir="{{ librsync_install_dir }}"
         --lflags="/NODEFAULTLIB:libcmt.lib msvcrt.lib"
       args:
         chdir: "{{ rdiffbackup_dir }}"
-
-# py2exe doesn't currently work with Python 3.7
-#    - name: compile rdiff-backup into an executable using py2exe
-#      win_command: python.exe setup.py py2exe --single-file
-#      args:
-#        chdir: "{{ rdiffbackup_dir }}"
-
+      register: bdist_wheel
+    - name: find out the name of the wheel package just created
+      set_fact:
+        wheel_pkg: "{{ bdist_wheel.stdout | regex_search('rdiff_backup-[^ ]*.whl') }}"
     - name: compile rdiff-backup into an executable using pyinstaller
       win_command: >
         pyinstaller --onefile
         --paths=build/lib.win-amd64-3.7 --paths={{ librsync_install_dir }}/lib
         --paths={{ librsync_install_dir }}/bin
         --console build/scripts-3.7/rdiff-backup
+        --add-data src/rdiff_backup.egg-info/PKG-INFO;rdiff_backup.egg-info
       environment:
         LIBRSYNC_DIR: "{{ librsync_install_dir }}"
       args:
         chdir: "{{ rdiffbackup_dir }}"
-    - name: fetch the compiled rdiff-backup.exe file into the local dist directory
+    - name: generate a versioned and specific name for the compiled executable
+      set_fact:
+        bin_exe: "{{ wheel_pkg | regex_replace('^rdiff_backup', 'rdiff-backup') | regex_replace('.whl$', '.exe') }}"
+    - name: rename the compiled executable
+      win_shell: >
+        Move-Item -Force
+        -Path {{ rdiffbackup_dir }}/dist/rdiff-backup.exe 
+        -Destination {{ rdiffbackup_dir }}/dist/{{ bin_exe }}
+    - name: fetch generated binary files into the local dist directory
       fetch:
-        src: "{{ rdiffbackup_dir }}/dist/rdiff-backup.exe"
+        src: "{{ rdiffbackup_dir }}/dist/{{ item }}"
         dest: "{{ rdiffbackup_local_dist_dir }}/"
         flat: true  # copy without the directory
+      loop:
+        - "{{ bin_exe }}"
+        - "{{ wheel_pkg }}"
 
     # the following lines are not absolutely necessary but help debugging rdiff-backup
 

--- a/tools/windows/playbook-provision-windows.yml
+++ b/tools/windows/playbook-provision-windows.yml
@@ -34,12 +34,13 @@
       state: present
     # once successful up until here, restart the playbook
   - name: install necessary python libraries
-    win_command: pip.exe install py2exe pywin32 pyinstaller
+    win_command: pip.exe install py2exe pywin32 pyinstaller wheel
     register: pipcmd
-    changed_when:
-      - "'Requirement already satisfied: py2exe' not in pipcmd.stdout"
-      - "'Requirement already satisfied: pywin32' not in pipcmd.stdout"
-      - "'Requirement already satisfied: pyinstaller' not in pipcmd.stdout"
+    changed_when: >
+      'Successfully installed py2exe' in pipcmd.stdout
+      or 'Successfully installed pywin32' in pipcmd.stdout
+      or 'Successfully installed pyinstaller' in pipcmd.stdout
+      or 'Successfully installed wheel' in pipcmd.stdout
     # pylibacl and pyxattr aren't supported under Windows
   - name: validate that python seems to work as it should
     win_shell: "python.exe -c 'import pywintypes, winnt, win32api, win32security, win32file, win32con'"


### PR DESCRIPTION
- make sure rdiff-backup --version outputs a proper version, closes #190
- use version 2.2.1 of librsync (thanks to @ardovm)
- generate a wheel package and make sure binary has a specific versioned name