### PR TITLE
Add description of the API versioning approach

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -7,10 +7,14 @@ installations.
 
 ## API version files
 
-Each version file named vX.Y.md lists the objects and functions or methods
-defining the API interfaces. A basis version can be created using the script
-`tools/prepare_api_doc.sh` but it needs to be improved respecting the
-following structure:
+Each version file named vXYY.md lists the objects and functions or methods
+defining the API interfaces for the major version X, minor version YY.
+We use an integer instead of a traditional version scheme to make comparaisons
+easier internally, and avoid confusion with the application's version.
+
+A basis version of the file can be created using the script
+`tools/prepare_api_doc.sh` but it needs to be improved manually respecting
+the following structure:
 
 * _Format_ contains changes at the communication format as a bulleted
   list of free text describing the changes.
@@ -75,8 +79,8 @@ Each interface is described on a separate line of the following formats,
 * API and application don't need to be aligned, else we wouldn't need to
   consider separate versioning schemes.
 
-> **NOTE:** we consider v1.0 the implicit API version of the 1.y application
-	version and v2.0 the de-facto API version of the 2.0.z application
+> **NOTE:** we consider v100 the implicit API version of the 1.y application
+	version and v200 the de-facto API version of the 2.0.z application
 	versions. The interfaces of both API versions don't differ, they
 	are still incompatible due to changes between Python 2 and 3.
 
@@ -84,12 +88,12 @@ Each interface is described on a separate line of the following formats,
 
 To make the above rules more concrete:
 
-Version 15.0.0 of rdiff-backup uses version 5.0 of the API and has 2 interfaces:
+Version 15.0.0 of rdiff-backup uses version 500 of the API and has 2 interfaces:
 
 * `deepen`
 * `unchain`
 
-A version 5.1 of the API is created with a new function `neglect` and making
+A version 501 of the API is created with a new function `neglect` and making
 `deepen` deprecated:
 
 * `deepen` **deprecated**
@@ -103,20 +107,20 @@ to change API version in a bug-fix version). Version 15.1.0 defines the
 its use, it could be simply a new command line option).
 Version 15.1.0 works hence by default with version 15.0.0.
 
-A version 5.2 of the API could be created, with other changes, but the
+A version 502 of the API could be created, with other changes, but the
 new resp. deprecated states wouldn't change:
 
 * `deepen` **deprecated**
 * `neglect` **new**
 * `unchain`
 
-A version 6.0 of the API can then be created, which removes the deprecated
+A version 600 of the API can then be created, which removes the deprecated
 interface and makes the new interface usable by default:
 
 * `neglect`
 * `unchain`
 
