### PR TITLE
Restrict flake8 call in tox.ini to relevant files/dirs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands =
 deps =
     flake8
 commands =
-    flake8 .
+    flake8 setup.py src testing tools
 
 [flake8]
 ignore =


### PR DESCRIPTION
Else it might be that flake8 chokes on foreign code installed via
dependencies (happened to me once), and it should go very slightly
faster.
DEV: flake8 checks only setup.py, src, testing and tools code.