### PR TITLE
Restructure coverage to capture sub-processes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,72 +15,87 @@ envlist = py35, py36, py37, py38, flake8
 # user being correctly identified (which might not happen in a container)
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 setenv =
+# paths for coverage must be absolute so that sub-processes find them
+# even if they're started from another location.
 	COVERAGE_FILE = {envlogdir}/coverage.sqlite
+	COVERAGE_PROCESS_START = {toxinidir}/tox.ini
 deps =
-    importlib-metadata ~= 1.0 ; python_version < "3.8"
-    pyxattr
-    pylibacl
-    coverage
+	importlib-metadata ~= 1.0 ; python_version < "3.8"
+	pyxattr
+	pylibacl
+	coverage
 # whitelist_externals =
 commands_pre =
-    rdiff-backup --version
-    # must be the first command to setup the test environment
-    python testing/commontest.py
-    coverage erase
+	rdiff-backup --version
+# must be the first command to setup the test environment
+	python testing/commontest.py
+	coverage erase
+# write the hook file which will make sure that coverage is loaded
+# also for sub-processes, like for "client/server" rdiff-backup
+	python -c 'with open("{envsitepackagesdir}/coverage.pth","w") as fd: fd.write("import coverage; coverage.process_startup()\n")'
 commands =
-    coverage run --parallel testing/ctest.py
-    coverage run --parallel testing/timetest.py
-    coverage run --parallel testing/librsynctest.py
-    coverage run --parallel testing/statisticstest.py
-    coverage run --parallel testing/user_grouptest.py
-    coverage run --parallel testing/setconnectionstest.py
-    coverage run --parallel testing/iterfiletest.py
-    coverage run --parallel testing/longnametest.py
-    coverage run --parallel testing/robusttest.py
-    coverage run --parallel testing/connectiontest.py
-    coverage run --parallel testing/incrementtest.py
-    coverage run --parallel testing/hardlinktest.py
-    coverage run --parallel testing/eas_aclstest.py
-    coverage run --parallel testing/FilenameMappingtest.py
-    coverage run --parallel testing/fs_abilitiestest.py
-    coverage run --parallel testing/hashtest.py
-    coverage run --parallel testing/selectiontest.py
-    coverage run --parallel testing/metadatatest.py
-    coverage run --parallel testing/rpathtest.py
-    coverage run --parallel testing/rorpitertest.py
-    coverage run --parallel testing/rdifftest.py
-    coverage run --parallel testing/securitytest.py
-    coverage run --parallel testing/killtest.py
-    coverage run --parallel testing/backuptest.py
-    coverage run --parallel testing/comparetest.py
-    coverage run --parallel testing/regresstest.py
-    coverage run --parallel testing/restoretest.py
-    coverage run --parallel testing/cmdlinetest.py
-    coverage run --parallel testing/rdiffbackupdeletetest.py
-    coverage run --parallel testing/errorsrecovertest.py
+	coverage run testing/ctest.py
+	coverage run testing/timetest.py
+	coverage run testing/librsynctest.py
+	coverage run testing/statisticstest.py
+	coverage run testing/user_grouptest.py
+	coverage run testing/setconnectionstest.py
+	coverage run testing/iterfiletest.py
+	coverage run testing/longnametest.py
+	coverage run testing/robusttest.py
+	coverage run testing/connectiontest.py
+	coverage run testing/incrementtest.py
+	coverage run testing/hardlinktest.py
+	coverage run testing/eas_aclstest.py
+	coverage run testing/FilenameMappingtest.py
+	coverage run testing/fs_abilitiestest.py
+	coverage run testing/hashtest.py
+	coverage run testing/selectiontest.py
+	coverage run testing/metadatatest.py
+	coverage run testing/rpathtest.py
+	coverage run testing/rorpitertest.py
+	coverage run testing/rdifftest.py
+	coverage run testing/securitytest.py
+	coverage run testing/killtest.py
+	coverage run testing/backuptest.py
+	coverage run testing/comparetest.py
+	coverage run testing/regresstest.py
+	coverage run testing/restoretest.py
+	coverage run testing/cmdlinetest.py
+	coverage run testing/rdiffbackupdeletetest.py
+	coverage run testing/errorsrecovertest.py
 # can only work on OS/X TODO later
-#    coverage run testing/resourceforktest.py
+#	coverage run testing/resourceforktest.py
 
-commands_post =
-    coverage combine
-    coverage report --include '*/rdiff_backup/*' --skip-empty --fail-under=70
+# combine all coverage results and show the summary
+	coverage combine
+	coverage report
 
 [testenv:flake8]
 deps =
-    flake8
+	flake8
 commands_pre=
 commands =
-    flake8 setup.py src testing tools
-commands_post=
+	flake8 setup.py src testing tools
 
 [flake8]
 ignore =
-    E501 # line too long (86 > 79 characters)
-    W503 # line break before binary operator
+	E501 # line too long (86 > 79 characters)
+	W503 # line break before binary operator
 exclude =
-    .git
-    .tox
-    .tox.root
-    __pycache__
-    build
+	.git
+	.tox
+	.tox.root
+	__pycache__
+	build
 max-complexity = 40
+
+[coverage:run]
+parallel = True
+
+[coverage:report]
+include =
+	*/rdiff_backup/*
+skip_empty = True
+fail_under = 80
+sort = Cover


### PR DESCRIPTION
DEV: Re-write tox.ini to make sure that also sub-processes are part of the coverage calculation, raises test coverage above 80%