### PR TITLE
Reduce max complexity to 30 by simplifying CompareRecursive

### DIFF
--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -161,16 +161,6 @@ class ExtendedAttributes:
         return not self.attr_dict
 
 
-def _ea_compare_rps(rp1, rp2):
-    """Return true if rp1 and rp2 have same extended attributes.
-    TEST: This function is used solely as part of the test suite."""
-    ea1 = ExtendedAttributes(rp1.index)
-    ea1.read_from_rp(rp1)
-    ea2 = ExtendedAttributes(rp2.index)
-    ea2.read_from_rp(rp2)
-    return ea1 == ea2
-
-
 class EAExtractor(metadata.FlatExtractor):
     """Iterate ExtendedAttributes objects from the EA information file"""
     record_boundary_regexp = re.compile(b'(?:\\n|^)(# file: (.*?))\\n')
@@ -621,16 +611,6 @@ def _list_to_acl(entry_list, map_names=1):
         entry.permset.write = perms >> 1 & 1
         entry.permset.execute = perms & 1
     return acl
-
-
-def _acl_compare_rps(rp1, rp2):
-    """Return true if rp1 and rp2 have same acl information.
-    TEST: This function is used solely as part of the test suite."""
-    acl1 = AccessControlLists(rp1.index)
-    acl1.read_from_rp(rp1)
-    acl2 = AccessControlLists(rp2.index)
-    acl2.read_from_rp(rp2)
-    return acl1 == acl2
 
 
 class ACLExtractor(EAExtractor):

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -4,7 +4,7 @@ import re
 import sys
 import time
 import pathlib
-from commontest import rdiff_backup, Myrm, CompareRecursive, \
+from commontest import rdiff_backup, Myrm, compare_recursive, \
     old_test_dir, abs_test_dir, get_increment_rp
 from rdiff_backup import Globals, log, rpath, robust, FilenameMapping, Time, selection
 """Regression tests"""
@@ -95,7 +95,7 @@ class PathSetter(unittest.TestCase):
                      Local.inc1rp.path,
                      Local.rpout.path,
                      current_time=10000)
-        assert CompareRecursive(Local.inc1rp, Local.rpout)
+        assert compare_recursive(Local.inc1rp, Local.rpout)
         time.sleep(1)
 
         # Backing up increment2
@@ -104,7 +104,7 @@ class PathSetter(unittest.TestCase):
                      Local.inc2rp.path,
                      Local.rpout.path,
                      current_time=20000)
-        assert CompareRecursive(Local.inc2rp, Local.rpout)
+        assert compare_recursive(Local.inc2rp, Local.rpout)
         time.sleep(1)
 
         # Backing up increment3
@@ -113,7 +113,7 @@ class PathSetter(unittest.TestCase):
                      Local.inc3rp.path,
                      Local.rpout.path,
                      current_time=30000)
-        assert CompareRecursive(Local.inc3rp, Local.rpout)
+        assert compare_recursive(Local.inc3rp, Local.rpout)
         time.sleep(1)
 
         # Backing up increment4
@@ -122,7 +122,7 @@ class PathSetter(unittest.TestCase):
                      Local.inc4rp.path,
                      Local.rpout.path,
                      current_time=40000)
-        assert CompareRecursive(Local.inc4rp, Local.rpout)
+        assert compare_recursive(Local.inc4rp, Local.rpout)
 
         # Getting restore rps
         inc_paths = self.getinc_paths(
@@ -132,15 +132,15 @@ class PathSetter(unittest.TestCase):
 
         # Restoring increment1
         rdiff_backup(from_local, to_local, inc_paths[0], Local.rpout1.path)
-        assert CompareRecursive(Local.inc1rp, Local.rpout1)
+        assert compare_recursive(Local.inc1rp, Local.rpout1)
 
         # Restoring increment2
         rdiff_backup(from_local, to_local, inc_paths[1], Local.rpout2.path)
-        assert CompareRecursive(Local.inc2rp, Local.rpout2)
+        assert compare_recursive(Local.inc2rp, Local.rpout2)
 
         # Restoring increment3
         rdiff_backup(from_local, to_local, inc_paths[2], Local.rpout3.path)
-        assert CompareRecursive(Local.inc3rp, Local.rpout3)
+        assert compare_recursive(Local.inc3rp, Local.rpout3)
 
         # Test restoration of a few random files
         vft_paths = self.getinc_paths(
@@ -149,7 +149,7 @@ class PathSetter(unittest.TestCase):
                          b"increments"))
         rdiff_backup(from_local, to_local, vft_paths[1], Local.vft_out.path)
         self.refresh(Local.vft_in, Local.vft_out)
