### PR TITLE
Add crossversion smoke tests

### DIFF
--- a/tools/crossversion/.gitignore
+++ b/tools/crossversion/.gitignore
@@ -1,0 +1,3 @@
+.vagrant/
+# ignore roles installed using ansible-galaxy
+roles/*.*/

--- a/tools/crossversion/README.md
+++ b/tools/crossversion/README.md
@@ -1,0 +1,32 @@
+# Vagrant setup for testing older versions of rdiff-backup
+
+Just call `vagrant up` to get the version.
+
+If you want to get a different version of rdiff-backup than the default one in
+`host_vars`, use following command:
+
+```
+ansible-playbook playbook-provision.yml -e rdiff_backup_old_version=2.0.3
+```
+
+To come back to the default version, just leave out the `-e xxx` option
+(or simply call `vagrant provision`).
+
+You may call the smoke tests using the following command and validate that
+nothing wrong happens:
+
+```
+ansible-playbook -v playbook-smoke-test.yml
+```
+
+You can use the current development version by using something like the following,
+after having built from source using `./setup.py build`:
+
+```
+PATH=../../build/scripts-3.8:$PATH PYTHONPATH=../../build/lib.linux-x86_64-3.8 \
+	ansible-playbook -v playbook-smoke-test.yml
+```
+
+> **CAUTION:** the version shown locally might be DEV or any other version
+	installed elsewhere locally, but the version used is definitely the
+	built development version.

--- a/tools/crossversion/Vagrantfile
+++ b/tools/crossversion/Vagrantfile
@@ -1,0 +1,76 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.define "oldrdiffbackup" do |oldrdiffbackup|
+    oldrdiffbackup.vm.box = "centos/6"
+  end
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  config.vm.provision "ansible" do |ansible|
+    ansible.verbose = "v"
+    ansible.playbook = "playbook-provision.yml"
+  end
+end

--- a/tools/crossversion/ansible.cfg
+++ b/tools/crossversion/ansible.cfg
@@ -1,0 +1,8 @@
+# config file for ansible -- https://ansible.com/
+# ===============================================
+
+[defaults]
+
+inventory      = .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
+
+stdout_callback = debug

--- a/tools/crossversion/host_vars/oldrdiffbackup/version.yml
+++ b/tools/crossversion/host_vars/oldrdiffbackup/version.yml
@@ -1,0 +1,2 @@
+---
+rdiff_backup_old_version: "2.0.0"

--- a/tools/crossversion/playbook-provision.yml
+++ b/tools/crossversion/playbook-provision.yml
@@ -1,0 +1,30 @@
+- name: provision with an old version of rdiff-backup for cross-version tests
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: install software collections (SCL) repository and Ansible dependencies
+    package:
+      name:
+      - centos-release-scl
+      - libselinux-python
+      state: present
+  - name: install python 3 and other build dependencies
+    package:
+      name:
+      - rh-python36
+      - gcc
+      - libacl-devel
+      state: present
+  - name: install rdiff-backup and dependencies using pip within the SCL environment
+    command: >
+      scl enable rh-python36
+      -- pip install --upgrade rdiff-backup=={{ rdiff_backup_old_version }} pyxattr pylibacl
+  - name: create rdiff-backup wrapper to always use the SCL version
+    copy:
+      dest: /usr/bin/rdiff-backup
+      content: |
+        #!/bin/sh
+        exec scl enable rh-python36 -- rdiff-backup "$@"
+      mode: a+rx

