### PR TITLE
Handle selection files with Windows/DOS endings

### DIFF
--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -402,6 +402,7 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
         something_excluded, tuple_list = None, []
         separator = Globals.null_separator and b"\0" or b"\n"
         for line in filelist_fp.read().split(separator):
+            line = line.rstrip(b'\r')  # for Windows/DOS endings
             if not line:
                 continue  # skip blanks
             try:
@@ -478,6 +479,7 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
         log.Log("Reading globbing filelist %s" % list_name, 4)
         separator = Globals.null_separator and b"\0" or b"\n"
         for line in filelist_fp.read().split(separator):
+            line = line.rstrip(b'\r')  # for Windows/DOS endings
             if not line:
                 continue  # skip blanks
             if line[:2] == b"+ ":

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -383,6 +383,19 @@ rdiff-backup_testfiles/select/1/1
 - **
 """])
 
+    def test_globbing_filelist_winending(self):
+        """Filelist glob test with Windows/DOS endings"""
+        # the \r's are used to test Windows/DOS endings
+        self.ParseTest([("--include-globbing-filelist", "file")],
+                       [(), ('1', ), ('1', '1'), ('1', '1', '2'),
+                        ('1', '1', '3')], [
+                            """
+- rdiff-backup_testfiles/select/1/1/1\r
+rdiff-backup_testfiles/select/1/1\r
+- rdiff-backup_testfiles/select/1\r
+- **\r
+"""])
+
     def testGlob(self):
         """Test globbing expression"""
         self.ParseTest([("--exclude", "**[3-5]"),


### PR DESCRIPTION
FIX: handle properly include/exclude files with Windows/DOS endings, closes #357
Also added a test to check for this case.