### PR TITLE
Remove Debian packages from deploy to GitHub to avoid confusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,10 +170,10 @@ jobs:
         - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
         - ls dist/
 
-    #--- Build and deploy Debian packages ---
+    #--- Build Debian packages ---
     - os: linux
       language: shell
-      env: MAKE_STEP=bdist_deb RUN_COMMAND=
+      env: MAKE_STEP=dist_deb RUN_COMMAND=
       addons:
         apt:
           packages:  # make sure these match debian/control contents
@@ -193,8 +193,6 @@ jobs:
       script:
         - make $MAKE_STEP
         - cat ../*.changes
-        - mkdir -vp dist
-        - cp -v ../*.* dist/
 
     #--- Build and deploy Debian packages ---
     - os: linux

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ sdist:
 	# Prepare wheel for deployment.
 	${RUN_COMMAND} ./setup.py sdist
 
-bdist_deb:
+dist_deb:
 	${RUN_COMMAND} debian/autobuild.sh
 
 container:


### PR DESCRIPTION
FIX: remove too specific Debian packages from GitHub deployment, closes #263
The Debian target has been renamed so that we can keep the generic target
pattern for future distributable targets ({one letter}dist{whatever}).