### PR TITLE
NEW: add support for Python 3.9 (alpha release).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 
 #=== DEPLOYMENTS ===
 # - everything to GitHub releases

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # Use tox_slow.ini for longer running tests.
 
 [tox]
-envlist = py35, py36, py37, py38, flake8
+envlist = py35, py36, py37, py38, py39, flake8
 
 [testenv]
 # make sure those variables are passed down; you should define 

--- a/tox_dist.ini
+++ b/tox_dist.ini
@@ -6,7 +6,7 @@
 # Configuration file for creating binary packages, esp. wheels
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py35, py36, py37, py38, py39
 
 [testenv]
 # make sure those variables are passed down; you should define 

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -8,7 +8,7 @@
 # Use tox_slow.ini for longer running tests and tox.ini for normal tests.
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py35, py36, py37, py38, py39
 # some directories to avoid creating files with root rights that
 # couldn't be overwritten by the non-root tests:
 toxworkdir = {toxinidir}/.tox.root

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -7,7 +7,7 @@
 # Call with `tox -c tox_slow.ini`
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py35, py36, py37, py38, py39
 
 [testenv]
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*


### PR DESCRIPTION
Even if Python 3.9 is still an alpha version, we should start testing it to avoid issues