### PR TITLE
Validate set_resource_fork_readwrite with bytes instead of str

### DIFF
--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -517,7 +517,7 @@ class FSAbilities:
         reg_rp = dir_rp.append('regfile')
         reg_rp.touch()
 
-        s = 'test string---this should end up in resource fork'
+        s = b'test string---this should end up in resource fork'
         try:
             fp_write = open(
                 os.path.join(reg_rp.path, b'..namedfork', b'rsrc'), 'wb')

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -115,7 +115,7 @@ def RORP2Record(rorpath):
         # If there is a resource fork, save it.
         if rorpath.has_resource_fork():
             if not rorpath.get_resource_fork():
-                rf = "None"
+                rf = b"None"
             else:
                 rf = binascii.hexlify(rorpath.get_resource_fork())
             str_list.append(b"  ResourceFork %b\n" % (rf, ))
@@ -202,7 +202,7 @@ def Record2RORP(record_string):
             data_dict['size'] = int(data)
         elif field == "ResourceFork":
             if data == b"None":
-                data_dict['resourcefork'] = ""
+                data_dict['resourcefork'] = b""
             else:
                 data_dict['resourcefork'] = binascii.unhexlify(data)
         elif field == "CarbonFile":

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1688,11 +1688,11 @@ class RPath(RORPath):
         except KeyError:
             try:
                 rfork_fp = self.conn.open(
-                    os.path.join(self.path, '..namedfork', 'rsrc'), 'rb')
+                    os.path.join(self.path, b'..namedfork', b'rsrc'), 'rb')
                 rfork = rfork_fp.read()
                 assert not rfork_fp.close()
             except (IOError, OSError):
-                rfork = ''
+                rfork = b''
             self.data['resourcefork'] = rfork
         return rfork
 
@@ -1700,7 +1700,7 @@ class RPath(RORPath):
         """Write new resource fork to self"""
         log.Log("Writing resource fork to %s" % (self.index, ), 7)
         fp = self.conn.open(
-            os.path.join(self.path, '..namedfork', 'rsrc'), 'wb')
+            os.path.join(self.path, b'..namedfork', b'rsrc'), 'wb')
         fp.write(rfork_data)
         assert not fp.close()
         self.set_resource_fork(rfork_data)


### PR DESCRIPTION
FIX: avoid bytes/str object issue under MacOS/X while checking forks FS abilities, closes #320

Without ability to test on MacOS, I can't tell for sure that it fixes the issue (and even less that it fixes all issues), but it should take the first hurdle.