### PR TITLE
Add workaround because Popen doesn't accept byte commands on Windows

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -169,11 +169,19 @@ def init_connection(remote_cmd):
     try:
         # we need buffered read on SSH communications, hence using
         # default value for bufsize parameter
-        process = subprocess.Popen(
-            remote_cmd,
-            shell=True,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE)
+        if os.name == 'nt':
+            # FIXME workaround because python 3.7 doesn't yet accept bytes
+            process = subprocess.Popen(
+                os.fsdecode(remote_cmd),
+                shell=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE)
+        else:
+            process = subprocess.Popen(
+                remote_cmd,
+                shell=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE)
         (stdin, stdout) = (process.stdin, process.stdout)
     except OSError:
         (stdin, stdout) = (None, None)


### PR DESCRIPTION
FIX: avoid int is not iterable error when calling remote command on Windows
Closes #260

I didn't have time to test, if someone finds the time...