### PR TITLE
Fix failing exclude/include on accentuated characters

### DIFF
--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -742,9 +742,9 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
         by Donovan Baarda.
 
         """
-        i, n, res = 0, len(pat), ''
         # trying to analyze bytes would be quite complicated hence back to str
         str_pat = os.fsdecode(pat)
+        i, n, res = 0, len(str_pat), ''
         while i < n:
             c, s = str_pat[i], str_pat[i:i + 2]
             i = i + 1

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -215,7 +215,9 @@ rdiff-backup_testfiles/select/1/1
 
         cmp_glob_to_re("hello", b"hello")
         cmp_glob_to_re(".e?ll**o", b"\\.e[^/]ll.*o")
-        cmp_glob_to_re("*/é", os.fsencode("[^/]*/é"))
+        # since Python 3.7 only characters special to reg expr are quoted
+        # it seems that also non-ASCII characters were quoted before
+        cmp_glob_to_re("*/é", os.fsencode("[^/]*/é"), os.fsencode("[^/]*\\/\\é"))
         cmp_glob_to_re("[abc]el[^de][!fg]h", b"[abc]el[^de][^fg]h")
         # since Python 3.7 only characters special to reg expr are quoted
         cmp_glob_to_re("/usr/*/bin/", b"/usr/[^/]*/bin/", b"\\/usr\\/[^/]*\\/bin\\/")


### PR DESCRIPTION
FIX: avoid IndexError: string index out of range error when using accentuated characters in exclude/include patterns, closes #340

Taking the length of the bytes _before_ converting to string wasn't the best idea.
Also added test to reproduce issue #340 (and cleaned-up the code of the test case itself).

Please review and squash/merge (cleaning up the merge message)!