-        assert CompareRecursive(Local.vft_in, Local.vft_out)
+        assert compare_recursive(Local.vft_in, Local.vft_out)
 
         timbar_paths = self.getinc_paths(
             b"timbar.pyc.",
@@ -166,7 +166,7 @@ class PathSetter(unittest.TestCase):
                      Local.vft_recover.path,
                      extra_options=b"--restore-as-of 25000")
         self.refresh(Local.vft_recover, Local.vft_in)
-        assert CompareRecursive(Local.vft_recover, Local.vft_in)
+        assert compare_recursive(Local.vft_recover, Local.vft_in)
 
         # Make sure too many increment files not created
         assert len(
@@ -236,7 +236,7 @@ class Final(PathSetter):
                      Local.inc1rp.path,
                      procout.path,
                      current_time=30000)
-        assert CompareRecursive(Local.inc1rp, procout)
+        assert compare_recursive(Local.inc1rp, procout)
         time.sleep(1)
         rdiff_backup(True, True, '/proc', procout.path, current_time=40000)
 
@@ -255,7 +255,7 @@ class Final(PathSetter):
                      Local.inc1rp.path,
                      procout.path,
                      current_time=30000)
-        assert CompareRecursive(Local.inc1rp, procout)
+        assert compare_recursive(Local.inc1rp, procout)
         time.sleep(1)
         rdiff_backup(True, False, '/proc', procout.path, current_time=40000)
 
@@ -316,16 +316,16 @@ class Final(PathSetter):
         Globals.chars_to_quote = None
         assert len(inc_paths) == 1, inc_paths
         self.exec_rb(None, inc_paths[0], b'testfiles/restoretarget2')
-        assert CompareRecursive(Local.wininc2,
-                                Local.rpout2,
-                                compare_hardlinks=0)
+        assert compare_recursive(Local.wininc2,
+                                 Local.rpout2,
+                                 compare_hardlinks=0)
 
         # Restore increment 3 again, using different syntax
         self.rb_schema = old_schema + b'-r 30000 '
         self.exec_rb(None, b'testfiles/output', b'testfiles/restoretarget3')
-        assert CompareRecursive(Local.wininc3,
-                                Local.rpout3,
-                                compare_hardlinks=0)
+        assert compare_recursive(Local.wininc3,
+                                 Local.rpout3,
+                                 compare_hardlinks=0)
         self.rb_schema = old_schema
 
     def testLegacy(self):
@@ -352,7 +352,7 @@ class Final(PathSetter):
                      Local.rpout.path,
                      Local.rpout1.path,
                      extra_options=b'-r0')
-        assert CompareRecursive(Local.vftrp, Local.rpout1, compare_hardlinks=0)
+        assert compare_recursive(Local.vftrp, Local.rpout1, compare_hardlinks=0)
 
 
 class FinalMisc(PathSetter):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -329,7 +329,7 @@ def _files_rorp_eq(src_rorp, dest_rorp,
         Log("Dest rorp missing: %s" % str(src_rorp), 3)
         return False
     if not src_rorp._equal_verbose(dest_rorp,
-                                  compare_ownership=compare_ownership):
+                                   compare_ownership=compare_ownership):
         return False
     if compare_hardlinks and not _hardlink_rorp_eq(src_rorp, dest_rorp):
         return False

