### PR TITLE
Update issue templates to better fit rdiff-backup's needs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+## Bug summary
+
+A clear and concise description of what the bug is.
+
+## Version, Python, Operating System
+
+Call `rdiff-backup -v9` and paste the output between the backquotes below, repeat for each environment impacted:
+
+```
+```
+
+## rdiff-backup call
+
+How did you call rdiff-backup, with which parameter:
+
+```
+```
+
+## What happened and what did you expect?
+
+
+## More information
+
+If you can, please repeat the action leading to the error, adding the option `-v9` and attach the output to this bug report.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[ENH] "
+labels: ''
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
I'd like to have a bug and an enhancement template for new issues.