### PR TITLE
Fix rdiff-backup crashing on certain devices

### DIFF
--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -145,14 +145,9 @@ def RORP2Record(rorpath):
     elif type == "sym":
         str_list.append(b"  SymData %b\n" % quote_path(rorpath.readlink()))
     elif type == "dev":
-        major, minor = rorpath.getdevnums()
-        if rorpath.isblkdev():
-            devchar = "b"
-        else:
-            assert rorpath.ischardev()
-            devchar = "c"
+        devchar, major, minor = rorpath.getdevnums()
         str_list.append(
-            b"  DeviceNum %b %i %i\n" % (devchar.encode(), major, minor))
+            b"  DeviceNum %b %i %i\n" % (devchar.encode('ascii'), major, minor))
 
     # Store time information
     if type != 'sym' and type != 'dev':

--- a/testing/rpathtest.py
+++ b/testing/rpathtest.py
@@ -312,12 +312,12 @@ class FilenameOps(RPathTest):
         """Test getting file numbers"""
         if (os.path.exists(b'/dev/sda')):
             devnums = rpath.RPath(self.lc, b"/dev/sda", ()).getdevnums()
-            assert devnums == (8, 0), devnums
+            self.assertEqual(devnums, ('b', 8, 0))
         else:
             devnums = rpath.RPath(self.lc, b"/dev/nvme0n1", ()).getdevnums()
-            assert devnums == (259, 0), devnums
+            self.assertEqual(devnums, ('b', 259, 0))
         devnums = rpath.RPath(self.lc, b"/dev/tty2", ()).getdevnums()
-        assert devnums == (4, 2), devnums
+        self.assertEqual(devnums, ('c', 4, 2))
 
 
 class FileIO(RPathTest):


### PR DESCRIPTION
FIX: failed on certain device files with no such file or directory error, closes #401
DEV: function rpath.getdevnums now also returns the device type, block or char
Using the functions os.minor and os.major instead of doing own maths
fixed most of the issue, also took the chance to simplify the code,
and fix accordingly the rpath tests.

Thanks to @wiebeytec for actually identifying the issue, fixing it was the easy part :smile: 