### PR TITLE
Remove manylinux1 builds from Travis CI configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,31 +74,6 @@ matrix:
      sudo: required
      services:
        - docker
-     env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-          PLAT=manylinux1_x86_64
-          MAKE_STEP=bdist_wheel
-     install:
-       - docker pull $DOCKER_IMAGE
-     script:
-       - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
-       - ls wheelhouse/
-   - os: linux
-     sudo: required
-     services:
-       - docker
-     env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-          PRE_CMD=linux32
-          PLAT=manylinux1_i686
-          MAKE_STEP=bdist_wheel
-     install:
-       - docker pull $DOCKER_IMAGE
-     script:
-       - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
-       - ls wheelhouse/
-   - os: linux
-     sudo: required
-     services:
-       - docker
      env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
           PLAT=manylinux2010_x86_64
           MAKE_STEP=bdist_wheel


### PR DESCRIPTION
The manylinux2010 build environment builds manylinux1 wheels anyway.

Partially addresses issue #221.