### PR TITLE
Fix for #377 - incorrect Python download link in docs.

### DIFF
--- a/docs/Windows-DEVELOP.md
+++ b/docs/Windows-DEVELOP.md
@@ -29,7 +29,7 @@ Use Windows Update to upgrade your system. Then proceed with the installation.
 
 ### Python 3
 
-[Download Python 3.7.5 x86](https://www.python.org/ftp/python/3.7.3/python-3.7.3-amd64.exe)
+[Download Python 3.7.5 x86](https://www.python.org/ftp/python/3.7.5/python-3.7.5.exe)
 
 1. Check "Add Python 3.7 to PATH"
 2. Choose "Customize instalation" to select the installation path.


### PR DESCRIPTION
Fix for link in documentation - kept the target Python ad 3.7.5 32-bit to be consistent with the text