### PR TITLE
Add setuptools as runtime dependency to tox and setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ python:
 deploy:
   - provider: releases
     file_glob: true
-    file: dist/*.*
+    file: dist/rdiff*.*
     skip_cleanup: true
     draft: true
     token:

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -136,6 +136,7 @@ The same pre-requisites as for the installation of rdiff-backup also apply for b
 * librsync 1.0.0 or higher
 * pylibacl (optional, to support ACLs)
 * pyxattr (optional, to support extended attributes) - even if the xattr library (without py) isn't part of our CI/CD pipeline, feel free to use it for your development
+* python3-setuptools (for a proper version instead of DEV)
 
 Additionally are following pre-requisites needed:
 

--- a/setup.py
+++ b/setup.py
@@ -222,5 +222,6 @@ setup(
         'build_py': build_py,
         'clean': clean,
     },
+    install_requires=['setuptools'],
     setup_requires=['setuptools_scm'],
 )

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -12,7 +12,7 @@ for PYBIN in $pybindirs; do
 done
 
 # Bundle external shared libraries into the wheels
-for whl in dist/*.whl; do
+for whl in dist/rdiff_backup*.whl; do
     auditwheel repair "$whl" --plat $PLAT -w /io/dist/
 done
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ envlist = py35, py36, py37, py38, flake8
 # user being correctly identified (which might not happen in a container)
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
+    setuptools
     pyxattr
     pylibacl
 # whitelist_externals =

--- a/tox_dist.ini
+++ b/tox_dist.ini
@@ -15,6 +15,7 @@ envlist = py35, py36, py37, py38
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 skip_install = true
 deps =
+    setuptools-scm
     pyxattr
     pylibacl
     wheel

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -20,6 +20,7 @@ isolated_build_env = .package.root
 # or explicitly the RDIFF_* ones:
 passenv = SUDO_USER SUDO_UID SUDO_GID RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
+    setuptools
     pyxattr
     pylibacl
 #whitelist_externals = env

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -12,6 +12,7 @@ envlist = py35, py36, py37, py38
 [testenv]
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
+    setuptools
     pyxattr
     pylibacl
 # whitelist_externals =


### PR DESCRIPTION
Also add a note in the developer documentation.
CHG: setuptools is a runtime dependency for installation and tests so that version appears correctly instead of DEV, closes #305

This is obviously a follow-up of the corresponding discussion regarding Debian packages, it applies also to any kind of packaging, even wheels.