### PR TITLE
Add Globals.pickle_protocol and raise version from 1 to 4

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -281,6 +281,14 @@ remote_tempdir = None
 # and pre-regress
 do_fsync = True
 
+# This represents the pickle protocol used by rdiff-backup over the connection
+# https://docs.python.org/3/library/pickle.html#pickle-protocols
+# Note that the receiving end will automatically recognize the protocol used so
+# that both ends don't need to use the same one to send, as long as they both
+# understand the maximum protocol version used.
+# Protocol 4 is understood since Python 3.4, protocol 5 since 3.8.
+pickle_protocol = 4
+
 
 def get(name):
     """Return the value of something in this module"""

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -287,7 +287,7 @@ do_fsync = True
 # that both ends don't need to use the same one to send, as long as they both
 # understand the maximum protocol version used.
 # Protocol 4 is understood since Python 3.4, protocol 5 since 3.8.
-pickle_protocol = 4
+PICKLE_PROTOCOL = 4
 
 
 def get(name):

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -192,7 +192,7 @@ class LowLevelPipeConnection(Connection):
 
     def _putobj(self, obj, req_num):
         """Send a generic python obj down the outpipe"""
-        self._write("o", pickle.dumps(obj, Globals.pickle_protocol), req_num)
+        self._write("o", pickle.dumps(obj, Globals.PICKLE_PROTOCOL), req_num)
 
     def _putbuf(self, buf, req_num):
         """Send buffer buf down the outpipe"""
@@ -217,13 +217,15 @@ class LowLevelPipeConnection(Connection):
         """
         rpath_repr = (rpath.conn.conn_number, rpath.base, rpath.index,
                       rpath.data)
-        self._write("R", pickle.dumps(rpath_repr, Globals.pickle_protocol), req_num)
+        self._write("R", pickle.dumps(rpath_repr,
+                                      Globals.PICKLE_PROTOCOL), req_num)
 
     def _putqrpath(self, qrpath, req_num):
         """Put a quoted rpath into the pipe (similar to _putrpath above)"""
         qrpath_repr = (qrpath.conn.conn_number, qrpath.base, qrpath.index,
                        qrpath.data)
-        self._write("Q", pickle.dumps(qrpath_repr, Globals.pickle_protocol), req_num)
+        self._write("Q", pickle.dumps(qrpath_repr,
+                                      Globals.PICKLE_PROTOCOL), req_num)
 
     def _putrorpath(self, rorpath, req_num):
         """Put an rorpath into the pipe
@@ -233,7 +235,8 @@ class LowLevelPipeConnection(Connection):
 
         """
         rorpath_repr = (rorpath.index, rorpath.data)
-        self._write("r", pickle.dumps(rorpath_repr, Globals.pickle_protocol), req_num)
+        self._write("r", pickle.dumps(rorpath_repr,
+                                      Globals.PICKLE_PROTOCOL), req_num)
 
     def _putconn(self, pipeconn, req_num):
         """Put a connection into the pipe

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -18,15 +18,16 @@
 # 02110-1301, USA
 """Support code for remote execution and data transfer"""
 
-import types  # noqa: F401
-import os  # noqa: F401
-import tempfile  # noqa: F401
-import pickle  # noqa: F401
-import shutil  # noqa: F401
-import traceback  # noqa: F401
-import socket  # noqa: F401
-import sys  # noqa: F401
+import pickle
+import sys
+import traceback
+# we need those imports because they are used through the connection
 import gzip  # noqa: F401
+import os  # noqa: F401
+import shutil  # noqa: F401
+import socket  # noqa: F401
+import tempfile  # noqa: F401
+import types  # noqa: F401
 
 # The following EA and ACL modules may be used if available
 try:
@@ -191,7 +192,7 @@ class LowLevelPipeConnection(Connection):
 
     def _putobj(self, obj, req_num):
         """Send a generic python obj down the outpipe"""
-        self._write("o", pickle.dumps(obj, 1), req_num)
+        self._write("o", pickle.dumps(obj, Globals.pickle_protocol), req_num)
 
     def _putbuf(self, buf, req_num):
         """Send buffer buf down the outpipe"""
@@ -216,13 +217,13 @@ class LowLevelPipeConnection(Connection):
         """
         rpath_repr = (rpath.conn.conn_number, rpath.base, rpath.index,
                       rpath.data)
-        self._write("R", pickle.dumps(rpath_repr, 1), req_num)
+        self._write("R", pickle.dumps(rpath_repr, Globals.pickle_protocol), req_num)
 
     def _putqrpath(self, qrpath, req_num):
         """Put a quoted rpath into the pipe (similar to _putrpath above)"""
         qrpath_repr = (qrpath.conn.conn_number, qrpath.base, qrpath.index,
                        qrpath.data)
-        self._write("Q", pickle.dumps(qrpath_repr, 1), req_num)
+        self._write("Q", pickle.dumps(qrpath_repr, Globals.pickle_protocol), req_num)
 
     def _putrorpath(self, rorpath, req_num):
         """Put an rorpath into the pipe
@@ -232,7 +233,7 @@ class LowLevelPipeConnection(Connection):
 
         """
         rorpath_repr = (rorpath.index, rorpath.data)
-        self._write("r", pickle.dumps(rorpath_repr, 1), req_num)
+        self._write("r", pickle.dumps(rorpath_repr, Globals.pickle_protocol), req_num)
 
     def _putconn(self, pipeconn, req_num):
         """Put a connection into the pipe

--- a/src/rdiff_backup/iterfile.py
+++ b/src/rdiff_backup/iterfile.py
@@ -227,7 +227,7 @@ class FileWrappingIter:
                 self.currently_in_file = currentobj
                 self._add_from_file(b"f")
             else:
