### PR TITLE
Improve error message with local paths given to test-server

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -298,7 +298,9 @@ def TestConnections(rpaths):
     if len(Globals.connections) == 1:
         print("No remote connections specified")
     else:
-        assert len(Globals.connections) == len(rpaths) + 1
+        assert len(Globals.connections) == len(rpaths) + 1, \
+            "All %d parameters must be remote of the form 'server::path'." % \
+            len(rpaths)
         for i in range(1, len(Globals.connections)):
             test_connection(i, rpaths[i - 1])
 


### PR DESCRIPTION
FIX: more meaningful error message when trying to test-server a local path, addresses #396
The message could be even better, an assert statement isn't the right way to handle this, but let's improve once we have a better parameter parsing.