### PR TITLE
Make pipeline faster by joining small jobs together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -219,11 +219,9 @@ addons:
 
 # Each env becomes a separate job. Add more Python versions to have a matrix.
 env:
-  - MAKE_STEP=test-static RUN_COMMAND= SUDO=sudo
-  - MAKE_STEP=build RUN_COMMAND= SUDO=sudo
+  - MAKE_STEP=test-misc         RUN_COMMAND= SUDO=sudo
   - MAKE_STEP=test-runtime-base RUN_COMMAND= SUDO=sudo
   - MAKE_STEP=test-runtime-root RUN_COMMAND= SUDO=root  # see below
-  - MAKE_STEP=test-runtime-slow RUN_COMMAND= SUDO=sudo
 
 script:
   # We need the following line because travis runs already in a virtualenv

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ test-runtime-slow: test-runtime-files
 	@echo "=== Long running performance tests ==="
 	${RUN_COMMAND} tox -c tox_slow.ini -e py
 
+test-misc: clean build test-static test-runtime-slow
+
 build:
 	# Build rdiff-backup (assumes src/ is in directory 'rdiff-backup' and it's
 	# parent is writeable)


### PR DESCRIPTION
Because each job means a new VM to be started, it takes much more time
than putting the smaller jobs into one single VM. And because build and
static tests don't influence the slow tox job, it's also OK.