### PR TITLE
fix invalid type in ea.read_from_rp()

### DIFF
--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -77,6 +77,8 @@ class ExtendedAttributes:
                 return
             raise
         for attr in attr_list:
+            if isinstance(attr, str):
+                attr = bytes(attr, 'utf-8')
             if attr.startswith(b'system.'):
                 # Do not preserve system extended attributes
                 continue


### PR DESCRIPTION
TypeError: startswith first arg must be str or a tuple of str, not bytes
Not sure if thisis dependent of the used xattr package, so just convert
it to bytes if it is a string.