### PR TITLE
Fix semi-broken nongnu.org links

### DIFF
--- a/docs/rdiff-backup-statistics.1
+++ b/docs/rdiff-backup-statistics.1
@@ -24,7 +24,7 @@ later run "rdiff-backup-statistics out".
 The output has two parts.  The first is simply an average of the all
 matching session_statistics files.  The meaning of these fields is
 explained in the FAQ included in the package, and also at
-.IR https://www.nongnu.org/rdiff-backup/FAQ.html#statistics .
+.IR https://rdiff-backup.net/docs/FAQ.html#statistics .
 
 The second section lists some particularly significant files
 (including directories).  These files are either contain a lot of

--- a/docs/rdiff-backup.1
+++ b/docs/rdiff-backup.1
@@ -700,7 +700,7 @@ complicated, but it is supposed to be flexible and easy-to-use.  If
 you just want to learn the basics, first look at the selection
 examples in the examples.html file included in the package, or on the
 web at
-.IR https://www.nongnu.org/rdiff-backup/examples.html
+.IR https://rdiff-backup.net/docs/examples.html
 
 .BR rdiff-backup 's
 selection system was originally inspired by


### PR DESCRIPTION
The problem with these https://www.nongnu.org/rdiff-backup/... links
is that they redirect to the top level https://rdiff-backup.net/ page,
rather than to the corresponding subpage.