### PR TITLE
bytestotime() should return None on decode failure (issue #295)

### DIFF
--- a/src/rdiff_backup/Time.py
+++ b/src/rdiff_backup/Time.py
@@ -120,7 +120,10 @@ def stringtotime(timestring):
 
 
 def bytestotime(timebytes):
-    return stringtotime(timebytes.decode('ascii'))
+    try:
+        return stringtotime(timebytes.decode('ascii'))
+    except UnicodeDecodeError:
+        return None
 
 
 def timetopretty(timeinseconds):

--- a/testing/timetest.py
+++ b/testing/timetest.py
@@ -35,6 +35,15 @@ class TimeTest(unittest.TestCase):
         assert cmp("2001-09-01T12:00:00-08:00",
                    "2001-09-01T12:00:00-07:00") == 1
 
+    def testBytestotime(self):
+        """Test converting byte string to time"""
+        timesec = int(time.time())
+        assert timesec == int(Time.bytestotime(Time.timetostring(timesec).encode('ascii')))
+
+        # assure that non-ascii byte strings return None and that they don't
+        # throw an exception (issue #295)
+        assert Time.bytestotime(b'\xff') is None
+
     def testStringtotime(self):
         """Test converting string to time"""
         timesec = int(time.time())


### PR DESCRIPTION
The function may be called with arbitrary non-ascii byte strings.  In such
cases it should return None without throwing a UnicodeDecodeError exception.