### PR TITLE
Just slightly reformat win_acls for analysis reasons

### DIFF
--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -343,7 +343,7 @@ class PipeConnection(LowLevelPipeConnection):
     """Provide server and client functions for a Pipe Connection
 
     Both sides act as modules that allows for remote execution.  For
-    instance, self.conn.pow(2,8) will execute the operation on the
+    instance, self.connX.pow(2,8) will execute the operation on the
     server side.
 
     The only difference between the client and server is that the

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -72,8 +72,8 @@ class ACL:
             return
 
         try:
-            sd = rp.conn.win32security.GetNamedSecurityInfo(os.fsdecode(rp.path),
-                                                            SE_FILE_OBJECT, ACL.flags)
+            sd = rp.conn.win32security.GetNamedSecurityInfo(
+                os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to read ACL from %s: %s" % (repr(rp.path),
@@ -111,10 +111,8 @@ class ACL:
             sd.SetSecurityDescriptorSacl(0, None, 0)
 
         try:
-            self.__acl = \
-                rp.conn.win32security.ConvertSecurityDescriptorToStringSecurityDescriptor(sd,
-                                                                                          SDDL_REVISION_1,
-                                                                                          ACL.flags)
+            self.__acl = rp.conn.win32security.ConvertSecurityDescriptorToStringSecurityDescriptor(
+                sd, SDDL_REVISION_1, ACL.flags)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to convert ACL from %s to string: %s" % (repr(
@@ -126,8 +124,8 @@ class ACL:
         # not sure how to interpret this
         # I'll just clear all acl-s from rp.path
         try:
-            sd = rp.conn.win32security. \
-                GetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
+            sd = rp.conn.win32security.GetNamedSecurityInfo(
+                os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to read ACL from %s for clearing: %s" % (repr(
@@ -154,15 +152,16 @@ class ACL:
                 sd.SetSecurityDescriptorSacl(0, acl, 0)
 
         try:
-            rp.conn.win32security. \
-                SetNamedSecurityInfo(os.fsdecode(rp.path),
-                                     SE_FILE_OBJECT,
-                                     ACL.flags,
-                                     sd.GetSecurityDescriptorOwner(),
-                                     sd.GetSecurityDescriptorGroup(),
-                                     sd.GetSecurityDescriptorDacl(),
-                                     (ACL.flags & SACL_SECURITY_INFORMATION)
-                                     and sd.GetSecurityDescriptorSacl() or None)
+            rp.conn.win32security.SetNamedSecurityInfo(
+                os.fsdecode(rp.path),
+                SE_FILE_OBJECT,
+                ACL.flags,
+                sd.GetSecurityDescriptorOwner(),
+                sd.GetSecurityDescriptorGroup(),
+                sd.GetSecurityDescriptorDacl(),
+                (ACL.flags & SACL_SECURITY_INFORMATION)
+                and sd.GetSecurityDescriptorSacl() or None
+            )
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to set ACL on %s after clearing: %s" % (repr(
@@ -173,10 +172,8 @@ class ACL:
             return
 
         try:
-            sd = rp.conn.win32security. \
-                ConvertStringSecurityDescriptorToSecurityDescriptor(
-                    os.fsdecode(self.__acl),
-                    SDDL_REVISION_1)
+            sd = rp.conn.win32security.ConvertStringSecurityDescriptorToSecurityDescriptor(
+                os.fsdecode(self.__acl), SDDL_REVISION_1)
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to convert string %s to ACL: %s" % (repr(
@@ -209,14 +206,15 @@ class ACL:
             self._clear_rp(rp)
 
         try:
-            rp.conn.win32security. \
-                SetNamedSecurityInfo(os.fsdecode(rp.path),
-                                     SE_FILE_OBJECT, ACL.flags,
-                                     sd.GetSecurityDescriptorOwner(),
-                                     sd.GetSecurityDescriptorGroup(),
-                                     sd.GetSecurityDescriptorDacl(),
-                                     (ACL.flags & SACL_SECURITY_INFORMATION)
-                                     and sd.GetSecurityDescriptorSacl() or None)
+            rp.conn.win32security.SetNamedSecurityInfo(
+                os.fsdecode(rp.path),
+                SE_FILE_OBJECT, ACL.flags,
+                sd.GetSecurityDescriptorOwner(),
+                sd.GetSecurityDescriptorGroup(),
+                sd.GetSecurityDescriptorDacl(),
+                (ACL.flags & SACL_SECURITY_INFORMATION)
+                and sd.GetSecurityDescriptorSacl() or None
+            )
         except (OSError, IOError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to set ACL on %s: %s" % (repr(rp.path), exc),


### PR DESCRIPTION
It allows one to call something like the following command and get
a meaningful list of calls through the connection (hence kind of
describes the API between client and server):
`grep -ro conn\.[a-zA-Z0-9._]* src testing | awk -F: '{print }' | sort -u`