### PR TITLE
FIX: do not fail when starting with uid/gid equal to maximum

### DIFF
--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -180,7 +180,7 @@ class FSAbilities:
         tmp_rp.touch()
         uid, gid = tmp_rp.getuidgid()
         try:
-            tmp_rp.chown(uid + 1, gid + 1)  # just choose random uid/gid
+            tmp_rp.chown(uid // 2 + 1, gid // 2 + 1)  # just choose random uid/gid
             tmp_rp.chown(0, 0)
         except (IOError, OSError, AttributeError):
             self.ownership = 0


### PR DESCRIPTION
Closes https://savannah.nongnu.org/bugs/?31624
A "random" uid/gid was generated by adding 1 to the current uid/gid
which would fail if one of them is equal to the maximum possible
(might apparently happen under MacOS), now half of the id is taken
and one added (to avoid 0).