### PR TITLE
Fix some more ugly bytes output in strings using _safe_str

### DIFF
--- a/src/rdiff-backup-statistics
+++ b/src/rdiff-backup-statistics
@@ -78,13 +78,13 @@ def parse_args():
         os.path.join(os.fsencode(args[0]), b"rdiff-backup-data"),
     )
     if not Globals.rbdir.isdir():
-        sys.exit("Directory %a not found" % (Globals.rbdir.path,))
+        sys.exit("Directory %s not found" % (Globals.rbdir.get_safepath(),))
 
 
 def system(cmd):
     sys.stdout.flush()
     if os.system(cmd):
-        sys.exit("Error running command '%a'\n" % (cmd,))
+        sys.exit("Error running command '%s'\n" % _safe_str(cmd))
 
 
 class StatisticsRPaths:
@@ -125,7 +125,7 @@ class StatisticsRPaths:
                 result.append((session_dict[time], filestat_dict[time]))
             else:
                 sys.stderr.write(
-                    "No file_statistics to match %a\n" % (session_dict[time].path,)
+                    "No file_statistics to match '%s'\n" % session_dict[time].get_safepath()
                 )
         return result
 
@@ -284,7 +284,7 @@ def make_fst(session_rp, filestat_rp):
                 continue
             match = r.match(line)
             if not match:
-                sys.stderr.write("Error parsing line: %a\n" % (line,))
+                sys.stderr.write("Error parsing line: %s\n" % _safe_str(line))
                 continue
 
             filename = match.group(1)
@@ -519,6 +519,14 @@ def set_chars_to_quote():
         Globals.must_escape_dos_devices = 0  # No DOS devices will be present
         FilenameMapping.set_init_quote_vals()
         Globals.rbdir = FilenameMapping.get_quotedrpath(Globals.rbdir)
+
+
+def _safe_str(cmd):
+    """Transform bytes into string without risk of conversion error"""
+    if isinstance(cmd, str):
+        return cmd
+    else:
+        return str(cmd, errors='replace')
 
 
 def Main():

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -151,7 +151,7 @@ def fill_schema(host_info):
     try:
         return __cmd_schema % host_info
     except TypeError:
-        Log.FatalError("Invalid remote schema:\n\n%a\n" % __cmd_schema)
+        Log.FatalError("Invalid remote schema:\n\n%s\n" % _safe_str(__cmd_schema))
 
 
 def init_connection(remote_cmd):
@@ -165,7 +165,7 @@ def init_connection(remote_cmd):
     if not remote_cmd:
         return Globals.local_connection
 
-    Log("Executing %a" % remote_cmd, 4)
+    Log("Executing %s" % _safe_str(remote_cmd), 4)
     try:
         # we need buffered read on SSH communications, hence using
         # default value for bufsize parameter
@@ -196,13 +196,13 @@ def check_connection_version(conn, remote_cmd):
 
 Couldn't start up the remote connection by executing
 
-    %a
+    %s
 
 Remember that, under the default settings, rdiff-backup must be
 installed in the PATH on the remote system.  See the man page for more
 information on this.  This message may also be displayed if the remote
 version of rdiff-backup is quite different from the local version (%s).""" %
-                       (exception, remote_cmd, Globals.version))
+                       (exception, _safe_str(remote_cmd), Globals.version))
     except OverflowError:
         Log.FatalError(
             """Integer overflow while attempting to establish the
@@ -213,10 +213,11 @@ remote connection by executing
 Please make sure that nothing is printed (e.g., by your login shell) when this
 command executes. Try running this command:
 
-    %a
+    %s
 
 which should only print out the text: rdiff-backup <version>""" %
-            (remote_cmd, remote_cmd.replace(b"--server", b"--version")))
+            (_safe_str(remote_cmd),
+             _safe_str(remote_cmd.replace(b"--server", b"--version"))))
 
     if remote_version != Globals.version:
         Log(
@@ -320,3 +321,11 @@ and 0.13.3, nor 0.13.2 and 0.13.4.
 """ % (Globals.version, version))
     else:
         print("Server OK")
+
+
+def _safe_str(cmd):
+    """Transform bytes into string without risk of conversion error"""
+    if isinstance(cmd, str):
+        return cmd
+    else:
+        return str(cmd, errors='replace')

