### PR TITLE
WIP: Address duplicate timestamps in metadata mirror files

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -175,6 +175,12 @@ escape_trailing_spaces = os.name == 'nt'
 # don't need to be escaped on Windows.
 use_compatible_timestamps = 0
 
+# Normally there shouldn't be any case of duplicate timestamp but it seems
+# we had the issue at some point in time, hence we need the flag to allow
+# users to clean up their repository. The default is to abort on such cases.
+
+allow_duplicate_timestamps = False
+
 # If true, emit output intended to be easily readable by a
 # computer.  False means output is intended for humans.
 parsable_output = None

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -67,6 +67,7 @@ def parse_cmdlineoptions(arglist):  # noqa: C901
 
     try:
         optlist, args = getopt.getopt(arglist, "blr:sv:V", [
+            "allow-duplicate-timestamps",
             "backup-mode", "calculate-average", "carbonfile",
             "check-destination-dir", "compare", "compare-at-time=",
             "compare-hash", "compare-hash-at-time=", "compare-full",
@@ -235,6 +236,8 @@ def parse_cmdlineoptions(arglist):  # noqa: C901
             action = "test-server"
         elif opt == "--use-compatible-timestamps":
             Globals.set("use_compatible_timestamps", 1)
+        elif opt == "--allow-duplicate-timestamps":
+            Globals.set("allow_duplicate_timestamps", True)
         elif opt == "--user-mapping-file":
             user_mapping_filename = os.fsencode(arg)
         elif opt == "-v" or opt == "--verbosity":

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -726,8 +726,33 @@ class PatchDiffMan(Manager):
         if prefix not in self.prefixmap:
             return []
         sortlist = [(rp.getinctime(), rp) for rp in self.prefixmap[prefix]]
-        sortlist.sort()
-        sortlist.reverse()
+
+        # we sort before we validate against duplicates so that we tell
+        # first about the youngest case of duplication
+        sortlist.sort(reverse=True, key=lambda x: x[0])
+
+        # we had cases where the timestamp of the metadata files were
+        # duplicates, we need to fail or at least warn about such cases
+        unique_set = set()
+        for (time, rp) in sortlist:
+            if time in unique_set:
+                if Globals.allow_duplicate_timestamps:
+                    log.Log("Warning: metadata file '%s' has a duplicate "
+                            "timestamp date, you might not be able to "
+                            "recover files on or earlier than this date. "
+                            "Assuming you're in the process of cleaning your "
+                            "repository." %
+                            rp.getsafepath(), 2)
+                else:
+                    log.FatalError("Metadata file '%s' has a duplicate "
+                                   "timestamp date, you might not be able to "
+                                   "recover files on or earlier than this date. "
+                                   "You should clean your repository using "
+                                   "e.g. the '--remove-older-than' option." %
+                                   rp.getsafepath())
+            else:
+                unique_set.add(time)
+
         return [rp for (time, rp) in sortlist if time >= min_time]
 
     def check_needs_diff(self):


### PR DESCRIPTION
FIX: fail with meaningful error message on metadata mirror files with duplicate timestamps, closes #322
NEW: option --allow-duplicate-timestamps to only warn about duplicate timestamps in metadata mirror files, use this option with care and only to clean an impacted backup repository.

I still need to add a test for this and document the new option in the manpage and in the completion files.