### PR TITLE
Replace deprecated xattr functions

### DIFF
--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -67,7 +67,7 @@ class ExtendedAttributes:
     def read_from_rp(self, rp):
         """Set the extended attributes from an rpath"""
         try:
-            attr_list = rp.conn.xattr.listxattr(rp.path, rp.issym())
+            attr_list = rp.conn.xattr.list(rp.path, rp.issym())
         except IOError as exc:
             if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.ETXTBSY):
                 return  # if not supported, consider empty
@@ -85,7 +85,7 @@ class ExtendedAttributes:
                 continue
             try:
                 self.attr_dict[attr] = \
-                    rp.conn.xattr.getxattr(rp.path, attr, rp.issym())
+                    rp.conn.xattr.get(rp.path, attr, rp.issym())
             except IOError as exc:
                 # File probably modified while reading, just continue
                 if exc.errno == errno.ENODATA:
@@ -101,9 +101,9 @@ class ExtendedAttributes:
     def clear_rp(self, rp):
         """Delete all the extended attributes in rpath"""
         try:
-            for name in rp.conn.xattr.listxattr(rp.path, rp.issym()):
+            for name in rp.conn.xattr.list(rp.path, rp.issym()):
                 try:
-                    rp.conn.xattr.removexattr(rp.path, name, rp.issym())
+                    rp.conn.xattr.remove(rp.path, name, rp.issym())
                 except PermissionError:  # errno.EACCES
                     # SELinux attributes cannot be removed, and we don't want
                     # to bail out or be too noisy at low log levels.
@@ -131,10 +131,10 @@ class ExtendedAttributes:
         self.clear_rp(rp)
         for (name, value) in self.attr_dict.items():
             try:
-                rp.conn.xattr.setxattr(rp.path, name, value, 0, rp.issym())
+                rp.conn.xattr.set(rp.path, name, value, 0, rp.issym())
             except IOError as exc:
                 # Mac and Linux attributes have different namespaces, so
-                # fail gracefully if can't call setxattr
+                # fail gracefully if can't call xattr.set
                 if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.EACCES,
                                  errno.ENOENT, errno.EINVAL):
                     log.Log(

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -409,10 +409,10 @@ class FSAbilities:
                 return
 
         try:
-            xattr.listxattr(rp.path)
+            xattr.list(rp.path)
             if write:
-                xattr.setxattr(rp.path, b"user.test", b"test val")
-                assert xattr.getxattr(rp.path, b"user.test") == b"test val"
+                xattr.set(rp.path, b"user.test", b"test val")
+                assert xattr.get(rp.path, b"user.test") == b"test val"
         except IOError:
             log.Log(
                 "Extended attributes not supported by "


### PR DESCRIPTION
DEV: replace deprecated xattr.<verb>xattr with xattr.<verb> function, closes #177

I didn't even document that we need at least version 0.4 as this version is already 12 years old (it's not even any more available from PyPI).