### PR TITLE
Fix naming of changelog in Windows travis instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
         - vername=rdiff-backup-`python setup.py --version`
         - PyInstaller --onefile --distpath build/$vername --paths=build/lib.win32-$pyverbrief --add-data=src/rdiff_backup.egg-info/PKG-INFO\;rdiff_backup.egg-info --console build/scripts-$pyverbrief/rdiff-backup
       before_deploy:
-        - cp CHANGELOG COPYING README.md docs/FAQ.md docs/examples.md docs/DEVELOP.md docs/Windows-README.md docs/Windows-DEVELOP.md build/$vername
+        - cp CHANGELOG.md COPYING README.md docs/FAQ.md docs/examples.md docs/DEVELOP.md docs/Windows-README.md docs/Windows-DEVELOP.md build/$vername
         - pushd build
         - 7z a -tzip ../dist/$vername.win32exe.zip $vername
         - popd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 RDIFF-BACKUP CHANGELOG
 ======================
 
-New in v2.0.2
+New in v2.0.3
 -------------
 
 ## Changes


### PR DESCRIPTION
The renaming of CHANGELOG to CHANGELOG.md made the Windows build fail.