### PR TITLE
Workaround to avoid choking on extended characters under Windows

### DIFF
--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -26,6 +26,14 @@ import re
 import os  # needed to grab verbosity as environment variable
 from . import Globals, rpath
 
+# FIXME Dirty hack in order to make sure that log files are written in Unicode
+# format because else they are written as cp1252 under Windows
+# Influences program-wide all writing in text mode, not binary.
+if os.name == "nt":
+    import _locale
+    _locale._gdl_bak = _locale._getdefaultlocale
+    _locale._getdefaultlocale = (lambda *args: (_locale._gdl_bak()[0], 'utf8'))
+
 
 class LoggerError(Exception):
     pass


### PR DESCRIPTION
FIX: avoid charmap encoding errors during logging on Windows due to extended characters, closes #344

Under Windows text files are opened by default in cp1252 encoding which
doesn't cover the full Unicode charset. There is no clean way to change
this globally and changing this in rpath, with compressing and remote
calls, would be quite a tremendous change, hence the workaround.