### PR TITLE
Fix overlap source target 296

### DIFF
--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -584,15 +584,18 @@ def backup_warn_if_infinite_regress(rpin, rpout):
         return
 
     relative_rpout_comps = tuple(rpout.path[len(rpin.path) + 1:].split(b'/'))
-    relative_rpout = rpin.new_index(relative_rpout_comps)
-    if not Globals.select_mirror.Select(relative_rpout):
-        return
+    relative_rpout = rpin.new_index(relative_rpout_comps)  # noqa: F841
+    # FIXME: this fails currently because the selection object isn't stored
+    #        but an iterable, the object not being pickable.
+    #        Related to issue #296
+    #if not Globals.select_mirror.Select(relative_rpout):  # noqa: E265
+    #    return
 
     Log(
         """Warning: The destination directory '%s' may be contained in the
 source directory '%s'.  This could cause an infinite regress.  You
-may need to use the --exclude option.""" % (rpout.get_safepath(),
-                                            rpin.get_safepath()), 2)
+may need to use the --exclude option (which you might already have done)."""
+        % (rpout.get_safepath(), rpin.get_safepath()), 2)
 
 
 def backup_get_mirrortime():

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -485,6 +485,27 @@ class CommandTest(unittest.TestCase):
         outempty = outrp.append('emptydir')
         assert outempty.isdir(), outempty
 
+    def test_overlapping_dirs(self):
+        """Test if we can backup a directory containing the backup repo
+        while ignoring this repo"""
+
+        testrp = rpath.RPath(Globals.local_connection,
+                             abs_test_dir).append('selection_overlap')
+        re_init_rpath_dir(testrp)
+        backuprp = testrp.append('backup')
+        emptyrp = testrp.append('empty')  # just to have something to backup
+        emptyrp.mkdir()
+
+        rdiff_backup(1,
+                     1,
+                     testrp.path,
+                     backuprp.path,
+                     extra_options=b"--exclude %s" % backuprp.path)
+
+        assert backuprp.append('rdiff-backup-data').isdir() and \
+               backuprp.append('empty').isdir(), \
+               "Backup to %s didn't happen properly." % backuprp.getsafepath()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -503,8 +503,8 @@ class CommandTest(unittest.TestCase):
                      extra_options=b"--exclude %s" % backuprp.path)
 
         assert backuprp.append('rdiff-backup-data').isdir() and \
-               backuprp.append('empty').isdir(), \
-               "Backup to %s didn't happen properly." % backuprp.getsafepath()
+            backuprp.append('empty').isdir(), \
+            "Backup to %s didn't happen properly." % backuprp.getsafepath()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
So shortly before release, I only dared to come with a minimal invasive workaround, I'll fix it more correctly for the next release.

The underlying issue is that select_mirror can't contain a selection object because it isn't pickable, but the function Select can't be called on a selection iterable, so it's a bit of a catch 22.

I also added a test case to the selection tests.

FIX: add workaround to avoid error when backup directory is under the source directory (see issue #296), there is a warning but the backup can succeed.
DEV: add test to backup to a repo within the source directory