### PR TITLE
Fix regression where Windows shares couldn't be backed-up

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1349,6 +1349,8 @@ class RPath(RORPath):
             b'', *[x for x in self.path.split(b"/") if x and x != b"."])
         if self.path[0:1] == b"/":
             newpath = b"/" + newpath
+            if self.path[1:2] == b"/":  # we assume a Windows share
+                newpath = b"/" + newpath
         elif not newpath:
             newpath = b"."
         return self.newpath(newpath)

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1349,7 +1349,7 @@ class RPath(RORPath):
             b'', *[x for x in self.path.split(b"/") if x and x != b"."])
         if self.path[0:1] == b"/":
             newpath = b"/" + newpath
-            if self.path[1:2] == b"/":  # we assume a Windows share
+            if self.path[1:2] == b"/" and self.path[2:3].isalnum():  # we assume a Windows share
                 newpath = b"/" + newpath
         elif not newpath:
             newpath = b"."

--- a/testing/rpathtest.py
+++ b/testing/rpathtest.py
@@ -268,7 +268,9 @@ class FilenameOps(RPathTest):
         b"a////b//c": b"a/b/c",
         b"..": b"..",
         b"a/": b"a",
-        b"/a//b///": b"/a/b"
+        b"/a//b///": b"/a/b",
+        b"//host/share": b"//host/share",
+        b"//host//share/": b"//host/share",
     }
     dirsplitdict = {
         b"/": (b"", b""),
@@ -276,7 +278,8 @@ class FilenameOps(RPathTest):
         b"/a/b": (b"/a", b"b"),
         b".": (b".", b"."),
         b"b/c": (b"b", b"c"),
-        b"a": (b".", b"a")
+        b"a": (b".", b"a"),
+        b"//host/share": (b"//host", b"share"),
     }
 
     def testQuote(self):


### PR DESCRIPTION
FIX: allow again to backup from and to Windows shares, closes #337