-This version 6.0 could then be used by a new version of rdiff-backup 15.2.0,
+This version 600 could then be used by a new version of rdiff-backup 15.2.0,
 which would work with version 15.1.0 but not with version 15.0.0.
 
 > **NOTE:** we could declare a version 16.0.0 but that shouldn't be necessary

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,127 @@
+# client/server API documentation
+
+It is important that the API between two versions of rdiff-backup run in
+client/server mode remains stable, so that an upgrade doesn't need to be done
+on both sides at the same time, as some of our users have sizable
+installations.
+
+## API version files
+
+Each version file named vX.Y.md lists the objects and functions or methods
+defining the API interfaces. A basis version can be created using the script
+`tools/prepare_api_doc.sh` but it needs to be improved respecting the
+following structure:
+
+* _Format_ contains changes at the communication format as a bulleted
+  list of free text describing the changes.
+* _Sources_ contains the analysis of the actual source files under `src`
+* _Testing_ contains the interfaces used by the test files. These don't require
+  to be stable and are present mostly for reference.
+
+We also make the difference between `internal` and `external` interfaces:
+
+* _Internal_ are defined in the rdiff-backup modules and are under control of
+  the programmer, and must respect the rules edicted later.
+
+* _External_ are defined in Python and 3rd party libraries, they are
+  rather independent of the programmer of rdiff-backup but more of the
+  system on each side of the connection, python version installed. This can
+  help to assess which version of Python can be supported. It must follow
+  similar rules to deprecated and new interfaces e.g. so that users can upgrade
+  their python version timely.
+
+> **CAUTION:** the functions defined in `connection.py` don't have a module
+	prefix like all the other internal interfaces.
+	Make sure that you don't mix them up with the external interfaces.
+
+Each API version has its own file so that different versions can be easily
+compared. For this reason it is important to keep a consistent format and
+ordering, including blank lines and formatting.
+
+Each interface is described on a separate line of the following formats,
+`<module>` being optional:
+
+```
+* `<module>.<interface>`
+* `<module>.<interface>` **new**
+* `<module>.<interface>` **deprecated**
+```
+
+## Rules and conventions
+
+* each call in the code through the connection must be done in the form of
+  `conn.<module>.<interface>` so that the code analysis can be successful.
+  The connection variable name only needs to _end_ in `conn` (e.g.
+  `client_conn` is also fine).
+* avoid using the above construct in comments to not have false positives,
+  use e.g. `connX.<module>.<interface>` to avoid this.
+* interfaces defined in `connect.py` should be named `conn_<interface>` to
+  compensate for the lack of module prefix.
+* a new interface is marked as **new** for _at least_ one minor version of the
+  API. In these versions, the new interface can't be used to guarantee backward
+  compatibility, unless a (yet to be defined) command line parameter allows it.
+* a deprecated interface is marked as **deprecated** for _at least_ one minor
+  version of the API.
+* to keep things simple, it is forbidden to modify an existing interface
+  (e.g. add or remove parameters to a function). In such cases, add a new
+  function and deprecate the old function.
+* a new major version of the API is declared once:
+    * a **deprecated** interface is being definitely removed,
+    * or a **new** interface given free for usage.
+    * any incompatible change of the communication format, e.g. pickle format.
+* there must be at least one _application_ version between two increases of
+  the API major version, so that upgrades can be done for clients and servers
+  independently. Application bug-fix versions do _not_ count in this rule.
+* API and application don't need to be aligned, else we wouldn't need to
+  consider separate versioning schemes.
+
+> **NOTE:** we consider v1.0 the implicit API version of the 1.y application
+	version and v2.0 the de-facto API version of the 2.0.z application
+	versions. The interfaces of both API versions don't differ, they
+	are still incompatible due to changes between Python 2 and 3.
+
+## Example
+
+To make the above rules more concrete:
+
+Version 15.0.0 of rdiff-backup uses version 5.0 of the API and has 2 interfaces:
+
+* `deepen`
+* `unchain`
+
+A version 5.1 of the API is created with a new function `neglect` and making
+`deepen` deprecated:
+
+* `deepen` **deprecated**
+* `neglect` **new**
+* `unchain`
+
+At least one version of rdiff-backup must use the new API version, say 15.1.0.
+A version 15.0.1 wouldn't be sufficient (and it isn't expected or recommended
+to change API version in a bug-fix version). Version 15.1.0 defines the
+`neglect` function but does _not_ use it by default (unless a flag enforces
+its use, it could be simply a new command line option).
+Version 15.1.0 works hence by default with version 15.0.0.
+
+A version 5.2 of the API could be created, with other changes, but the
+new resp. deprecated states wouldn't change:
+
+* `deepen` **deprecated**
+* `neglect` **new**
+* `unchain`
+
+A version 6.0 of the API can then be created, which removes the deprecated
+interface and makes the new interface usable by default:
+
+* `neglect`
+* `unchain`
+
+This version 6.0 could then be used by a new version of rdiff-backup 15.2.0,
+which would work with version 15.1.0 but not with version 15.0.0.
+
+> **NOTE:** we could declare a version 16.0.0 but that shouldn't be necessary
+	and should more depend on the importance of the changes rather than
+	on individual interface changes.
+
+> **NOTE:** the `--version` option should long term also output the API
+	version(s) supported and the correct one be agreed automatically.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -73,11 +73,17 @@ Each interface is described on a separate line of the following formats,
     * a **deprecated** interface is being definitely removed,
     * or a **new** interface given free for usage.
     * any incompatible change of the communication format, e.g. pickle format.
-* there must be at least one _application_ version between two increases of
-  the API major version, so that upgrades can be done for clients and servers
-  independently. Application bug-fix versions do _not_ count in this rule.
+* there must be at least one _application_ major version between two increases
+  of the API major version, so that upgrades can be done for clients and servers
+  independently.
+* we strive to have at least one year, better more, between major releases to
+  give enough time for upgrades of big installations. Development constraints
+  might require faster cycles, but those should be avoided with time.
 * API and application don't need to be aligned, else we wouldn't need to
-  consider separate versioning schemes.
+  consider separate versioning schemes, but it makes things simpler when major
+  versions are aligned. Important changes not impacting the interface, e.g. to
+  the repository format, might nevertheless govern the introduction of an
+  application major version, independently of any breaking change to the API.
 
 > **NOTE:** we consider v100 the implicit API version of the 1.y application
 	version and v200 the de-facto API version of the 2.0.z application
