### PR TITLE
Better cross-platform compatibility in test files

### DIFF
--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -40,7 +40,11 @@ def Myrm(dirstring):
     for rp in selection.Select(root_rp).set_iter():
         if rp.isdir():
             rp.chmod(0o700)  # otherwise may not be able to remove
-    assert not os.system(b"rm -rf %s" % (root_rp.path, ))
+    path = root_rp.path
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+    elif os.path.isfile(path):
+        os.remove(path)
 
 
 def re_init_rpath_dir(rp, uid=-1, gid=-1):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -13,9 +13,9 @@ from rdiff_backup import Globals, Hardlink, SetConnections, Main, \
 RBBin = os.fsencode(shutil.which("rdiff-backup"))
 
 # Working directory is defined by Tox, venv or the current build directory
-abs_work_dir = os.getenvb(
-    b'TOX_ENV_DIR',
-    os.getenvb(b'VIRTUAL_ENV', os.path.join(os.getcwdb(), b'build')))
+abs_work_dir = os.getenv(
+    'TOX_ENV_DIR',
+    os.getenv('VIRTUAL_ENV', os.path.join(os.getcwdb(), b'build'))).encode()
 abs_test_dir = os.path.join(abs_work_dir, b'testfiles')
 abs_output_dir = os.path.join(abs_test_dir, b'output')
 abs_restore_dir = os.path.join(abs_test_dir, b'restore')

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -13,9 +13,9 @@ from rdiff_backup import Globals, Hardlink, SetConnections, Main, \
 RBBin = os.fsencode(shutil.which("rdiff-backup"))
 
 # Working directory is defined by Tox, venv or the current build directory
-abs_work_dir = os.getenv(
+abs_work_dir = os.fsencode(os.getenv(
     'TOX_ENV_DIR',
-    os.getenv('VIRTUAL_ENV', os.path.join(os.getcwdb(), b'build'))).encode()
+    os.getenv('VIRTUAL_ENV', os.path.join(os.getcwd(), 'build'))))
 abs_test_dir = os.path.join(abs_work_dir, b'testfiles')
 abs_output_dir = os.path.join(abs_test_dir, b'output')
 abs_restore_dir = os.path.join(abs_test_dir, b'restore')

--- a/testing/librsynctest.py
+++ b/testing/librsynctest.py
@@ -10,11 +10,8 @@ def MakeRandomFile(path, length=None):
     """Writes a random file of given length, or random len if unspecified"""
     if not length:
         length = random.randrange(5000, 100000)
-    fp = open(path, "wb")
-    try:
+    with open(path, "wb") as fp:
         fp.write(os.urandom(length))
-    finally:
-        fp.close()
 
 
 class LibrsyncTest(unittest.TestCase):

--- a/testing/librsynctest.py
+++ b/testing/librsynctest.py
@@ -11,12 +11,10 @@ def MakeRandomFile(path, length=None):
     if not length:
         length = random.randrange(5000, 100000)
     fp = open(path, "wb")
-    fp_random = open('/dev/urandom', 'rb')
-
-    fp.write(fp_random.read(length))
-
-    fp.close()
-    fp_random.close()
+    try:
+        fp.write(os.urandom(length))
+    finally:
+        fp.close()
 
 
 class LibrsyncTest(unittest.TestCase):


### PR DESCRIPTION
This is a (small) step towards #347, to ensure tests run on Windows. I have found a pretty good way to run the tests both on Linux and Windows (manually, yet) which allows me to identify areas which need some more work, address them, then check if tests still run on both.

- `os.getenvb` is not supported on Windows
- `rm -rf` obviously also isn't, unfortunately `shutil.rmtree` only removes directories so an additional check to delete files was necessary
- Again, obviously no `/dev/urandom` on Windows