### PR TITLE
metadata: handle unknown group ids from file system

### DIFF
--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -236,7 +236,7 @@ def Record2RORP(record_string):
             else:
                 data_dict['uname'] = data.decode()
         elif field == "Gname":
-            if data == ':' or data == 'None':
+            if data == b':' or data == b'None':
                 data_dict['gname'] = None
             else:
                 data_dict['gname'] = data.decode()


### PR DESCRIPTION
an unknown group id did cause all files to be backed up every time
due to an invalid comparison.
When saving metadata 'None' was converted to ":", but when reading
":" was not converted back to 'None'.