### PR TITLE
Make it easier to use and test rdiff-backup directly from Git under Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ _site/
 
 # Profiling information
 mprofile_*.dat
+
+# Ignore Windows artefacts
+*.dll

--- a/tools/windows/playbook-build-rdiff-backup.yml
+++ b/tools/windows/playbook-build-rdiff-backup.yml
@@ -55,18 +55,30 @@
 
     # the following lines are not absolutely necessary but help debugging rdiff-backup
 
-    - name: copy rsync.dll to build directory to call rdiff-backup from there
+    - name: copy rsync.dll to build directory to call rdiff-backup from repo
       win_copy:  # newer versions of rsync.dll are installed in bin not lib
         src: "{{ librsync_install_dir }}/bin/rsync.dll"
         remote_src: true  # file is already on the Windows machine
-        dest: "{{ rdiffbackup_dir }}/build/"
+        dest: "{{ rdiffbackup_dir }}/"
       tags: debug_help
-    - name: create a simple helper script to call rdiff-backup from the build dir
+    - name: prepare variable backquote to avoid quoting issues
+      set_fact:
+        bq: \
+      tags: debug_help
+    - name: create a simple setup script to call rdiff-backup from the repo
       win_copy:
         content: |
           REM call this script to get the right environment variable and examples
           SET PYTHONPATH={{ rdiffbackup_dir }}/build/lib.win-{{ python_win_bits }}-3.7
-          REM python scripts-3.7\rdiff-backup --version
-          REM python -m pdb scripts-3.7\rdiff-backup --version
-        dest: "{{ rdiffbackup_dir }}/build/rdiff-backup.bat"
+          SET PATH={{ rdiffbackup_dir | replace('/', bq) }}\build\scripts-3.7;%PATH%
+        dest: "{{ rdiffbackup_dir }}/build/setup-rdiff-backup.bat"
+      tags: debug_help
+    - name: create a wrapper script to call rdiff-backup from the repo
+      win_copy:
+        content: |
+          @ECHO OFF
+          REM simple wrapper script to call rdiff-backup from the repo
+          REM d=Disk, p=(dir)path, n=name(without extension), x=extension
+          python "%~dpn0" %*
+        dest: "{{ rdiffbackup_dir }}/build/scripts-3.7/rdiff-backup.bat"
       tags: debug_help


### PR DESCRIPTION
DEV: make it easier to use and test rdiff-backup directly from the Git repo under Windows using Vagrant