### PR TITLE
refactor travis closes #221

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ jobs:
         - ls dist/
     - os: linux
       language: shell
-      env: MAKE_STEP=build_deb RUN_COMMAND=
+      env: MAKE_STEP=bdist_deb RUN_COMMAND=
       addons:
         apt:
           packages:  # make sure these match debian/control contents

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,7 @@ branches:
   only:
     - master
     - /_$/  # put an underscore at the end of the branch name to force building
+    - /^v\d+\.\d+\.\d+[a-z]?[0-9]?$/  # we need to whitelist tags or nothing will happen
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,7 @@ jobs:
 branches:
   only:
     - master
-    - /[^_]$/  # put an underscore at the end of the branch name to avoid building
+    - /_$/  # put an underscore at the end of the branch name to force building
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       before_deploy:
         - cp CHANGELOG COPYING README.md docs/FAQ.md docs/examples.md docs/DEVELOP.md docs/Windows-README.md build/$vername
         - pushd build
-        - 7z a -tzip ../dist/$vername.zip $vername
+        - 7z a -tzip ../dist/$vername.win32exe.zip $vername
         - popd
     # Build and deploy Linux wheels using manylinux Docker containers
     # avoiding manylinux2014_i686 because it does not provide librsync-devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+---
 language: python
 
 os: linux
 dist: bionic
 
-install: pip3 install --upgrade pip tox pyxattr pylibacl setuptools-scm auditwheel
+install: pip3 install --upgrade pip tox pyxattr pylibacl setuptools-scm
 
 python:
   - 3.5
@@ -14,20 +15,22 @@ python:
 deploy:
   provider: releases
   file_glob: true
