### PR TITLE
Added forgotten SVG file for rdiff-backup logo

### DIFF
--- a/src/rdiff-backup.svg
+++ b/src/rdiff-backup.svg
@@ -1,0 +1,970 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:ooo="http://xml.openoffice.org/svg/export"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   style="fill-rule:evenodd;stroke-width:28.22200012;stroke-linejoin:round"
+   id="svg359"
+   xml:space="preserve"
+   preserveAspectRatio="xMidYMid"
+   viewBox="0 0 13546.666 13546.666"
+   height="512"
+   width="512"
+   version="1.2"><metadata
+   id="metadata363"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata>
+ <defs
+   id="defs8"
+   class="ClipPathGroup">
+  <clipPath
+   clipPathUnits="userSpaceOnUse"
+   id="presentation_clip_path">
+   <rect
+   id="rect2"
+   height="29700"
+   width="21000"
+   y="0"
+   x="0" />
+  </clipPath>
+  <clipPath
+   clipPathUnits="userSpaceOnUse"
+   id="presentation_clip_path_shrink">
+   <rect
+   id="rect5"
+   height="29641"
+   width="20958"
+   y="29"
+   x="21" />
+  </clipPath>
+ </defs>
+ <defs
+   id="defs12"
+   class="TextShapeIndex">
+  <g
+   id="g10"
+   ooo:id-list="id3 id4 id5 id6 id7 id8 id9 id10 id11 id12 id13 id14 id15 id16 id17 id18 id19 id20 id21 id22 id23 id24 id25 id26 id27 id28 id29 id30 id31 id32 id33 id34 id35 id36 id37 id38 id39 id40 id41 id42 id43 id44"
+   ooo:slide="id1" />
+ </defs>
+ <defs
+   id="defs44"
+   class="EmbeddedBulletChars">
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-57356">
+   <path
+   id="path14"
+   d="M 580,1141 1163,571 580,0 -4,571 Z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-57354">
+   <path
+   id="path17"
+   d="M 8,1128 H 1137 V 0 H 8 Z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-10146">
+   <path
+   id="path20"
+   d="M 174,0 602,739 174,1481 1456,739 Z M 1358,739 309,1346 659,739 Z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-10132">
+   <path
+   id="path23"
+   d="M 2015,739 1276,0 H 717 l 543,543 H 174 v 393 h 1086 l -543,545 h 557 z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-10007">
+   <path
+   id="path26"
+   d="m 0,-2 c -7,16 -16,29 -25,39 l 381,530 c -94,256 -141,385 -141,387 0,25 13,38 40,38 9,0 21,-2 34,-5 21,4 42,12 65,25 l 27,-13 111,-251 280,301 64,-25 24,25 c 21,-10 41,-24 62,-43 C 886,937 835,863 770,784 769,783 710,716 594,584 L 774,223 c 0,-27 -21,-55 -63,-84 l 16,-20 C 717,90 699,76 672,76 641,76 570,178 457,381 L 164,-76 c -22,-34 -53,-51 -92,-51 -42,0 -63,17 -64,51 -7,9 -10,24 -10,44 0,9 1,19 2,30 z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-10004">
+   <path
+   id="path29"
+   d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 c 0,78 14,145 41,201 34,71 87,106 158,106 53,0 88,-31 106,-94 l 23,-176 c 8,-64 28,-97 59,-98 l 735,706 c 11,11 33,17 66,17 42,0 63,-15 63,-46 V 965 c 0,-36 -10,-64 -30,-84 L 442,47 C 390,-6 338,-33 285,-33 Z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-9679">
+   <path
+   id="path32"
+   d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 c 0,181 53,324 160,431 106,107 249,161 430,161 179,0 323,-54 432,-161 108,-107 162,-251 162,-431 0,-180 -54,-324 -162,-431 C 1136,54 992,0 813,0 Z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-8226">
+   <path
+   id="path35"
+   d="m 346,457 c -73,0 -137,26 -191,78 -54,51 -81,114 -81,188 0,73 27,136 81,188 54,52 118,78 191,78 73,0 134,-26 185,-79 51,-51 77,-114 77,-187 0,-75 -25,-137 -76,-188 -50,-52 -112,-78 -186,-78 z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-8211">
+   <path
+   id="path38"
+   d="M -4,459 H 1135 V 606 H -4 Z" />
+  </g>
+  <g
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)"
+   id="bullet-char-template-61548">
+   <path
+   id="path41"
+   d="m 173,740 c 0,163 58,303 173,419 116,115 255,173 419,173 163,0 302,-58 418,-173 116,-116 174,-256 174,-419 0,-163 -58,-303 -174,-418 C 1067,206 928,148 765,148 601,148 462,206 346,322 231,437 173,577 173,740 Z" />
+  </g>
+ </defs>
+ <g
+   transform="translate(-1112,4312.6662)"
+   id="g49">
+  <g
+   class="Master_Slide"
+   id="id2">
+   <g
+   class="Background"
+   id="bg-id2" />
+   <g
+   class="BackgroundObjects"
+   id="bo-id2" />
+  </g>
+ </g>
+ <g
+   transform="matrix(1.9346852,0,0,1.9346852,-2151.3699,-4318.2171)"
+   id="g357"
+   class="SlideGroup">
+  <g
+   id="g355">
+   <g
+   id="container-id1">
+    <g
+   clip-path="url(#presentation_clip_path)"
+   class="Slide"
+   id="id1">
+     <g
+   id="g351"
+   class="Page">
+      <g
+   id="g56"
+   class="com.sun.star.drawing.CustomShape">
+       <g
+   id="id3">
+        <rect
+   style="fill:none;stroke:none"
+   id="rect51"
+   height="7001"
+   width="7001"
+   y="2232"
+   x="1112"
+   class="BoundingBox" />
+        <path
+   style="fill:#729fcf;stroke:none"
+   id="path53"
+   d="M 4612,9232 H 1112 V 2232 h 7000 v 7000 z" />
+       </g>
+      </g>
+      <g
+   id="g63"
+   class="com.sun.star.drawing.CustomShape">
+       <g
+   id="id4">
+        <rect
+   style="fill:none;stroke:none"
+   id="rect58"
+   height="7002"
+   width="7002"
+   y="2232"
+   x="1112"
+   class="BoundingBox" />
+        <path
+   style="fill:#0000ff;stroke:none"
+   id="path60"
+   d="m 5943,3232 c -1676,0 -3057,1381 -3057,3000 0,857 -690,1524 -1577,1524 -197,0 -197,0 -197,0 0,1477 0,1477 0,1477 197,0 197,0 197,0 1725,0 3106,-1334 3106,-3001 0,-810 690,-1476 1528,-1476 247,0 247,0 247,0 0,952 0,952 0,952 C 8113,3994 8113,3994 8113,3994 6190,2232 6190,2232 6190,2232 c 0,1000 0,1000 0,1000 z" />
+       </g>
+      </g>
+      <g
+   id="g191"
+   class="Group">
+       <g
+   id="g70"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id5">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect65"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4273"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path67"
+   d="m 7334,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4273 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6211,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5075 V 5541 Z m 160,3061 H 5075 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g77"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id6">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect72"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4273"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path74"
+   d="m 7334,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4273 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6211,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5075 V 5541 Z m 160,3061 H 5075 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g84"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id7">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect79"
+   height="4321"
+   width="3841"
+   y="4912"
+   x="4272"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path81"
+   d="m 7333,6986 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4272 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6210,5542 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5074 V 5542 Z m 160,3061 H 5074 V 7356 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g91"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id8">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect86"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4271"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path88"
+   d="m 7332,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4271 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6209,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5073 V 5541 Z m 160,3061 H 5073 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g98"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id9">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect93"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4271"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path95"
+   d="m 7332,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4271 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6209,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5073 V 5541 Z m 160,3061 H 5073 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g105"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id10">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect100"
+   height="4321"
+   width="3840"
+   y="4910"
+   x="4271"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path102"
+   d="m 7332,6984 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4271 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6209,5540 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5073 V 5540 Z m 160,3061 H 5073 V 7354 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g112"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id11">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect107"
+   height="4321"
+   width="3841"
+   y="4909"
+   x="4272"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path109"
+   d="m 7333,6983 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4272 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6210,5539 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5074 V 5539 Z m 160,3061 H 5074 V 7353 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g119"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id12">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect114"
+   height="4321"
+   width="3840"
+   y="4910"
+   x="4273"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path116"
+   d="m 7334,6984 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4273 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6211,5540 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5075 V 5540 Z m 160,3061 H 5075 V 7354 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g126"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id13">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect121"
+   height="4321"
+   width="3841"
+   y="4911"
+   x="4272"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path123"
+   d="m 7333,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4272 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6210,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5074 V 5541 Z m 160,3061 H 5074 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g133"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id14">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect128"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4273"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path130"
+   d="m 7334,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4273 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6211,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5075 V 5541 Z m 160,3061 H 5075 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g140"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id15">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect135"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4273"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path137"
+   d="m 7334,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4273 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6211,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5075 V 5541 Z m 160,3061 H 5075 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g147"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id16">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect142"
+   height="4321"
+   width="3841"
+   y="4912"
+   x="4272"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path144"
+   d="m 7333,6986 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4272 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6210,5542 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5074 V 5542 Z m 160,3061 H 5074 V 7356 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g154"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id17">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect149"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4271"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path151"
+   d="m 7332,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4271 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6209,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5073 V 5541 Z m 160,3061 H 5073 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g161"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id18">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect156"
+   height="4321"
+   width="3840"
+   y="4911"
+   x="4271"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path158"
+   d="m 7332,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4271 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6209,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5073 V 5541 Z m 160,3061 H 5073 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g168"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id19">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect163"
+   height="4321"
+   width="3840"
+   y="4910"
+   x="4271"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path165"
+   d="m 7332,6984 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4271 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6209,5540 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5073 V 5540 Z m 160,3061 H 5073 V 7354 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g175"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id20">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect170"
+   height="4321"
+   width="3841"
+   y="4909"
+   x="4272"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path172"
+   d="m 7333,6983 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4272 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6210,5539 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5074 V 5539 Z m 160,3061 H 5074 V 7353 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g182"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id21">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect177"
+   height="4321"
+   width="3840"
+   y="4910"
+   x="4273"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path179"
+   d="m 7334,6984 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4273 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6211,5540 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5075 V 5540 Z m 160,3061 H 5075 V 7354 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+       <g
+   id="g189"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id22">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect184"
+   height="4321"
+   width="3841"
+   y="4911"
+   x="4272"
+   class="BoundingBox" />
+         <path
+   style="fill:#ffffff;stroke:none"
+   id="path186"
+   d="m 7333,6985 c 334,-179 556,-506 556,-951 0,-685 -556,-1123 -1593,-1123 H 4272 v 4320 h 2148 c 1111,0 1691,-432 1691,-1172 0,-562 -315,-926 -778,-1074 z M 6210,5541 c 555,0 870,197 870,598 0,395 -315,593 -870,593 H 5074 V 5541 Z m 160,3061 H 5074 V 7355 h 1296 c 605,0 932,191 932,623 0,433 -327,624 -932,624 z" />
+        </g>
+       </g>
+      </g>
+      <g
+   id="g319"
+   class="Group">
+       <g
+   id="g198"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id23">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect193"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1114"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path195"
+   d="M 4805,6554 3811,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1114 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3922,3771 c 0,543 -364,864 -1067,864 H 1916 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g205"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id24">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect200"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1114"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path202"
+   d="M 4805,6554 3811,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1114 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3922,3771 c 0,543 -364,864 -1068,864 H 1916 V 2913 h 938 c 704,0 1068,315 1068,858 z" />
+        </g>
+       </g>
+       <g
+   id="g212"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id25">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect207"
+   height="4321"
+   width="3692"
+   y="2235"
+   x="1113"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path209"
+   d="M 4804,6555 3810,5136 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1113 v 4320 h 802 V 5296 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3921,3772 c 0,543 -364,864 -1067,864 H 1915 V 2914 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g219"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id26">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect214"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1112"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path216"
+   d="M 4803,6554 3809,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1112 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3920,3771 c 0,543 -364,864 -1067,864 H 1914 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g226"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id27">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect221"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1112"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path223"
+   d="M 4803,6554 3809,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1112 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3920,3771 c 0,543 -364,864 -1067,864 H 1914 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g233"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id28">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect228"
+   height="4321"
+   width="3692"
+   y="2233"
+   x="1112"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path230"
+   d="M 4803,6553 3809,5134 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1112 v 4320 h 802 V 5294 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3920,3770 c 0,543 -364,864 -1067,864 H 1914 V 2912 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g240"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id29">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect235"
+   height="4321"
+   width="3692"
+   y="2232"
+   x="1113"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path237"
+   d="M 4804,6552 3810,5133 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1113 v 4320 h 802 V 5293 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3921,3769 c 0,543 -364,864 -1067,864 H 1915 V 2911 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g247"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id30">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect242"
+   height="4321"
+   width="3692"
+   y="2233"
+   x="1114"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path244"
+   d="M 4805,6553 3811,5134 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1114 v 4320 h 802 V 5294 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3922,3770 c 0,543 -364,864 -1068,864 H 1916 V 2912 h 938 c 704,0 1068,315 1068,858 z" />
+        </g>
+       </g>
+       <g
+   id="g254"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id31">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect249"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1113"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path251"
+   d="M 4804,6554 3810,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1113 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3921,3771 c 0,543 -364,864 -1067,864 H 1915 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g261"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id32">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect256"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1114"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path258"
+   d="M 4805,6554 3811,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1114 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3922,3771 c 0,543 -364,864 -1067,864 H 1916 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g268"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id33">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect263"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1114"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path265"
+   d="M 4805,6554 3811,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1114 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3922,3771 c 0,543 -364,864 -1068,864 H 1916 V 2913 h 938 c 704,0 1068,315 1068,858 z" />
+        </g>
+       </g>
+       <g
+   id="g275"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id34">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect270"
+   height="4321"
+   width="3692"
+   y="2235"
+   x="1113"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path272"
+   d="M 4804,6555 3810,5136 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1113 v 4320 h 802 V 5296 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3921,3772 c 0,543 -364,864 -1067,864 H 1915 V 2914 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g282"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id35">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect277"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1112"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path279"
+   d="M 4803,6554 3809,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1112 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3920,3771 c 0,543 -364,864 -1067,864 H 1914 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g289"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id36">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect284"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1112"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path286"
+   d="M 4803,6554 3809,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1112 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3920,3771 c 0,543 -364,864 -1067,864 H 1914 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g296"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id37">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect291"
+   height="4321"
+   width="3692"
+   y="2233"
+   x="1112"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path293"
+   d="M 4803,6553 3809,5134 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1112 v 4320 h 802 V 5294 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3920,3770 c 0,543 -364,864 -1067,864 H 1914 V 2912 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g303"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id38">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect298"
+   height="4321"
+   width="3692"
+   y="2232"
+   x="1113"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path300"
+   d="M 4804,6552 3810,5133 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1113 v 4320 h 802 V 5293 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3921,3769 c 0,543 -364,864 -1067,864 H 1915 V 2911 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+       <g
+   id="g310"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id39">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect305"
+   height="4321"
+   width="3692"
+   y="2233"
+   x="1114"
+   class="BoundingBox" />
+         <path
+   style="fill:#000000;stroke:none"
+   id="path307"
+   d="M 4805,6553 3811,5134 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1114 v 4320 h 802 V 5294 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3922,3770 c 0,543 -364,864 -1068,864 H 1916 V 2912 h 938 c 704,0 1068,315 1068,858 z" />
+        </g>
+       </g>
+       <g
+   id="g317"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id40">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect312"
+   height="4321"
+   width="3692"
+   y="2234"
+   x="1113"
+   class="BoundingBox" />
+         <path
+   style="fill:#ffffff;stroke:none"
+   id="path314"
+   d="M 4804,6554 3810,5135 c 587,-229 920,-710 920,-1364 0,-957 -704,-1537 -1839,-1537 H 1113 v 4320 h 802 V 5295 h 976 c 55,0 111,0 166,-6 l 883,1265 z M 3921,3771 c 0,543 -364,864 -1067,864 H 1915 V 2913 h 939 c 703,0 1067,315 1067,858 z" />
+        </g>
+       </g>
+      </g>
+      <g
+   id="g349"
+   class="Group">
+       <g
+   id="g326"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id41">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect321"
+   height="2125"
+   width="1935"
+   y="6920"
+   x="1417"
+   class="BoundingBox" />
+         <path
+   style="fill:#729fcf;stroke:none"
+   id="path323"
+   d="m 1523,7322 446,393 c -124,1 -239,55 -353,160 -264,247 -281,630 48,937 329,307 745,294 1009,48 126,-118 187,-234 182,-358 l 83,79 413,-377 -1396,-1283 z m 931,1134 c -95,85 -234,90 -366,-34 -134,-125 -129,-253 -34,-338 93,-88 234,-96 368,28 134,124 125,256 32,344 z" />
+        </g>
+       </g>
+       <g
+   id="g333"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id42">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect328"
+   height="1763"
+   width="1923"
+   y="5720"
+   x="2681"
+   class="BoundingBox" />
+         <path
+   style="fill:#729fcf;stroke:none"
+   id="path330"
+   d="m 3268,6242 c 171,-153 179,-336 44,-452 -126,-109 -321,-91 -492,65 -171,156 -179,335 -51,445 129,111 329,96 499,-58 z m 873,1239 462,-416 -1020,-958 -460,420 z" />
+        </g>
+       </g>
+       <g
+   id="g340"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id43">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect335"
+   height="2003"
+   width="1650"
+   y="4256"
+   x="4334"
+   class="BoundingBox" />
+         <path
+   style="fill:#729fcf;stroke:none"
+   id="path337"
+   d="m 5002,4923 c -84,-77 -71,-151 -2,-215 40,-35 92,-62 139,-78 l -187,-374 c -109,35 -241,125 -347,219 -340,306 -351,629 -79,871 l 6,6 -160,145 314,284 159,-145 649,622 488,-438 -649,-621 244,-221 -311,-287 -261,234 z" />
+        </g>
+       </g>
+       <g
+   id="g347"
+   class="com.sun.star.drawing.ClosedBezierShape">
+        <g
+   id="id44">
+         <rect
+   style="fill:none;stroke:none"
+   id="rect342"
+   height="2050"
+   width="1673"
+   y="2774"
+   x="5950"
+   class="BoundingBox" />
+         <path
+   style="fill:#729fcf;stroke:none"
+   id="path344"
+   d="m 6644,3459 c -84,-77 -70,-156 4,-222 43,-37 98,-63 145,-84 l -178,-379 c -110,37 -254,130 -368,230 -361,323 -384,657 -112,900 l 5,4 -172,153 315,287 170,-153 647,628 521,-465 -645,-625 260,-232 -311,-289 -280,248 z" />
+        </g>
+       </g>
+      </g>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>


### PR DESCRIPTION
The logo might not be the nicest but it's the best I could do and is
currently used on GitHub. Anybody with better graphical skills is
welcome to step up and propose something better.