--- a/tools/crossversion/playbook-smoke-test.yml
+++ b/tools/crossversion/playbook-smoke-test.yml
@@ -1,0 +1,112 @@
+- name: do some smoke tests between the current version of rdiff-backup and a deemed older version
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    test_user: vagrant
+    test_server: oldrdiffbackup
+    ssh_config: ssh.local.cfg
+    remote_schema: 'ssh -F {{ ssh_config }} -C %s rdiff-backup --server'
+    remote_base_dir: '/home/{{ test_user }}/smoke.local.d'
+    local_base_dir: '../smoke.local.d'
+
+  pre_tasks:
+
+  - name: generate the necessary SSH configuration
+    shell: vagrant ssh-config oldrdiffbackup > "{{ ssh_config }}"
+    args:
+      creates: "{{ ssh_config }}"
+    delegate_to: localhost
+  - name: remove remote base directory {{ remote_base_dir }}
+    file:
+      path: "{{ remote_base_dir }}"
+      state: absent
+  - name: remove local base directory {{ local_base_dir }}
+    file:
+      path: "{{ local_base_dir }}"
+      state: absent
+    delegate_to: localhost
+  - name: create remote base directory {{ remote_base_dir }}
+    file:
+      path: "{{ remote_base_dir }}"
+      state: directory
+  - name: create local base directory {{ local_base_dir }}
+    file:
+      path: "{{ local_base_dir }}"
+      state: directory
+    delegate_to: localhost
+  - name: delete dummy file
+    file:
+      path: file.local.txt
+      state: absent
+    delegate_to: localhost
+
+  tasks:
+
+  - name: call remote rdiff-backup --version
+    command: rdiff-backup --version
+
+  - name: call remote rdiff-backup --verbosity 9 (with expected failure)
+    command: rdiff-backup --verbosity 9
+    register: rb_res
+    failed_when: rb_res.rc != 1
+
+  - name: call local rdiff-backup --version
+    command: rdiff-backup --version
+    delegate_to: localhost
+
+  - name: call local rdiff-backup --verbosity 9 (with expected failure)
+    command: rdiff-backup --verbosity 9
+    register: rb_res
+    failed_when: rb_res.rc != 1
+    delegate_to: localhost
+
+  - name: check that the remote rdiff-backup works
+    command: >
+      rdiff-backup --remote-schema '{{ remote_schema }}' --test-server
+      {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}/simplebackup
+    delegate_to: localhost
+
+  - name: make a simple backup from the local directory to remote repo
+    command: >
+      rdiff-backup --remote-schema '{{ remote_schema }}'
+      . {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}/simplebackup
+    delegate_to: localhost
+
+  - name: compare the current directory with the remote repo
+    command: >
+      rdiff-backup --remote-schema '{{ remote_schema }}' --compare-hash
+      . {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}/simplebackup
+    delegate_to: localhost
+
+  - name: create a dummy file to modify the local directory
+    copy:
+      dest: file.local.txt
+      content: "{{ now() }}"
+    delegate_to: localhost
+
+  - name: re-make a simple backup from the local directory to remote repo
+    command: >
+      rdiff-backup --remote-schema '{{ remote_schema }}'
+      . {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}/simplebackup
+    delegate_to: localhost
+
+  - name: list the increments with size in the remote repo
+    command: >
+      rdiff-backup --remote-schema '{{ remote_schema }}' --list-increment-sizes
+      {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}/simplebackup
+    delegate_to: localhost
+
+  - name: verify using the remote rdiff-backup the hashes in the repo
+    command: >
+      rdiff-backup --remote-schema '{{ remote_schema }}' --verify
+      {{ remote_base_dir }}/simplebackup
+
+  - name: restore from remote repo to local directory
+    command: >
+      rdiff-backup --remote-schema '{{ remote_schema }}' --restore-as-of now
+      {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}/simplebackup
+      {{ local_base_dir }}/simplerestore
+    delegate_to: localhost
+


### PR DESCRIPTION
DEV: add a new Vagrant configuration to do some smoke tests between the current/development version and any older one

This is something I wanted to have since a long time, but the comment from @ikus060 in PR #414 made me aware that it was time to really do something about it.

Even if you don't "speak" Ansible, the playbook-smoke-test.yml is simple to follow: `name:` describes the task and `command:` which command is being called. Can't be easier... I chose CentOS 6 as remote system because it's the basis for the oldest available manylinux, so I guess it makes interoperability as difficult as it can be.