### PR TITLE
improve handling of file description

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -120,7 +120,7 @@ def parse_file_desc(file_desc):
         # Hence we split along double ones, remove single ones in each element,
         # and join back with a single backslash.
         file_host = b'\\'.join(
-            [x.replace(b'\\',b'') for x in re.split(rb'\\\\', file_host) if x])
+            [x.replace(b'\\', b'') for x in re.split(rb'\\\\', file_host) if x])
         file_path = file_match.group("path")
     else:
         if re.match(rb"^::", file_desc):

--- a/testing/setconnectionstest.py
+++ b/testing/setconnectionstest.py
@@ -8,21 +8,20 @@ class SetConnectionsTest(unittest.TestCase):
     def testParsing(self):
         """Test parsing of various file descriptors"""
         pfd = SetConnections.parse_file_desc
-        assert pfd(b"bescoto@folly.stanford.edu::/usr/bin/ls") == \
-            (b"bescoto@folly.stanford.edu", b"/usr/bin/ls")
-        assert pfd(b"hello there::/goodbye:euoeu") == \
-            (b"hello there", b"/goodbye:euoeu")
-        assert pfd(rb"test\\ing\::more::and more\\..") == \
-            (rb"test\ing::more", rb"and more\\.."), \
-            pfd(r"test\\ing\::more::and more\\..")
-        assert pfd(b"a:b:c:d::e") == (b"a:b:c:d", b"e")
-        assert pfd(b"foobar") == (None, b"foobar")
-        assert pfd(rb"hello\::there") == (None, rb"hello\::there")
+        self.assertEqual(pfd(b"bescoto@folly.stanford.edu::/usr/bin/ls"),
+                         (b"bescoto@folly.stanford.edu", b"/usr/bin/ls"))
+        self.assertEqual(pfd(b"hello there::/goodbye:euoeu"),
+                         (b"hello there", b"/goodbye:euoeu"))
+        self.assertEqual(pfd(rb"test\\ing\::more::and more\\.."),
+                         (rb"test\ing::more", rb"and more\\.."))
+        self.assertEqual(pfd(b"a:b:c:d::e"), (b"a:b:c:d", b"e"))
+        self.assertEqual(pfd(b"foobar"), (None, b"foobar"))
+        self.assertEqual(pfd(rb"hello\::there"), (None, rb"hello\::there"))
+        self.assertEqual(pfd(rb"foobar\\"), (None, rb"foobar\\"))
 
-        self.assertRaises(SetConnections.SetConnectionsException, pfd,
-                          rb"hello\:there::")
-        self.assertRaises(SetConnections.SetConnectionsException, pfd,
-                          b"foobar\\")
+        # test missing path and missing host
+        self.assertRaises(SetConnections.SetConnectionsException, pfd, rb"hello\:there::")
+        self.assertRaises(SetConnections.SetConnectionsException, pfd, b"::some/path/without/host")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
FIX: avoid issue with backslash at the end of file path under Windows, closes #395
The function parse_file_desc was simplified by using a proper regexp instead
of parsing the line manually. The setconnection tests were also improved to
use assertEqual function.