### PR TITLE
Pin specific version v2.32.1 of pyenv-win in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
       language: shell
       env: MAKE_STEP=bdist_win
       before_install:
-        - git clone https://github.com/pyenv-win/pyenv-win.git $HOME/.pyenv
+        - git clone --depth 1 --branch v2.32.1 https://github.com/pyenv-win/pyenv-win.git $HOME/.pyenv
         - export PATH="$HOME/.pyenv/pyenv-win/bin:$HOME/.pyenv/pyenv-win/shims:$PATH"
         - export pyver=3.7.7
         - export pyverbrief=${pyver:0:3}


### PR DESCRIPTION
See also: https://github.com/rdiff-backup/rdiff-backup/pull/444#issuecomment-669061713

`pyenv-win` now by default installs a 64-bit Python rather than 32-bit. And since rdiff-backup just takes the `master` rather than any specific tag or release, any newly started build will get any changes for free.

Using a 64-bit Python will fail to build using a `Win32` build of librsync (and vice versa).

I used the newly released version `v2.32.1` which seems to be explicitly meant for 32-bit (rather than using the master revision of the last successful build).