### PR TITLE
Prepare release of version v1.9.2rc0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+New in v1.9.2rc0 (2020-03-08)
+-----------------------------
+
+## Changes
+
+* FIX: UpdateError: Updated mirror temp file does not match source, Closes #237
+* CHG: Add new logo and improve visual appeal of the README (Closes: #286) (#287)
+* NEW: Add Windows developments documentations, closes #220
+* FIX: do not fail when starting with uid/gid equal to maximum, avoid OverflowError on os.chown
+
+## Authors
+
+* Eric L
+* Patrik Dufresne
+* zjw
+
 New in v1.9.1b0 (2020-02-23)
 ----------------------------
 

--- a/tools/get_changelog_since.sh
+++ b/tools/get_changelog_since.sh
@@ -9,7 +9,7 @@ then
 fi
 RELTAG="${1}"
 
-echo "(make sure the version is the next correct one)"
+echo "(make sure the version is the next correct one)" >&2
 echo
 echo "New in v$($(dirname $0)/../setup.py --version) ($(date -I))"
 echo "----------------------------"


### PR DESCRIPTION
Extend changelog and send warning to stderr instead of stdout.