### PR TITLE
CHG: increased version of bundled Python Windows version from 3.7.5 to 3.7.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
       before_install:
         - git clone https://github.com/pyenv-win/pyenv-win.git $HOME/.pyenv
         - export PATH="$HOME/.pyenv/pyenv-win/bin:$HOME/.pyenv/pyenv-win/shims:$PATH"
-        - export pyver=3.7.5
+        - export pyver=3.7.7
         - export pyverbrief=${pyver:0:3}
         - pyenv install --list
         - pyenv install -q $pyver || pyenv rehash


### PR DESCRIPTION
I had forgotten about this one, also because I had bundled it with a librsync update which went wrong. As all my development is already done since a long time with 3.7.7 it isn't a big change, and would make sure that we don't carry old Python bugs with us.

Hence I'd like to merge this before final release of the bugfix.

Note: Python 3.7.8 has been released very recently but isn't yet supported by pyenv.