-                pickled_data = pickle.dumps(currentobj, 1)
+                pickled_data = pickle.dumps(currentobj, Globals.pickle_protocol)
                 self.array_buf.frombytes(b"o")
                 self.array_buf.frombytes(self._i2b(len(pickled_data), 7))
                 self.array_buf.frombytes(pickled_data)
@@ -246,12 +246,12 @@ class FileWrappingIter:
                                         [Globals.blocksize])
         if buf is None:  # error occurred above, encode exception
             self.currently_in_file = None
-            excstr = pickle.dumps(self.last_exception, 1)
+            excstr = pickle.dumps(self.last_exception, Globals.pickle_protocol)
             total = b"".join((b'e', self._i2b(len(excstr), 7), excstr))
         else:
             total = b"".join((prefix_letter, self._i2b(len(buf), 7), buf))
             if buf == b"":  # end of file
-                cstr = pickle.dumps(self.currently_in_file.close(), 1)
+                cstr = pickle.dumps(self.currently_in_file.close(), Globals.pickle_protocol)
                 self.currently_in_file = None
                 total += b"".join((b'h', self._i2b(len(cstr), 7), cstr))
         self.array_buf.frombytes(total)
@@ -370,7 +370,7 @@ class MiscIterToFile(FileWrappingIter):
 
     def _add_misc_object(self, obj):
         """Add an arbitrary pickleable object to the buffer"""
-        pickled_data = pickle.dumps(obj, 1)
+        pickled_data = pickle.dumps(obj, Globals.pickle_protocol)
         self.array_buf.frombytes(b"o")
         self.array_buf.frombytes(self._i2b(len(pickled_data), 7))
         self.array_buf.frombytes(pickled_data)
@@ -378,10 +378,10 @@ class MiscIterToFile(FileWrappingIter):
     def _add_rorp(self, rorp):
         """Add a rorp to the buffer"""
         if rorp.file:
-            pickled_data = pickle.dumps((rorp.index, rorp.data, 1), 1)
+            pickled_data = pickle.dumps((rorp.index, rorp.data, 1), Globals.pickle_protocol)
             self.next_in_line = rorp.file
         else:
-            pickled_data = pickle.dumps((rorp.index, rorp.data, 0), 1)
+            pickled_data = pickle.dumps((rorp.index, rorp.data, 0), Globals.pickle_protocol)
             self.rorps_in_buffer += 1
         self.array_buf.frombytes(b"r")
         self.array_buf.frombytes(self._i2b(len(pickled_data), 7))

--- a/src/rdiff_backup/iterfile.py
+++ b/src/rdiff_backup/iterfile.py
@@ -227,7 +227,8 @@ class FileWrappingIter:
                 self.currently_in_file = currentobj
                 self._add_from_file(b"f")
             else:
-                pickled_data = pickle.dumps(currentobj, Globals.pickle_protocol)
+                pickled_data = pickle.dumps(currentobj,
+                                            Globals.PICKLE_PROTOCOL)
                 self.array_buf.frombytes(b"o")
                 self.array_buf.frombytes(self._i2b(len(pickled_data), 7))
                 self.array_buf.frombytes(pickled_data)
@@ -246,12 +247,13 @@ class FileWrappingIter:
                                         [Globals.blocksize])
         if buf is None:  # error occurred above, encode exception
             self.currently_in_file = None
-            excstr = pickle.dumps(self.last_exception, Globals.pickle_protocol)
+            excstr = pickle.dumps(self.last_exception, Globals.PICKLE_PROTOCOL)
             total = b"".join((b'e', self._i2b(len(excstr), 7), excstr))
         else:
             total = b"".join((prefix_letter, self._i2b(len(buf), 7), buf))
             if buf == b"":  # end of file
-                cstr = pickle.dumps(self.currently_in_file.close(), Globals.pickle_protocol)
+                cstr = pickle.dumps(self.currently_in_file.close(),
+                                    Globals.PICKLE_PROTOCOL)
                 self.currently_in_file = None
                 total += b"".join((b'h', self._i2b(len(cstr), 7), cstr))
         self.array_buf.frombytes(total)
@@ -370,7 +372,7 @@ class MiscIterToFile(FileWrappingIter):
 
     def _add_misc_object(self, obj):
         """Add an arbitrary pickleable object to the buffer"""
-        pickled_data = pickle.dumps(obj, Globals.pickle_protocol)
+        pickled_data = pickle.dumps(obj, Globals.PICKLE_PROTOCOL)
         self.array_buf.frombytes(b"o")
         self.array_buf.frombytes(self._i2b(len(pickled_data), 7))
         self.array_buf.frombytes(pickled_data)
@@ -378,10 +380,12 @@ class MiscIterToFile(FileWrappingIter):
     def _add_rorp(self, rorp):
         """Add a rorp to the buffer"""
         if rorp.file:
-            pickled_data = pickle.dumps((rorp.index, rorp.data, 1), Globals.pickle_protocol)
+            pickled_data = pickle.dumps((rorp.index, rorp.data, 1),
+                                        Globals.PICKLE_PROTOCOL)
             self.next_in_line = rorp.file
         else:
-            pickled_data = pickle.dumps((rorp.index, rorp.data, 0), Globals.pickle_protocol)
+            pickled_data = pickle.dumps((rorp.index, rorp.data, 0),
+                                        Globals.PICKLE_PROTOCOL)
             self.rorps_in_buffer += 1
         self.array_buf.frombytes(b"r")
         self.array_buf.frombytes(self._i2b(len(pickled_data), 7))


### PR DESCRIPTION
DEV: add Globals.pickle_protocol variable and raise it's version from 1 to 4
This shouldn't have an impact on compatibility has already Python 3.4 can
understand the protocol 4 and the receiving end detects the protocol used.