@@ -88,7 +94,7 @@ Each interface is described on a separate line of the following formats,
 
 To make the above rules more concrete:
 
-Version 15.0.0 of rdiff-backup uses version 500 of the API and has 2 interfaces:
+Version 5.0.0 of rdiff-backup uses version 500 of the API and has 2 interfaces:
 
 * `deepen`
 * `unchain`
@@ -100,12 +106,12 @@ A version 501 of the API is created with a new function `neglect` and making
 * `neglect` **new**
 * `unchain`
 
-At least one version of rdiff-backup must use the new API version, say 15.1.0.
-A version 15.0.1 wouldn't be sufficient (and it isn't expected or recommended
-to change API version in a bug-fix version). Version 15.1.0 defines the
+At least one version of rdiff-backup must use the new API version, say 5.1.0.
+A version 5.0.1 wouldn't be sufficient (and it isn't expected or recommended
+to change API version in a bug-fix version). Version 5.1.0 defines the
 `neglect` function but does _not_ use it by default (unless a flag enforces
 its use, it could be simply a new command line option).
-Version 15.1.0 works hence by default with version 15.0.0.
+Version 5.1.0 works hence by default with version 5.0.0.
 
 A version 502 of the API could be created, with other changes, but the
 new resp. deprecated states wouldn't change:
@@ -120,8 +126,8 @@ interface and makes the new interface usable by default:
 * `neglect`
 * `unchain`
 
-This version 600 could then be used by a new version of rdiff-backup 15.2.0,
-which would work with version 15.1.0 but not with version 15.0.0.
+This version 600 could then be used by a new version of rdiff-backup 6.0.0,
+which would work with version 5.1.0 but not with version 5.0.z.
 
 > **NOTE:** we could declare a version 16.0.0 but that shouldn't be necessary
 	and should more depend on the importance of the changes rather than

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -129,9 +129,8 @@ interface and makes the new interface usable by default:
 This version 600 could then be used by a new version of rdiff-backup 6.0.0,
 which would work with version 5.1.0 but not with version 5.0.z.
 
-> **NOTE:** we could declare a version 16.0.0 but that shouldn't be necessary
-	and should more depend on the importance of the changes rather than
-	on individual interface changes.
+> **NOTE:** it could be as well a version 7.0.0 should other important changes
+	have justified a major version in-between.
 
 > **NOTE:** the `--version` option should long term also output the API
 	version(s) supported and the correct one be agreed automatically.

