### PR TITLE
tox_win.ini: commented failing tests and included deps

### DIFF
--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -10,7 +10,7 @@ from rdiff_backup.log import Log
 from rdiff_backup import Globals, Hardlink, SetConnections, Main, \
     selection, rpath, eas_acls, rorpiter, Security, hash
 
-RBBin = os.fsencode(shutil.which("rdiff-backup"))
+RBBin = os.fsencode(shutil.which("rdiff-backup") or "rdiff-backup")
 
 # Working directory is defined by Tox, venv or the current build directory
 abs_work_dir = os.fsencode(os.getenv(

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -30,7 +30,7 @@ commands =
     python testing/ctest.py
     python testing/timetest.py
 #    python testing/librsynctest.py
-#    python testing/statisticstest.py
+    python testing/statisticstest.py
 #    python testing/user_grouptest.py
 #    python testing/setconnectionstest.py
 #    python testing/iterfiletest.py

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -14,9 +14,10 @@ envlist = py37, flake8
 # either explicitly the RDIFF_TEST_* variables or rely on the current
 # user being correctly identified (which might not happen in a container)
 passenv = RDIFF_TEST_* RDIFF_BACKUP_* LIBRSYNC_DIR
-#deps =
-#    pyxattr
-#    pylibacl
+deps =
+    pywin32
+    pyinstaller
+    wheel
 whitelist_externals = cmd
 commands_pre =
     cmd /c set
@@ -25,42 +26,46 @@ commands_pre =
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =
+# The commented tests do not run on Windows yet and will be fixed & uncommented one by one
     python testing/ctest.py
     python testing/timetest.py
-    python testing/librsynctest.py
-    python testing/statisticstest.py
-    python testing/user_grouptest.py
-    python testing/setconnectionstest.py
-    python testing/iterfiletest.py
-    python testing/longnametest.py
+#    python testing/librsynctest.py
+#    python testing/statisticstest.py
+#    python testing/user_grouptest.py
+#    python testing/setconnectionstest.py
+#    python testing/iterfiletest.py
+#    python testing/longnametest.py
     python testing/robusttest.py
-    python testing/connectiontest.py
-    python testing/incrementtest.py
-    python testing/hardlinktest.py
-    python testing/eas_aclstest.py
-    python testing/FilenameMappingtest.py
-    python testing/fs_abilitiestest.py
+#    python testing/connectiontest.py
+#    python testing/incrementtest.py
+#    python testing/hardlinktest.py
+#    python testing/eas_aclstest.py
+#    python testing/FilenameMappingtest.py
+#    python testing/fs_abilitiestest.py
     python testing/hashtest.py
-    python testing/selectiontest.py
-    python testing/metadatatest.py
-    python testing/rpathtest.py
+#    python testing/selectiontest.py
+#    python testing/metadatatest.py
+#    python testing/rpathtest.py
     python testing/rorpitertest.py
-    python testing/rdifftest.py
-    python testing/securitytest.py
-    python testing/killtest.py
-    python testing/backuptest.py
-    python testing/comparetest.py
-    python testing/regresstest.py
-    python testing/restoretest.py
-    python testing/cmdlinetest.py
-    python testing/rdiffbackupdeletetest.py
-    python testing/errorsrecovertest.py
+#    python testing/rdifftest.py
+#    python testing/securitytest.py
+#    python testing/killtest.py
+#    python testing/backuptest.py
+#    python testing/comparetest.py
+#    python testing/regresstest.py
+#    python testing/restoretest.py
+#    python testing/cmdlinetest.py
+#    python testing/rdiffbackupdeletetest.py
+#    python testing/errorsrecovertest.py
 # can only work on OS/X TODO later
 #    python testing/resourceforktest.py
 
 [testenv:flake8]
 deps =
     flake8
+    pywin32
+    pyinstaller
+    wheel
 commands =
     flake8 setup.py src testing tools
 

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -1,0 +1,77 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+# Configuration file for quick / short tests.
+# Use tox_slow.ini for longer running tests.
+
+[tox]
+envlist = py37, flake8
+
+[testenv]
+# make sure those variables are passed down; you should define 
+# either explicitly the RDIFF_TEST_* variables or rely on the current
+# user being correctly identified (which might not happen in a container)
+passenv = RDIFF_TEST_* RDIFF_BACKUP_* LIBRSYNC_DIR
+#deps =
+#    pyxattr
+#    pylibacl
+whitelist_externals = cmd
+commands_pre =
+    cmd /c set
+    cmd /c copy %LIBRSYNC_DIR%\bin\rsync.dll {envbindir}
+    python {envbindir}\rdiff-backup --version
+    # must be the first command to setup the test environment
+    python testing/commontest.py
+commands =
+    python testing/ctest.py
+    python testing/timetest.py
+    python testing/librsynctest.py
+    python testing/statisticstest.py
+    python testing/user_grouptest.py
+    python testing/setconnectionstest.py
+    python testing/iterfiletest.py
+    python testing/longnametest.py
+    python testing/robusttest.py
+    python testing/connectiontest.py
+    python testing/incrementtest.py
+    python testing/hardlinktest.py
+    python testing/eas_aclstest.py
+    python testing/FilenameMappingtest.py
+    python testing/fs_abilitiestest.py
+    python testing/hashtest.py
+    python testing/selectiontest.py
+    python testing/metadatatest.py
+    python testing/rpathtest.py
+    python testing/rorpitertest.py
+    python testing/rdifftest.py
+    python testing/securitytest.py
+    python testing/killtest.py
+    python testing/backuptest.py
+    python testing/comparetest.py
+    python testing/regresstest.py
+    python testing/restoretest.py
+    python testing/cmdlinetest.py
+    python testing/rdiffbackupdeletetest.py
+    python testing/errorsrecovertest.py
+# can only work on OS/X TODO later
+#    python testing/resourceforktest.py
+
+[testenv:flake8]
+deps =
+    flake8
+commands =
+    flake8 setup.py src testing tools
+
+[flake8]
+ignore =
+    E501 # line too long (86 > 79 characters)
+    W503 # line break before binary operator
+exclude =
+    .git
+    .tox
+    .tox.root
+    __pycache__
+    build
+max-complexity = 40


### PR DESCRIPTION
I took your `tox_win.ini` from https://github.com/rdiff-backup/rdiff-backup/tree/ericzolf-make-tox-work-under-win, then proceeded to run every test and see which one succeeded and failed.

Personally I'm not fond of big-bang pull requests with a million and one fixes in it, so I would not be comfortable making a long-living branch in which I fix all the tests at once. So my suggestion is to merge this basic set up to `master`, after which I can look at, fix, uncomment, and submit each test individually.

I had to add the `deps` section to include the Windows specific dependencies (otherwise there were errors that it could find. eg `pwintypes` (`NameError: name 'pywintypes' is not defined`). Again, this is my lack of knowledge about the tooling, I'm not sure if this is the proper way to deal with this. I have all these dependencies installed globally on my system...

In a previous pull request you noted:
> Just one small thing for the future: check the prefixes to use for changelog-relevant messages in commits, in the developer documentation.

I am a little unsure when this applies and when it doesn't...