### PR TITLE
Validate existence of temporary directory and add test

### DIFF
--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -229,6 +229,8 @@ def parse_cmdlineoptions(arglist):  # noqa: C901
         elif opt == "--ssh-no-compression":
             Globals.set('ssh_compression', None)
         elif opt == "--tempdir":
+            if (not os.path.isdir(arg)):
+                Log.FatalError("Temporary directory '%s' doesn't exist." % arg)
             tempfile.tempdir = os.fsencode(arg)
         elif opt == "--terminal-verbosity":
             Log.setterm_verbosity(arg)

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -528,6 +528,16 @@ class FinalMisc(PathSetter):
         for inc in self.get_all_increments(rbdir):
             assert inc.getinctime() >= 20000
 
+    def testNonExistingTempDir(self):
+        """Test that a missing tempdir is properly catched as an error"""
+        Myrm(Local.rpout.path)
+        rdiff_backup(True,
+                     True,
+                     Local.vftrp.path,
+                     Local.rpout.path,
+                     extra_options=b"--tempdir DoesSurelyNotExist",
+                     expected_ret_val=1)
+
 
 class FinalSelection(PathSetter):
     """Test selection options"""


### PR DESCRIPTION
FIX: explicitly test existence of tempdir and avoid "Can't mix strings and bytes in path components" error, closes #367
CHG: testing explicitly for existence of tempdir might make certain setups fail now because tempdir was silently ignored
Also added a cmdlinetest test to check that a non-existing tempdir is properly catched and errored.