--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -236,8 +236,16 @@ class ExtendedAttributesFile(metadata.FlatFile):
 
 def join_ea_iter(rorp_iter, ea_iter):
     """Update a rorp iter by adding the information from ea_iter"""
+
+    def _safe_str(cmd):
+        """Transform bytes into string without risk of conversion error"""
+        if isinstance(cmd, str):
+            return cmd
+        else:
+            return str(cmd, errors='replace')
+
     for rorp, ea in rorpiter.CollateIterators(rorp_iter, ea_iter):
-        assert rorp, "Missing rorp for index %a" % (ea.index, )
+        assert rorp, "Missing rorp for index '%s'." % _safe_str(ea.index)
         if not ea:
             ea = ExtendedAttributes(rorp.index)
         rorp.set_ea(ea)

--- a/src/rdiff_backup/longname.py
+++ b/src/rdiff_backup/longname.py
@@ -106,7 +106,7 @@ def get_next_free():
         free_name_counter = scan_next_free()
     filename = b'%i' % free_name_counter
     rp = get_long_rp(filename)
-    assert not rp.lstat(), "Unexpected file at %a found" % (rp.path, )
+    assert not rp.lstat(), "Unexpected file at '%s' found" % rp.get_safepath()
     free_name_counter += 1
     write_next_free(free_name_counter)
     return filename
@@ -267,11 +267,18 @@ def get_inclist(inc_base_name):
 def update_rf(rf, rorp, mirror_root):
     """Return new or updated restorefile based on alt name info in rorp"""
 
+    def _safe_str(cmd):
+        """Transform bytes into string without risk of conversion error"""
+        if isinstance(cmd, str):
+            return cmd
+        else:
+            return str(cmd, errors='replace')
+
     def update_incs(rf, inc_base):
         """Swap inclist in rf with those with base inc_base and return"""
         log.Log(
-            "Restoring with increment base %a for file %s" %
-            (inc_base, rorp.get_safeindexpath()), 6)
+            "Restoring with increment base %s for file %s" %
+            (_safe_str(inc_base), rorp.get_safeindexpath()), 6)
         rf.inc_rp = get_long_rp(inc_base)
         rf.inc_list = get_inclist(inc_base)
         rf.set_relevant_incs()

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -145,7 +145,7 @@ def copy(rpin, rpout, compress=0):
     elif rpin.issock():
         rpout.mksock()
     else:
-        raise RPathException("File %a has unknown type" % rpin.path)
+        raise RPathException("File '%s' has unknown type." % rpin.get_safepath())
 
 
 def copy_reg_file(rpin, rpout, compress=0):

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -709,11 +709,19 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
 
     def glob_get_prefix_res(self, glob_str):
         """Return list of regexps equivalent to prefixes of glob_str"""
+
+        def _safe_str(cmd):
+            """Transform bytes into string without risk of conversion error"""
+            if isinstance(cmd, str):
+                return cmd
+            else:
+                return str(cmd, errors='replace')
+
         glob_parts = glob_str.split(b"/")
         if b"" in glob_parts[1:
                              -1]:  # "" OK if comes first or last, as in /foo/
             raise GlobbingError(
-                "Consecutive '/'s found in globbing string %a" % glob_str)
+                "Consecutive '/'s found in globbing string %s" % _safe_str(glob_str))
 
         prefixes = [
             b"/".join(glob_parts[:i + 1]) for i in range(len(glob_parts))

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -230,10 +230,18 @@ class ACL:
         return os.fsdecode(self.__bytes__())
 
     def from_string(self, acl_str):
+
+        def _safe_str(cmd):
+            """Transform bytes into string without risk of conversion error"""
+            if isinstance(cmd, str):
+                return cmd
+            else:
+                return str(cmd, errors='replace')
+
         lines = acl_str.splitlines()
         if len(lines) != 2 or not lines[0][:8] == b"# file: ":
             raise metadata.ParsingError(
-                "Bad record beginning: %a" % lines[0][:8])
+                "Bad record beginning: %s" % _safe_str(lines[0][:8]))
         filename = lines[0][8:]
         if filename == b'.':
             self.index = ()


### PR DESCRIPTION
FIX: remove some more ugly bytes output in strings using _safe_str, closes #238

The function _safe_str is for now a local workaround, which I'd like to move to the Log object at a later stage and avoid having this function all over the place.