--- a/docs/api/v2.0.md
+++ b/docs/api/v2.0.md
@@ -1,0 +1,119 @@
+# rdiff-backup API description v2.1
+
+## Format
+
+* format changed from Python 2 to Python 3 (incompatible types esp. bytes).
+
+## Sources
+
+
+### Internal
+
+* `backup.DestinationStruct`
+* `backup.SourceStruct`
+* `backup.SourceStruct.set_source_select`
+* `compare.DataSide`
+* `compare.RepoSide`
+* `compare.Verify`
+* `conn_number`
+* `quit`
+* `reval`
+* `eas_acls.get_acl_lists_from_rp`
+* `eas_acls.set_rp_acl`
+* `FilenameMapping.set_init_quote_vals`
+* `FilenameMapping.set_init_quote_vals_local`
+* `fs_abilities.backup_set_globals`
+* `fs_abilities.get_readonly_fsa`
+* `fs_abilities.restore_set_globals`
+* `fs_abilities.single_set_globals`
+* `Globals.get`
+* `Globals.postset_regexp_local`
+* `Globals.set`
+* `Globals.set_local`
+* `Hardlink.initialize_dictionaries`
+* `log.Log.close_logfile_allconn`
+* `log.Log.close_logfile_local`
+* `log.Log.log_to_file`
+* `log.Log.open_logfile_allconn`
+* `log.Log.open_logfile_local`
+* `log.Log.setterm_verbosity`
+* `log.Log.setverbosity`
+* `Main.backup_close_statistics`
+* `Main.backup_remove_curmirror_local`
+* `Main.backup_touch_curmirror_local`
+* `manage.delete_earlier_than_local`
+* `regress.check_pids`
+* `regress.Regress`
+* `restore.ListAtTime`
+* `restore.ListChangedSince`
+* `restore.MirrorStruct`
+* `restore.MirrorStruct.set_mirror_select`
+* `restore.TargetStruct`
+* `restore.TargetStruct.set_target_select`
+* `robust.install_signal_handlers`
+* `rpath.copy_reg_file`
+* `rpath.delete_dir_no_files`
+* `rpath.gzip_open_local_read`
+* `rpath.make_file_dict`
+* `rpath.make_socket_local`
+* `rpath.open_local_read`
+* `rpath.RPath.fsync_local`
+* `rpath.setdata_local`
+* `SetConnections.add_redirected_conn`
+* `SetConnections.init_connection_remote`
+* `statistics.record_error`
+* `Time.setcurtime_local`
+* `Time.setprevtime_local`
+* `user_group.init_group_mapping`
+* `user_group.init_user_mapping`
+* `user_group.map_rpath`
+
+### External
+
+* `gzip.GzipFile`
+* `open`
+* `os.chmod`
+* `os.chown`
+* `os.getuid`
+* `os.lchown`
+* `os.link`
+* `os.listdir`
+* `os.makedev`
+* `os.makedirs`
+* `os.mkdir`
+* `os.mkfifo`
+* `os.mknod`
+* `os.name`
+* `os.rename`
+* `os.rmdir`
+* `os.symlink`
+* `os.unlink`
+* `os.utime`
+* `shutil.rmtree`
+* `sys.stdout.write`
+* `win32security.ConvertSecurityDescriptorToStringSecurityDescriptor`
+* `win32security.ConvertStringSecurityDescriptorToSecurityDescriptor`
+* `win32security.GetNamedSecurityInfo`
+* `win32security.SetNamedSecurityInfo`
+* `xattr.get`
+* `xattr.list`
+* `xattr.remove`
+* `xattr.set`
+
+## Testing
+
+
+### Internal
+
+
+### External
+
+* `hasattr`
+* `int`
+* `ord`
+* `os.lstat`
+* `os.path.join`
+* `os.remove`
+* `pow`
+* `str`
+* `tempfile.mktemp`

--- a/docs/api/v200.md
+++ b/docs/api/v200.md
@@ -1,4 +1,4 @@
-# rdiff-backup API description v2.1
+# rdiff-backup API description v200
 
 ## Format
 

--- a/tools/prepare_api_doc.sh
+++ b/tools/prepare_api_doc.sh
@@ -6,7 +6,7 @@
 
 if ! [ -n "$1" ]
 then
-	echo "Usage: $0 X.Y" >&2
+	echo "Usage: $0 XYY" >&2
 	exit 1
 fi
 

--- a/tools/prepare_api_doc.sh
+++ b/tools/prepare_api_doc.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# this function gathers all calls going through the client/server connection.
+# the result can only be used as a basis or validation for the actual API
+# documentation, especially because it can't make the difference between
+# internal and external methods.
+
+if ! [ -n "$1" ]
+then
+	echo "Usage: $0 X.Y" >&2
+	exit 1
+fi
+
+API_FILE=docs/api/v${1}.md
+
+echo -e "\n## Sources\n" > ${API_FILE}.src
+
+echo -e "\n### Internal\n" >> ${API_FILE}.src
+
+grep -ro -e 'conn\.[a-zA-Z0-9._]*' src | \
+	awk -F:conn. '{print "* `" $2 "`"}' | sort -u >> ${API_FILE}.src
+
+echo -e "\n### External\n" >> ${API_FILE}.src
+
+
+echo -e "\n## Testing\n" > ${API_FILE}.testing
+
+echo -e "\n### Internal\n" >> ${API_FILE}.testing
+echo -e "\n### External\n" >> ${API_FILE}.testing
+
+grep -ro -e 'conn\.[a-zA-Z0-9._]*' testing | \
+	awk -F:conn. '{print "* `" $2 "`"}' | sort -u | \
+	grep --fixed-strings --line-regexp --file ${API_FILE}.src \
+		--invert-match >> ${API_FILE}.testing
+
+echo -e "# rdiff-backup API description v${1}\n" > ${API_FILE}
+echo -e "\n## Format\n" >> ${API_FILE}
+
+cat ${API_FILE}.* >> ${API_FILE}
+
+rm ${API_FILE}.*
+
+echo "API description prepared at '${API_FILE}'."


### PR DESCRIPTION
DEV: add docs/api folder with API description to be followed and API v2.0.

Also create a tool script `prepare_api_doc.sh` to help with documenting the API.

A thorough review is important as it will drive future changes of the code for the foreseeable future.