--- a/testing/eas_aclstest.py
+++ b/testing/eas_aclstest.py
@@ -6,8 +6,8 @@ import grp
 from rdiff_backup.eas_acls import AccessControlLists, metadata, ACLExtractor, \
     Record2ACL, ACL2Record, ExtendedAttributes, EAExtractor, EA2Record, Record2EA
 from rdiff_backup import Globals, rpath, user_group
-from commontest import rdiff_backup, abs_test_dir, abs_output_dir, abs_restore_dir, \
-    BackupRestoreSeries, CompareRecursive
+from commontest import rdiff_backup, abs_test_dir, abs_output_dir, \
+    abs_restore_dir, BackupRestoreSeries, compare_recursive
 
 user_group.init_user_mapping()
 user_group.init_group_mapping()
@@ -249,23 +249,23 @@ user.empty
                      self.ea_test1_rpath.path,
                      tempdir.path,
                      current_time=10000)
-        assert CompareRecursive(self.ea_test1_rpath, tempdir, compare_eas=1)
+        assert compare_recursive(self.ea_test1_rpath, tempdir, compare_eas=1)
 
         rdiff_backup(1,
                      1,
                      self.ea_test2_rpath.path,
                      tempdir.path,
                      current_time=20000)
-        assert CompareRecursive(self.ea_test2_rpath, tempdir, compare_eas=1)
+        assert compare_recursive(self.ea_test2_rpath, tempdir, compare_eas=1)
 
         rdiff_backup(1,
                      1,
                      tempdir.path,
                      restore_dir.path,
                      extra_options=b'-r 10000')
-        assert CompareRecursive(self.ea_test1_rpath,
-                                restore_dir,
-                                compare_eas=1)
+        assert compare_recursive(self.ea_test1_rpath,
+                                 restore_dir,
+                                 compare_eas=1)
 
 
 class ACLTest(unittest.TestCase):
@@ -517,23 +517,23 @@ other::---
                      self.acl_test1_rpath.path,
                      tempdir.path,
                      current_time=10000)
-        assert CompareRecursive(self.acl_test1_rpath, tempdir, compare_acls=1)
+        assert compare_recursive(self.acl_test1_rpath, tempdir, compare_acls=1)
 
         rdiff_backup(1,
                      1,
                      self.acl_test2_rpath.path,
                      tempdir.path,
                      current_time=20000)
-        assert CompareRecursive(self.acl_test2_rpath, tempdir, compare_acls=1)
+        assert compare_recursive(self.acl_test2_rpath, tempdir, compare_acls=1)
 
         rdiff_backup(1,
                      1,
                      tempdir.path,
                      restore_dir.path,
                      extra_options=b'-r 10000')
-        assert CompareRecursive(self.acl_test1_rpath,
-                                restore_dir,
-                                compare_acls=1)
+        assert compare_recursive(self.acl_test1_rpath,
+                                 restore_dir,
+                                 compare_acls=1)
 
         restore_dir.delete()
         rdiff_backup(1,
@@ -541,9 +541,9 @@ other::---
                      tempdir.path,
                      restore_dir.path,
                      extra_options=b'-r now')
-        assert CompareRecursive(self.acl_test2_rpath,
-                                restore_dir,
-                                compare_acls=1)
+        assert compare_recursive(self.acl_test2_rpath,
+                                 restore_dir,
+                                 compare_acls=1)
 
     def test_acl_mapping(self):
         """Test mapping ACL names"""

--- a/testing/hardlinktest.py
+++ b/testing/hardlinktest.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import time
 from commontest import abs_test_dir, abs_output_dir, old_test_dir, re_init_rpath_dir, \
-    CompareRecursive, BackupRestoreSeries, InternalBackup, InternalRestore, \
+    compare_recursive, BackupRestoreSeries, InternalBackup, InternalRestore, \
     MakeOutputDir, reset_hardlink_dicts
 from rdiff_backup import Globals, Hardlink, selection, rpath, restore, metadata
 
@@ -25,12 +25,12 @@ class HardlinkTest(unittest.TestCase):
     hello_str_hash = "943a702d06f34599aee1f8da8ef9f7296031d699"
 
     def testEquality(self):
