### PR TITLE
Add some info about python and platform to facilitate support

### DIFF
--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -25,6 +25,7 @@ import io
 import tempfile
 import time
 import errno
+import platform
 from .log import Log, LoggerError, ErrorLog
 from . import (
     Globals, Time, SetConnections, robust, rpath,
@@ -250,6 +251,11 @@ def parse_cmdlineoptions(arglist):  # noqa: C901
         else:
             Log.FatalError("Unknown option %s" % opt)
     Log("Using rdiff-backup version %s" % (Globals.version), 4)
+    Log("\twith %s %s version %s" % (
+        sys.implementation.name,
+        sys.executable,
+        platform.python_version()), 4)
+    Log("\ton %s, fs encoding %s" % (platform.platform(), sys.getfilesystemencoding()), 4)
 
 
 def check_action():


### PR DESCRIPTION
With verbosity equal or higher to 4, the information given looks now like this:

```
Using rdiff-backup version 1.4.0b1.dev14+g3451b64
	with cpython /usr/bin/python3 version 3.7.5
	on Linux-5.3.14-300.fc31.x86_64-x86_64-with-fedora-31-Thirty_One, fs encoding utf-8
```

Can someone check how it works under Windows, and other platforms?