### PR TITLE
Improve the PR #328 based on feedback from zjw

### DIFF
--- a/docs/rdiff-backup.1
+++ b/docs/rdiff-backup.1
@@ -64,9 +64,13 @@ out the examples.html file included in the rdiff-backup distribution.
 .TP
 .B \-\-allow-duplicate-timestamps
 This option is only to be used if you encounter the issue of metadata
-mirrors with the the same timestamp. In such cases, you may use this flag
-to overcome the error, which becomes a warning, and clean-up the repository,
-e.g. using the "\-\-remove-older-than" parameter.
+mirrors with the same timestamp. In such cases, you may use this flag
+to first recover from the failed backup with something like
+.B rdiff-backup \-\-allow-duplicate-timestamps \-\-check-destination-dir <targetdir>
+after which you will need to remove those old duplicate entries
+using the
+.B \-\-remove-older-than
+parameter.
 .TP
 .B \-b, \-\-backup-mode
 Force backup mode even if first argument appears to be an increment or

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -740,16 +740,16 @@ class PatchDiffMan(Manager):
                     log.Log("Warning: metadata file '%s' has a duplicate "
                             "timestamp date, you might not be able to "
                             "recover files on or earlier than this date. "
-                            "Assuming you're in the process of cleaning your "
-                            "repository." %
+                            "Assuming you're in the process of cleaning up "
+                            "your repository." %
                             rp.get_safepath(), 2)
                 else:
                     log.Log.FatalError(
                         "Metadata file '%s' has a duplicate timestamp date, "
                         "you might not be able to recover files on or earlier "
                         "than this date. "
-                        "You should clean your repository using "
-                        "e.g. the '--remove-older-than' option." %
+                        "Check the man page on how to clean up your repository "
+                        "using the '--allow-duplicate-timestamps' option." %
                         rp.get_safepath())
             else:
                 unique_set.add(time)

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands =
     python testing/restoretest.py
     python testing/cmdlinetest.py
     python testing/rdiffbackupdeletetest.py
+    python testing/errorsrecovertest.py
 # can only work on OS/X TODO later
 #    python testing/resourceforktest.py
 


### PR DESCRIPTION
- re-write the tests to take into consideration that --remove-older-than doesn't need --allow-duplicate-timestamps
- improve the error message and the man-page also accordingly
- make the tests also slightly more robust, sorting entry and using date instead of number of backups