-        """Test rorp_eq function in conjunction with CompareRecursive"""
-        assert CompareRecursive(self.hlinks_rp1, self.hlinks_rp1copy)
-        assert CompareRecursive(self.hlinks_rp1,
-                                self.hlinks_rp2,
-                                compare_hardlinks=None)
-        assert not CompareRecursive(
+        """Test rorp_eq function in conjunction with compare_recursive"""
+        assert compare_recursive(self.hlinks_rp1, self.hlinks_rp1copy)
+        assert compare_recursive(self.hlinks_rp1,
+                                 self.hlinks_rp2,
+                                 compare_hardlinks=None)
+        assert not compare_recursive(
             self.hlinks_rp1, self.hlinks_rp2, compare_hardlinks=1)
 
     def testBuildingDict(self):

--- a/testing/killtest.py
+++ b/testing/killtest.py
@@ -4,7 +4,7 @@ import signal
 import sys
 import random
 import time
-from commontest import abs_test_dir, old_test_dir, CompareRecursive, RBBin
+from commontest import abs_test_dir, old_test_dir, compare_recursive, RBBin
 from rdiff_backup import Globals, restore, rpath, Time
 """Test consistency by killing rdiff-backup as it is backing up"""
 
@@ -237,7 +237,7 @@ class KillTest(ProcessFuncs):
         # is kind of special (there's no incrementing, so different
         # code)
         self.exec_rb(10000, 1, Local.ktrp[2].path, Local.rpout.path)
-        assert CompareRecursive(Local.ktrp[2], Local.rpout)
+        assert compare_recursive(Local.ktrp[2], Local.rpout)
 
         def cycle_once(min_max_time_pair, curtime, input_rp, old_rp):
             """Backup input_rp, kill, regress, and then compare"""
@@ -247,7 +247,7 @@ class KillTest(ProcessFuncs):
             result = self.mark_incomplete(curtime, Local.rpout)
             assert not self.exec_rb(None, 1, '--check-destination-dir',
                                     Local.rpout.path)
-            assert CompareRecursive(old_rp, Local.rpout, compare_hardlinks=0)
+            assert compare_recursive(old_rp, Local.rpout, compare_hardlinks=0)
             return result
 
         # Keep backing ktrp[0], and then regressing to ktrp[2].  Then go to ktrp[0]

--- a/testing/longnametest.py
+++ b/testing/longnametest.py
@@ -1,7 +1,8 @@
 import unittest
 import errno
 import os
-from commontest import abs_test_dir, old_test_dir, Myrm, rdiff_backup, CompareRecursive
+from commontest import abs_test_dir, old_test_dir, Myrm, \
+    rdiff_backup, compare_recursive
 from rdiff_backup import rpath, Globals, regress, Time
 
 max_len = 255
@@ -187,8 +188,8 @@ class LongNameTest(unittest.TestCase):
                      output_dir,
                      restore_dir,
                      extra_options=b'-r 0')
-        CompareRecursive(rpath.RPath(Globals.local_connection, input_dir),
-                         rpath.RPath(Globals.local_connection, restore_dir))
+        compare_recursive(rpath.RPath(Globals.local_connection, input_dir),
+                          rpath.RPath(Globals.local_connection, restore_dir))
 
 
 if __name__ == "__main__":

--- a/testing/regresstest.py
+++ b/testing/regresstest.py
@@ -7,7 +7,7 @@ Not to be confused with the regression tests.
 import unittest
 import os
 from commontest import abs_output_dir, abs_test_dir, old_test_dir, Myrm, \
-    CompareRecursive, rdiff_backup
+    compare_recursive, rdiff_backup
 from rdiff_backup import regress, Time, rpath, Globals
 
 
@@ -40,43 +40,43 @@ class RegressTest(unittest.TestCase):
                      self.incrp[0].path,
                      self.output_rp.path,
                      current_time=10000)
-        assert CompareRecursive(self.incrp[0], self.output_rp)
+        assert compare_recursive(self.incrp[0], self.output_rp)
 
         rdiff_backup(1,
                      1,
                      self.incrp[1].path,
                      self.output_rp.path,
                      current_time=20000)
