### PR TITLE
Add test coverage to tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ rdiff-backup.spec
 
 # Jekyll static sites
 _site/
+
+# coverage files
+.coverage*

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -148,7 +148,8 @@ Additionally are following pre-requisites needed:
 * libacl-devel (for sys/acl.h)
 * tox (for testing)
 * rdiff (for testing)
-* flake8 (optional, but helpful to validate code correctness)
+* flake8 (optional, but helpful to validate code correctness locally)
+* coverage (optional, but helpful to validate test coverage locally)
 
 All of those should come packaged with your system or available from
 https://pypi.org/ but if you need them otherwise, here are some sources:

--- a/tox.ini
+++ b/tox.ini
@@ -14,54 +14,64 @@ envlist = py35, py36, py37, py38, flake8
 # either explicitly the RDIFF_TEST_* variables or rely on the current
 # user being correctly identified (which might not happen in a container)
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
+setenv =
+	COVERAGE_FILE = {envlogdir}/coverage.sqlite
 deps =
     setuptools
     pyxattr
     pylibacl
+    coverage
 # whitelist_externals =
 commands_pre =
     rdiff-backup --version
     # must be the first command to setup the test environment
     python testing/commontest.py
+    coverage erase
 commands =
-    python testing/ctest.py
-    python testing/timetest.py
-    python testing/librsynctest.py
-    python testing/statisticstest.py
-    python testing/user_grouptest.py
-    python testing/setconnectionstest.py
-    python testing/iterfiletest.py
-    python testing/longnametest.py
-    python testing/robusttest.py
-    python testing/connectiontest.py
-    python testing/incrementtest.py
-    python testing/hardlinktest.py
-    python testing/eas_aclstest.py
-    python testing/FilenameMappingtest.py
-    python testing/fs_abilitiestest.py
-    python testing/hashtest.py
-    python testing/selectiontest.py
-    python testing/metadatatest.py
-    python testing/rpathtest.py
-    python testing/rorpitertest.py
-    python testing/rdifftest.py
-    python testing/securitytest.py
-    python testing/killtest.py
-    python testing/backuptest.py
-    python testing/comparetest.py
-    python testing/regresstest.py
-    python testing/restoretest.py
-    python testing/cmdlinetest.py
-    python testing/rdiffbackupdeletetest.py
-    python testing/errorsrecovertest.py
+    coverage run --parallel testing/ctest.py
+    coverage run --parallel testing/timetest.py
+    coverage run --parallel testing/librsynctest.py
+    coverage run --parallel testing/statisticstest.py
+    coverage run --parallel testing/user_grouptest.py
+    coverage run --parallel testing/setconnectionstest.py
+    coverage run --parallel testing/iterfiletest.py
+    coverage run --parallel testing/longnametest.py
+    coverage run --parallel testing/robusttest.py
+    coverage run --parallel testing/connectiontest.py
+    coverage run --parallel testing/incrementtest.py
+    coverage run --parallel testing/hardlinktest.py
+    coverage run --parallel testing/eas_aclstest.py
+    coverage run --parallel testing/FilenameMappingtest.py
+    coverage run --parallel testing/fs_abilitiestest.py
+    coverage run --parallel testing/hashtest.py
+    coverage run --parallel testing/selectiontest.py
+    coverage run --parallel testing/metadatatest.py
+    coverage run --parallel testing/rpathtest.py
+    coverage run --parallel testing/rorpitertest.py
+    coverage run --parallel testing/rdifftest.py
+    coverage run --parallel testing/securitytest.py
+    coverage run --parallel testing/killtest.py
+    coverage run --parallel testing/backuptest.py
+    coverage run --parallel testing/comparetest.py
+    coverage run --parallel testing/regresstest.py
+    coverage run --parallel testing/restoretest.py
+    coverage run --parallel testing/cmdlinetest.py
+    coverage run --parallel testing/rdiffbackupdeletetest.py
+    coverage run --parallel testing/errorsrecovertest.py
 # can only work on OS/X TODO later
-#    python testing/resourceforktest.py
+#    coverage run testing/resourceforktest.py
+
+commands_post =
+    coverage combine
+    coverage report --include '*/rdiff_backup/*' --skip-empty --fail-under=70
 
 [testenv:flake8]
 deps =
     flake8
+commands_pre=
 commands =
     flake8 setup.py src testing tools
+commands_post=
 
 [flake8]
 ignore =


### PR DESCRIPTION
DEV: add measurement of test coverage to tox.ini and limit to 70% for further improvement, closes #113

It doesn't influence the code itself so I would suggest to merge it before we release the next bug-fix version. 70% as a baseline isn't too bad, we can then use the refactoring to improve this number as we go...