### PR TITLE
Resolve runtime dependency on setuptools to get version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,11 @@ sudo pip3 install rdiff-backup
 You need to make sure that the following requirements are met:
 
 * Python 3.5 or higher
-* librsync 1.0.0
+* librsync 1.0.0 or higher
 * pylibacl (optional, to support ACLs)
 * pyxattr (optional, to support extended attributes) - the xattr library (without py) isn't regularly tested but should work and you will be helped
+* if Python's version is 3.7.x or below, importlib-metadata 1.x
+  (or alternatively setuptools)
 * SSH for remote operations
 
 ```

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -136,7 +136,8 @@ The same pre-requisites as for the installation of rdiff-backup also apply for b
 * librsync 1.0.0 or higher
 * pylibacl (optional, to support ACLs)
 * pyxattr (optional, to support extended attributes) - even if the xattr library (without py) isn't part of our CI/CD pipeline, feel free to use it for your development
-* python3-setuptools (for a proper version instead of DEV)
+* if Python's version is 3.7.x or below, importlib-metadata 1.x
+  (or alternatively setuptools)
 
 Additionally are following pre-requisites needed:
 

--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,6 @@ setup(
         'build_py': build_py,
         'clean': clean,
     },
-    install_requires=['setuptools'],
+    install_requires=['importlib-metadata ~= 1.0 ; python_version < "3.8"'],
     setup_requires=['setuptools_scm'],
 )

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -24,11 +24,22 @@ from . import log
 
 # The current version of rdiff-backup
 # Get it from package info or fall back to DEV version.
+# importlib/metadata is the new approach, pkg_resources the old one, kept for
+# compatibility reasons (and because importlib_metadata -for Python < 3.8-
+# isn't yet packaged for all distros).
 try:
-    import pkg_resources
-    version = pkg_resources.get_distribution("rdiff-backup").version
-except BaseException:
-    version = "DEV"
+    from importlib import metadata
+    version = metadata.version('rdiff-backup')
+except ImportError:
+    try:  # the fallback library for Python below 3.8
+        import importlib_metadata as metadata
+        version = metadata.version('rdiff-backup')
+    except ImportError:
+        try:  # the old method requiring setuptools to be installed
+            import pkg_resources
+            version = pkg_resources.get_distribution("rdiff-backup").version
+        except BaseException:  # if everything else fails...
+            version = "DEV-no-metadata"
 
 # If this is set, use this value in seconds as the current time
 # instead of reading it from the clock.

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -8,6 +8,8 @@ yum install -y librsync-devel
 
 # Compile wheels
 for PYBIN in $pybindirs; do
+    "${PYBIN}/pip" install --user \
+        'importlib-metadata ~= 1.0 ; python_version < "3.8"'
     "${PYBIN}/pip" wheel /io/ -w dist/
 done
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist = py35, py36, py37, py38, flake8
 # user being correctly identified (which might not happen in a container)
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
-    setuptools
+    importlib-metadata ~= 1.0 ; python_version < "3.8"
     pyxattr
     pylibacl
 # whitelist_externals =

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -20,7 +20,7 @@ isolated_build_env = .package.root
 # or explicitly the RDIFF_* ones:
 passenv = SUDO_USER SUDO_UID SUDO_GID RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
-    setuptools
+    importlib-metadata ~= 1.0 ; python_version < "3.8"
     pyxattr
     pylibacl
 #whitelist_externals = env

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -12,7 +12,7 @@ envlist = py35, py36, py37, py38
 [testenv]
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
-    setuptools
+    importlib-metadata ~= 1.0 ; python_version < "3.8"
     pyxattr
     pylibacl
 # whitelist_externals =


### PR DESCRIPTION
CHG: depend on importlib-metadata instead of setuptools to get rdiff-backup veersion, closes #418