-        assert CompareRecursive(self.incrp[1], self.output_rp)
+        assert compare_recursive(self.incrp[1], self.output_rp)
 
         rdiff_backup(1,
                      1,
                      self.incrp[2].path,
                      self.output_rp.path,
                      current_time=30000)
-        assert CompareRecursive(self.incrp[2], self.output_rp)
+        assert compare_recursive(self.incrp[2], self.output_rp)
 
         rdiff_backup(1,
                      1,
                      self.incrp[3].path,
                      self.output_rp.path,
                      current_time=40000)
-        assert CompareRecursive(self.incrp[3], self.output_rp)
+        assert compare_recursive(self.incrp[3], self.output_rp)
 
         Globals.rbdir = self.output_rbdir_rp
 
         regress_function(30000)
-        assert CompareRecursive(self.incrp[2],
-                                self.output_rp,
-                                compare_hardlinks=0)
+        assert compare_recursive(self.incrp[2],
+                                 self.output_rp,
+                                 compare_hardlinks=0)
         regress_function(20000)
-        assert CompareRecursive(self.incrp[1],
-                                self.output_rp,
-                                compare_hardlinks=0)
+        assert compare_recursive(self.incrp[1],
+                                 self.output_rp,
+                                 compare_hardlinks=0)
         regress_function(10000)
-        assert CompareRecursive(self.incrp[0],
-                                self.output_rp,
-                                compare_hardlinks=0)
+        assert compare_recursive(self.incrp[0],
+                                 self.output_rp,
+                                 compare_hardlinks=0)
 
     def regress_to_time_local(self, time):
         """Regress self.output_rp to time by running regress locally"""

--- a/testing/restoretest.py
+++ b/testing/restoretest.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 from commontest import abs_output_dir, old_test_dir, Myrm, MakeOutputDir, \
-    InternalRestore, CompareRecursive
+    InternalRestore, compare_recursive
 from rdiff_backup import restore, Globals, rpath, TempFile, Time, log, Main
 
 lc = Globals.local_connection
@@ -160,16 +160,16 @@ class RestoreTest(unittest.TestCase):
 
         InternalRestore(mirror_local, dest_local, restore3_dir, abs_output_dir,
                         45000)
-        assert CompareRecursive(inc4_rp, target_rp)
+        assert compare_recursive(inc4_rp, target_rp)
         InternalRestore(mirror_local, dest_local, restore3_dir, abs_output_dir,
                         35000)
-        assert CompareRecursive(inc3_rp, target_rp, compare_hardlinks=0)
+        assert compare_recursive(inc3_rp, target_rp, compare_hardlinks=0)
         InternalRestore(mirror_local, dest_local, restore3_dir, abs_output_dir,
                         25000)
-        assert CompareRecursive(inc2_rp, target_rp, compare_hardlinks=0)
+        assert compare_recursive(inc2_rp, target_rp, compare_hardlinks=0)
         InternalRestore(mirror_local, dest_local, restore3_dir, abs_output_dir,
                         5000)
-        assert CompareRecursive(inc1_rp, target_rp, compare_hardlinks=0)
+        assert compare_recursive(inc1_rp, target_rp, compare_hardlinks=0)
 
     def testRestoreNoincs(self):
         """Test restoring a directory with no increments, just mirror"""

--- a/testing/roottest.py
+++ b/testing/roottest.py
@@ -1,8 +1,8 @@
 import unittest
 import os
 from commontest import old_test_dir, abs_test_dir, abs_output_dir, Myrm, \