-  file: wheelhouse/*.whl
+  file: dist/*.*
   skip_cleanup: true
   draft: true
   token:
     secure: V1Ad29+3lIQB1Sxqt8RiNKwferucTIr2mJo1Ka0m8Y1GdscP0ZkvHN4Vzjb0hts+lap8cU24tJ1zq9k22bdsNmoS3/YEg7fwbQSOPCJSYbjwMQeitDc1NP3u1mp5LWiEnQ7cflalIkmWUVpwGbwPSnUQdW3JyheUm4DP6jndGHmv3sC2r4WtZDkVY44SI5OGjvOTStTLnXhVlwXMIBKzw+o9BNdmIcpRvI3UTR+C9mA2yoNE7qgpzALZ4qn7qAmTMJzcVQb22yVZqXVCF8VD72Z66GHx75aatMmsJ/2isOEap19sVYt03fY8lchsTUsdRRCAIInxUvbdfgaEoBWj8Vfv2r/vm5DgWh93amv1RkJdmAYAMTGZG/k20vd7N+sNGKCdAF0W8hj5kriGkNnSQg7dFd+NWrF3pX9XcUkT9IGzv5eT5eYeS+yzgB3YPy8qGKwF5dRkRf7Ylw68j8YOly40rAAfgEx/pcFlYrJh62LDPr5RNhKA679+9UAp0rgkiszNH327bj1i0drqeDIhJAZSXw86B8tJZI1JRBVllKNbwDc5GRFNyms4+pvKCO+lAy5Pcn0bQMUq49qxDsdnM1t2RISivWy5CdkOTNW5WYglhovOSoA8/NjcxmsOpOazCaENEvsB3AogI+LRmpZ7lUZKxjaILuVUM2rwXlKxFB0=
   on:
+    tags: true
     all_branches: true
-    condition: $MAKE_STEP = bdist_wheel
+    condition: $MAKE_STEP == ?dist*
 
 jobs:
   include:
     # Build and deploy Windows executable
     - os: windows
       language: shell
+      env: MAKE_STEP=bdist_win
       before_install:
         - git clone https://github.com/pyenv-win/pyenv-win.git $HOME/.pyenv
         - export PATH="$HOME/.pyenv/pyenv-win/bin:$HOME/.pyenv/pyenv-win/shims:$PATH"
@@ -51,23 +54,13 @@ jobs:
         - popd
       script:
         - python setup.py bdist
-        - PyInstaller --onefile --distpath dist/win32 --paths=build/lib.win32-$pyverbrief --add-data=src/rdiff_backup.egg-info/PKG-INFO\;rdiff_backup.egg-info --console build/scripts-$pyverbrief/rdiff-backup
+        - vername=rdiff-backup-`python setup.py --version`
+        - PyInstaller --onefile --distpath build/$vername --paths=build/lib.win32-$pyverbrief --add-data=src/rdiff_backup.egg-info/PKG-INFO\;rdiff_backup.egg-info --console build/scripts-$pyverbrief/rdiff-backup
       before_deploy:
-        - cp CHANGELOG COPYING README.md docs/FAQ.md docs/examples.md docs/DEVELOP.md docs/Windows-README.md dist/win32
-        - version=`python setup.py --version`
-        - pushd dist/win32
-        - 7z a -tzip rdiff-backup-$version.zip *
+        - cp CHANGELOG COPYING README.md docs/FAQ.md docs/examples.md docs/DEVELOP.md docs/Windows-README.md build/$vername
+        - pushd build
+        - 7z a -tzip ../dist/$vername.zip $vername
         - popd
-      deploy:
-        provider: releases
-        file_glob: true
-        file: dist/win32/rdiff-backup*.zip
-        skip_cleanup: true
-        draft: true
-        token:
-          secure: V1Ad29+3lIQB1Sxqt8RiNKwferucTIr2mJo1Ka0m8Y1GdscP0ZkvHN4Vzjb0hts+lap8cU24tJ1zq9k22bdsNmoS3/YEg7fwbQSOPCJSYbjwMQeitDc1NP3u1mp5LWiEnQ7cflalIkmWUVpwGbwPSnUQdW3JyheUm4DP6jndGHmv3sC2r4WtZDkVY44SI5OGjvOTStTLnXhVlwXMIBKzw+o9BNdmIcpRvI3UTR+C9mA2yoNE7qgpzALZ4qn7qAmTMJzcVQb22yVZqXVCF8VD72Z66GHx75aatMmsJ/2isOEap19sVYt03fY8lchsTUsdRRCAIInxUvbdfgaEoBWj8Vfv2r/vm5DgWh93amv1RkJdmAYAMTGZG/k20vd7N+sNGKCdAF0W8hj5kriGkNnSQg7dFd+NWrF3pX9XcUkT9IGzv5eT5eYeS+yzgB3YPy8qGKwF5dRkRf7Ylw68j8YOly40rAAfgEx/ pcFlYrJh62LDPr5RNhKA679+9UAp0rgkiszNH327bj1i0drqeDIhJAZSXw86B8tJZI1JRBVllKNbwDc5GRFNyms4+pvKCO+lAy5Pcn0bQMUq49qxDsdnM1t2RISivWy5CdkOTNW5WYglhovOSoA8/NjcxmsOpOazCaENEvsB3AogI+LRmpZ7lUZKxjaILuVUM2rwXlKxFB0=
-        on:
-          all_branches: true
     # Build and deploy Linux wheels using manylinux Docker containers
     # avoiding manylinux2014_i686 because it does not provide librsync-devel
     - os: linux
@@ -81,7 +74,7 @@ jobs:
         - docker pull $DOCKER_IMAGE
       script:
         - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
-        - ls wheelhouse/
+        - ls dist/
     - os: linux
       services:
         - docker
@@ -93,7 +86,7 @@ jobs:
         - docker pull $DOCKER_IMAGE
       script:
         - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
-        - ls wheelhouse/
+        - ls dist/
     - os: linux
       services:
         - docker
@@ -104,24 +97,24 @@ jobs:
         - docker pull $DOCKER_IMAGE
       script:
         - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
-        - ls wheelhouse/
+        - ls dist/
     - os: linux
       language: shell
       env: MAKE_STEP=build_deb RUN_COMMAND=
       addons:
         apt:
-          packages: # make sure these match debian/control contents
-          - build-essential
-          - debhelper-compat
-          - dh-python
-          - fakeroot
-          - git-buildpackage
-          - librsync-dev
-          - python3-all-dev
-          - python3-pylibacl
-          - python3-pyxattr
-          - python3-setuptools
-          - python3-setuptools-scm
+          packages:  # make sure these match debian/control contents
+            - build-essential
+            - debhelper-compat
+            - dh-python
+            - fakeroot
+            - git-buildpackage
+            - librsync-dev
+            - python3-all-dev
+            - python3-pylibacl
+            - python3-pyxattr
+            - python3-setuptools
+            - python3-setuptools-scm
       install:
         - echo "No pip here"
       script:
@@ -129,12 +122,19 @@ jobs:
         - cat ../*.changes
         - mkdir -vp dist
         - cp -v ../*.* dist/
+    - os: linux
+      env: MAKE_STEP=sdist RUN_COMMAND=
+      install:
+        - echo "No pip here"
+      script:
+        - make $MAKE_STEP
+        - ls dist/
 
 # Only run tests (and deploy) on master and specific branches
 branches:
   only:
-  - master
-  - /-dodeploy$/
+    - master
+    - /[^_]$/  # put an underscore at the end of the branch name to avoid building
 
 addons:
   apt:
@@ -142,16 +142,6 @@ addons:
       - librsync-dev
       - libacl1-dev
       - rdiff  # needed by tests in tox.ini
-      - patchelf # needed by auditwheel
-
-
-# We utilize Docker images, thus must have a Docker service
-#services:
-#  - docker
-
-# Build Docker image for development and testing
-#before_script:
-#  - make container
 
 # Each env becomes a separate job. Add more Python versions to have a matrix.
 env:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,11 @@ bdist_wheel:
 	${RUN_COMMAND} ./setup.py bdist_wheel
 	# ${RUN_COMMAND} auditwheel repair dist/*.whl
 
-build_deb:
+sdist:
+	# Prepare wheel for deployment.
+	${RUN_COMMAND} ./setup.py sdist
+
+bdist_deb:
 	${RUN_COMMAND} gbp buildpackage -us -uc
 
 container:

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -8,15 +8,15 @@ yum install -y librsync-devel
 
 # Compile wheels
 for PYBIN in $pybindirs; do
-    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    "${PYBIN}/pip" wheel /io/ -w dist/
 done
 
 # Bundle external shared libraries into the wheels
-for whl in wheelhouse/*.whl; do
-    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/
+for whl in dist/*.whl; do
+    auditwheel repair "$whl" --plat $PLAT -w /io/dist/
 done
 
 # Install packages
 for PYBIN in $pybindirs; do
-    "${PYBIN}/pip" install rdiff-backup --no-index -f /io/wheelhouse
+    "${PYBIN}/pip" install rdiff-backup --no-index -f /io/dist
 done


### PR DESCRIPTION
All the points described in the issue have been addressed and the .travis.yml is even a bit simpler.

I have another branch on-going ericzolf-dev-explain-deploy to document this properly but in a nutshell, the pipeline is only running on pull requests and on branches/tags ending with an underscore (for testing the pipeline) or looking like a version (obviously for releases). Releases are generated only on tagged commits, as draft, so you need to review and publish before it becomes apparent to users (there is one draft currently hanging around for you to check).

Once this MR is merged, I can just push a tag `v1.9.0b0` and the next beta release will be automatically created.