### PR TITLE
Fix backward compatibility of rdiff usage in librsync test

### DIFF
--- a/testing/librsynctest.py
+++ b/testing/librsynctest.py
@@ -36,7 +36,7 @@ class LibrsyncTest(unittest.TestCase):
             rdiff_help_text = subprocess.check_output(["rdiff", "--help"])
             if b'-R' in rdiff_help_text:
                 assert not os.system(
-                    b"rdiff -b %i -R rollup -H md4 signature %b %b" %
+                    b"rdiff -b %i -R rollsum -S 8 -H md4 signature %b %b" %
                     (blocksize, self.basis.path, self.sig.path))
             elif b'-H' in rdiff_help_text:
                 assert not os.system(


### PR DESCRIPTION
DEV: fix compatibility in rollsum and sum-size with rdiff 2.2/2.3 leading to errors in librsynctest, closes #304
It is an improvement and a completion of PR #349 / commit c276b7e