### PR TITLE
Add Windows test playbook to Vagrant tools

### DIFF
--- a/tools/windows/group_vars/windows_builders/rdiff-backup-test.yml
+++ b/tools/windows/group_vars/windows_builders/rdiff-backup-test.yml
@@ -1,0 +1,5 @@
+---
+# where to get the source code from
+rdiffbackup_files_git_repo: "https://github.com/rdiff-backup/rdiff-backup-filesrepo.git"
+# where to put the source code of rdiff-backup
+rdiffbackup_files_dir: "{{ working_dir }}/rdiff-backup-filesrepo"

--- a/tools/windows/playbook-test-rdiff-backup.yml
+++ b/tools/windows/playbook-test-rdiff-backup.yml
@@ -1,0 +1,30 @@
+---
+- name: Test rdiff-backup on a prepared Windows
+  hosts: windows_builders
+  gather_facts: false
+
+  tasks:
+  - name: make sure working directory {{ working_dir }} exists
+    win_file:
+      state: directory
+      path: "{{ working_dir }}"
+  - name: clone the rdiff-backup testfiles from Git
+    win_command: >
+      git.exe clone {{ rdiffbackup_files_git_repo }}
+      "{{ rdiffbackup_files_dir }}"
+    args:
+      creates: "{{ rdiffbackup_files_dir }}"
+
+  - name: unpack the testfiles (one hard link failure expected)
+    win_command: 7z x "{{ rdiffbackup_files_dir }}/rdiff-backup_testfiles.tar"
+    args:
+      chdir: "{{ working_dir }}"
+      creates: "{{ working_dir }}/rdiff-backup_testfiles"
+    ignore_errors: true  # 7z fails to extract one hard link
+
+  - name: test rdiff-backup using tox
+    win_command: tox -c tox_win.ini
+    environment:  # path absolutely needs to be Windows-style
+      LIBRSYNC_DIR: "{{ librsync_install_dir | replace('/', '\\\\') }}"
+    args:
+      chdir: "{{ rdiffbackup_dir }}"


### PR DESCRIPTION
The statistics test fails under Windows but it has nothing to do with the Ansible playbook as it also fails from the command line, cf. comment https://github.com/rdiff-backup/rdiff-backup/issues/347#issuecomment-674071029