### PR TITLE
Change travis config to allow CI runs on specific branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,10 +133,11 @@ matrix:
        - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
        - ls wheelhouse/
 
-# Don't run tests on WIP branches
+# Only run tests (and deploy) on master and specific branches
 branches:
-  except:
-    - /^WIP-.*$/
+  only:
+  - master
+  - /-dodeploy$/
 
 addons:
   apt:


### PR DESCRIPTION
Allow CI only on master and specific branches so that branches
can trigger runs without too many double builds when pull requests
are involved.
See https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests