### PR TITLE
Fix and improve automated installation of Windows dev VM

### DIFF
--- a/tools/windows/README.md
+++ b/tools/windows/README.md
@@ -2,12 +2,41 @@
 
 ## Create the Windows VM
 
-Starting from https://github.com/redhat-cop/automate-windows/tree/master/vagrant-libvirt-image, create a Windows VM
-usable by Ansible (any other alternative approach to a such VM is of course valid).
+A simple `vagrant up` should do, using a default Windows image, and you'll get
+in the best case a fully workable rdiff-backup development environment on Windows.
 
-Then apply the playbook playbook-provision-windows.yml using Ansible to the Windows you've just created to create the necessary development environment (a `vagrant up` resp. `vagrant provision` in the current directory might be sufficient).
+> **NOTE:** Starting from https://github.com/redhat-cop/automate-windows/tree/master/vagrant-libvirt-image,
+>	you can create your own Windows VM usable by Ansible (any other alternative
+>	approach to a such VM is of course valid).
+
+You can re-apply the changes using `vagrant provision` or direcly apply the
+playbook `playbook-provision-windows.yml` using Ansible to the Windows you've
+just created to create the necessary development environment.
 
 > **IMPORTANT:** The current state of the automation isn't very satisfying, the more complex packages need to be installed manually from the command line with something like `choco install <packagename>` and the playbook restarted. A few reboots in-between might be necessary.
+
+If you already have a Windows VM/PC/laptop/server, you'd like to use for
+rdiff-backup development, you don't need to use Vagrant, you can directly
+use Ansible:
+
+1. Make your [Windows host ready for Ansible](https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html).
+2. Create an inventory that looks as after this list.
+3. Call directly the provisioning playbook
+   `ansible-playbook -i YOURINVENTORYFILE playbook-provision-windows.yml`.
+
+Your inventory should look as follows, depending on your exact Windows setup,
+replacing at least the `MY*` placeholders (some level of Ansible knowledge
+doesn't hurt here):
+
+```
+[windows_ansible]
+MYWINDOWSHOST ansible_host=192.168.1.MYIP ansible_user='MYUSER' ansible_password='MYPASSWORD'
+
+[windows_ansible:vars]
+ansible_connection=winrm
+ansible_port=5986
+ansible_winrm_server_cert_validation=ignore
+```
 
 ## Build librsync and rdiff-backup
 
@@ -66,3 +95,8 @@ Those two settings didn't work as expected and made boot resp. network fail:
 ### Chocolatey
 
 The logs of Chocolatey are available under `C:\ProgramData\chocolatey\logs` and `C:\Users\IEUser\AppData\Local\Temp\chcolatey`.
+
+At some point in time, the VS Code packaging for the VC workload was broken and
+the only solution was to call _as administrator_ from the command line in the
+Windows VM
+`C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools" --includeRecommended --norestart --quiet --add Microsoft.VisualStudio.Workload.VCTools`.

--- a/tools/windows/README.md
+++ b/tools/windows/README.md
@@ -46,6 +46,8 @@ ansible_port=5986
 ansible_winrm_server_cert_validation=ignore
 ```
 
+> **TIP:** with the newest version of Windows, you can even connect to the VM using SSH e.g. with `vagrant ssh`.
+
 ## Build librsync and rdiff-backup
 
 It can be as easy as calling twice ansible-playbook:
@@ -108,3 +110,10 @@ At some point in time, the VS Code packaging for the VC workload was broken and
 the only solution was to call _as administrator_ from the command line in the
 Windows VM
 `C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools" --includeRecommended --norestart --quiet --add Microsoft.VisualStudio.Workload.VCTools`.
+
+### Cygwin
+
+You can install new Cygwin packages using `cyg-get.bat`, e.g. `cyg-get vim` or `cyg-get /?` (`cyg-get --help` isn't foreseen but seems to give much more parameters).
+
+You can start Cygwin using `\tools\cygwin\Cygwin.bat`.
+

--- a/tools/windows/README.md
+++ b/tools/windows/README.md
@@ -2,8 +2,16 @@
 
 ## Create the Windows VM
 
-A simple `vagrant up` should do, using a default Windows image, and you'll get
-in the best case a fully workable rdiff-backup development environment on Windows.
+Install Vagrant, ruby-devel and libvirt-devel as root and the necessary
+plug-ins with `vagrant plugin install <plugin>`:
+
+- vagrant-libvirt (_not_ libvirt!)
+- winrm
+- winrm-elevated
+
+A simple `vagrant up` should now do, using a default Windows image, and you'll
+get in the best case a fully workable rdiff-backup development environment on
+Windows.
 
 > **NOTE:** Starting from https://github.com/redhat-cop/automate-windows/tree/master/vagrant-libvirt-image,
 >	you can create your own Windows VM usable by Ansible (any other alternative

--- a/tools/windows/Vagrantfile
+++ b/tools/windows/Vagrantfile
@@ -5,9 +5,9 @@ Vagrant.configure("2") do |config|
 
   # Our box, we will have copied it manually to:
   # 	~/.vagrant.d/boxes/MSEdgeWin10/X/libvirt
-  config.vm.box = "MSEdgeWin10"
+  config.vm.box = "jborean93/WindowsServer2019"
   config.vm.provider :libvirt do |libvirt|
-    libvirt.memory = 4096  # installation of VS fails with too little memory
+    libvirt.memory = 8192  # installation of VS fails with too little memory
   end
 
   # WARNING: if following line is removed, Vagrant seems to act like it would
@@ -29,5 +29,11 @@ Vagrant.configure("2") do |config|
     ansible.groups = { "all:vars" => { "ansible_winrm_server_cert_validation" => "ignore" } }
     ansible.playbook = "playbook-provision-windows.yml"
   end
-
+  config.vm.guest = :windows
+  config.vm.communicator = "winrm"
+  config.vm.boot_timeout = 600
+  config.vm.graceful_halt_timeout = 600
+  config.winrm.transport = :ssl
+  config.winrm.basic_auth_only = true
+  config.winrm.ssl_peer_verification = false
 end

--- a/tools/windows/group_vars/all/generic.yml
+++ b/tools/windows/group_vars/all/generic.yml
@@ -1,5 +1,5 @@
 ---
-working_dir: "C:/Users/IEUser/Develop"
+working_dir: "C:/Users/{{ ansible_user }}/Develop"
 # define msbuild_exe if you want to use MSBuild directly instead of CMake
 #msbuild_exe: "C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/MSBuild.exe"
 # full path to CMake command

--- a/tools/windows/playbook-build-librsync.yml
+++ b/tools/windows/playbook-build-librsync.yml
@@ -7,14 +7,6 @@
       win_file:
         state: directory
         path: "{{ working_dir }}"
-    - name: Install NuGet to overcome issue 50332 in Ansible
-      # https://github.com/ansible/ansible/issues/50332
-      win_shell: Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-    - name: install the Powershell Community Extensions for win_unzip
-      win_psmodule:
-        name: Pscx
-        state: present
-        allow_clobber: true
 
     - name: include tasks to download and prepare librsync sources
       include_tasks: tasks/get-librsync-{{ librsync_git_repo is defined | ternary('git', 'tarball') }}.yml

--- a/tools/windows/playbook-build-rdiff-backup.yml
+++ b/tools/windows/playbook-build-rdiff-backup.yml
@@ -57,7 +57,7 @@
 
     - name: copy rsync.dll to build directory to call rdiff-backup from there
       win_copy:  # newer versions of rsync.dll are installed in bin not lib
-        src: "{{ librsync_install_dir }}/{{ librsync_git_repo is defined | ternary('bin', 'lib') }}/rsync.dll"
+        src: "{{ librsync_install_dir }}/bin/rsync.dll"
         remote_src: true  # file is already on the Windows machine
         dest: "{{ rdiffbackup_dir }}/build/"
       tags: debug_help

--- a/tools/windows/playbook-provision-windows.yml
+++ b/tools/windows/playbook-provision-windows.yml
@@ -50,7 +50,7 @@
     # once successful up until here, restart the playbook
 
   - name: install necessary python libraries
-    win_command: pip.exe install py2exe pywin32 pyinstaller wheel certifi setuptools-scm
+    win_command: pip.exe install py2exe pywin32 pyinstaller wheel certifi setuptools-scm tox
     register: pipcmd
     changed_when: "'Successfully installed ' in pipcmd.stdout"
     # pylibacl and pyxattr aren't supported under Windows

--- a/tools/windows/playbook-provision-windows.yml
+++ b/tools/windows/playbook-provision-windows.yml
@@ -11,38 +11,58 @@
     win_chocolatey:
       name:
       - virtio-drivers
-      - python
       - git
-      #- cygwin  # sadly broken
-      #- cyg-get  # depends on cygwin
+      - cygwin
+      - cyg-get  # depends on cygwin
       - cmake
       - 7zip
-      - dotnetfx  # dependency of visualstudio, allows for reboot in-between
+      - vscode # Visual Studio Code (editor)
       state: present
-    register: base_pkg
-  - name: execute reboot
-    win_reboot:
-    when: base_pkg.changed
-  - name: install further development tools via chocolatey (still failing)
+  - name: install python via chocolatey
+    win_chocolatey:
+      name: python
+      version: '3.7.7'
+      state: present
+      # we need to pin the version because pyinstaller doesn't support 3.8
+      # https://github.com/pyinstaller/pyinstaller/issues/4311
+  - name: install dependency of visualstudio, allows for reboot in-between
     win_chocolatey:
       name:
-      - visualstudio2017buildtools # didn't work here (memory?)
-      - vscode # Visual Studio Code (editor)
-      #- visualstudio2017-workload-vctools # fails...
-      #instead run from cmd as Administrator, possibly without quiet:
-      #"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools" --includeRecommended --norestart --quiet --add Microsoft.VisualStudio.Workload.VCTools
+      - dotnetfx
+      - vcredist140
       state: present
+    register: vs_deps
+  - name: execute reboot if something has changed to VS dependencies
+    win_reboot:
+    when: vs_deps is changed
+  - name: install visual studio tools via chocolatey
+    win_chocolatey:
+      name:  # VC 2017 is the version available on Travis CI
+      - visualstudio2017buildtools
+      - visualstudio2017-workload-python
+      - visualstudio2017-workload-vctools
+      state: present
+    register: vs
+  - name: execute reboot if something has been changed to visual studio
+    win_reboot:
+    when: vs is changed
+
     # once successful up until here, restart the playbook
+
   - name: install necessary python libraries
-    win_command: pip.exe install py2exe pywin32 pyinstaller wheel
+    win_command: pip.exe install py2exe pywin32 pyinstaller wheel certifi setuptools-scm
     register: pipcmd
-    changed_when: >
-      'Successfully installed py2exe' in pipcmd.stdout
-      or 'Successfully installed pywin32' in pipcmd.stdout
-      or 'Successfully installed pyinstaller' in pipcmd.stdout
-      or 'Successfully installed wheel' in pipcmd.stdout
+    changed_when: "'Successfully installed ' in pipcmd.stdout"
     # pylibacl and pyxattr aren't supported under Windows
   - name: validate that python seems to work as it should
     win_shell: "python.exe -c 'import pywintypes, winnt, win32api, win32security, win32file, win32con'"
     changed_when: false  # this command doesn't change anything ever
-  # TODO install / compile librsync
+
+  - name: Install NuGet to overcome issue 50332 in Ansible
+    # https://github.com/ansible/ansible/issues/50332
+    win_shell: Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+  - name: install the Powershell Community Extensions for win_unzip
+    win_psmodule:
+      name: Pscx
+      state: present
+      allow_clobber: true


### PR DESCRIPTION
DEV: much better automated installation of Windows development VM via Vagrant/Ansible
- use standard VM image from a known Ansible developer
- increase required memory to 8GB to avoid issues with VS installation
- add more robust Vagrant parameters to use Windows with Ansible
- development directory is dependent on the user's name through variable
- sort better and enable previously broken Chocolatey packages
- install certifi to avoid SSL errors and setuptools-scm
- shortly explain how to use the Ansible playbooks to use a non-Vagrant Windows

Allows me to address #337 much more easily, so a quick review and merge would be much appreciated.