### PR TITLE
Fix incorrect filename syntax error under Windows

### DIFF
--- a/src/rdiff_backup/FilenameMapping.py
+++ b/src/rdiff_backup/FilenameMapping.py
@@ -143,7 +143,11 @@ class QuotedRPath(rpath.RPath):
 
     def __init__(self, connection, base, index=(), data=None):
         """Make new QuotedRPath"""
-        super().__init__(connection, base, index, data)
+        # we avoid handing over "None" as data so that the parent
+        # class doesn't try to gather data of an unquoted filename
+        # Caution: this works only because RPath checks on "None"
+        #          and its parent RORPath on True/False.
+        super().__init__(connection, base, index, data or False)
         self.quoted_index = tuple(map(quote, self.index))
         # we need to recalculate path and data on the basis of
         # quoted_index (parent class does it on the basis of index)


### PR DESCRIPTION
This error happens when updating a repo created with version 1.2.x
because gathering data was done before quoting the filename containing
a column in the RORPath->RPath->QuotedRPath hierarchy.

Closes #216