-    abs_restore_dir, re_init_rpath_dir, CompareRecursive, BackupRestoreSeries, \
-    rdiff_backup, RBBin
+    abs_restore_dir, re_init_rpath_dir, compare_recursive, \
+    BackupRestoreSeries, rdiff_backup, RBBin
 from rdiff_backup import Globals, rpath, Main
 """Root tests - contain tests which need to be run as root.
 
@@ -298,7 +298,7 @@ class HalfRoot(unittest.TestCase):
         cmd3 = restore_schema % (b'10000', remote_schema, outrp.path,
                                  rout_rp.path)
         Run(cmd3)
-        assert CompareRecursive(in_rp1, rout_rp)
+        assert compare_recursive(in_rp1, rout_rp)
         rout_perms = rout_rp.append('unreadable_dir').getperms()
         outrp_perms = outrp.append('unreadable_dir').getperms()
         assert rout_perms == 0, rout_perms
@@ -308,7 +308,7 @@ class HalfRoot(unittest.TestCase):
         cmd4 = restore_schema % (b"now", remote_schema, outrp.path,
                                  rout_rp.path)
         Run(cmd4)
-        assert CompareRecursive(in_rp2, rout_rp)
+        assert compare_recursive(in_rp2, rout_rp)
         rout_perms = rout_rp.append('unreadable_dir').getperms()
         outrp_perms = outrp.append('unreadable_dir').getperms()
         assert rout_perms == 0, rout_perms
@@ -354,7 +354,7 @@ class NonRoot(unittest.TestCase):
         rp2.chown(2, 2)
         rp3 = sp.append("3")
         rp3.chown(1, 1)
-        assert not CompareRecursive(rp, sp, compare_ownership=1)
+        assert not compare_recursive(rp, sp, compare_ownership=1)
 
         return rp, sp
 
@@ -386,21 +386,21 @@ class NonRoot(unittest.TestCase):
 
         self.backup(input_rp1, output_rp, 1000000)
         self.restore(output_rp, restore_rp)
-        assert CompareRecursive(input_rp1, restore_rp, compare_ownership=1)
+        assert compare_recursive(input_rp1, restore_rp, compare_ownership=1)
 
         self.backup(input_rp2, output_rp, 2000000)
         self.restore(output_rp, restore_rp)
-        assert CompareRecursive(input_rp2, restore_rp, compare_ownership=1)
+        assert compare_recursive(input_rp2, restore_rp, compare_ownership=1)
 
         self.backup(empty_rp, output_rp, 3000000)
         self.restore(output_rp, restore_rp)
-        assert CompareRecursive(empty_rp, restore_rp, compare_ownership=1)
+        assert compare_recursive(empty_rp, restore_rp, compare_ownership=1)
 
         self.restore(output_rp, restore_rp, 1000000)
-        assert CompareRecursive(input_rp1, restore_rp, compare_ownership=1)
+        assert compare_recursive(input_rp1, restore_rp, compare_ownership=1)
 
         self.restore(output_rp, restore_rp, 2000000)
-        assert CompareRecursive(input_rp2, restore_rp, compare_ownership=1)
+        assert compare_recursive(input_rp2, restore_rp, compare_ownership=1)
 
 
 if __name__ == "__main__":

--- a/testing/rorpitertest.py
+++ b/testing/rorpitertest.py
@@ -1,7 +1,8 @@
 import unittest
 import pickle
 import os
-from commontest import old_test_dir, abs_output_dir, CompareRecursive, iter_equal
+from commontest import old_test_dir, abs_output_dir, \
+    compare_recursive, iter_equal
 from rdiff_backup import rpath, rorpiter, Globals
 from functools import reduce
 
@@ -58,7 +59,7 @@ class RORPIterTest(unittest.TestCase):
             return ((src_rorp.isdir() and dest_rorp.isdir())
                     or src_rorp == dest_rorp)
 
-        return CompareRecursive(src_rp, dest_rp, None, equal)
+        return compare_recursive(src_rp, dest_rp, None, equal)
 
 
 class IndexedTupleTest(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -83,4 +83,4 @@ exclude =
     .tox.root
     __pycache__
     build
-max-complexity = 40
+max-complexity = 30


### PR DESCRIPTION
The testing function CompareRecursive was the most complex function,
now broken down, renamed properly to compare_recursive, and using
properly booleans instead of integers.
DEV: reduce max complexity to 30 and rename CompareRecursive to compare_recursive.