### PR TITLE
Add `--rm` to docker command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Currently all steps are run isolated inside a Docker image, but this could
 # be extended to have more options.
-RUN_COMMAND ?= docker run -i -v ${PWD}/..:/build/ -w /build/$(shell basename `pwd`) rdiff-backup-dev:debian-sid
+RUN_COMMAND ?= docker run --rm -i -v ${PWD}/..:/build/ -w /build/$(shell basename `pwd`) rdiff-backup-dev:debian-sid
 
 # Define SUDO=sudo if you don't want to run the whole thing as root
 # we set SUDO="sudo -E env PATH=$PATH" if we want to keep the whole environment


### PR DESCRIPTION
To avoid accumulating docker container, add the `--rm` to auto-remove
the container when it exit.