### PR TITLE
Add no-compression defaults for .webm and .tzst

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -215,7 +215,7 @@ compression = 1
 no_compression_regexp_string = (
     b"(?i).*\\.(gz|z|bz|bz2|tgz|zip|zst|rpm|deb|"
     b"jpg|jpeg|gif|png|jp2|mp3|mp4|ogg|ogv|oga|ogm|avi|wmv|mpeg|mpg|rm|mov|mkv|flac|shn|pgp|"
-    b"gpg|rz|lz4|lzh|lzo|zoo|lharc|rar|arj|asc|vob|mdf)$")
+    b"gpg|rz|lz4|lzh|lzo|zoo|lharc|rar|arj|asc|vob|mdf|tzst|webm)$")
 no_compression_regexp = None
 
 # If true, filelists and directory statistics will be split on


### PR DESCRIPTION
.tzst is the abbreviated form of .tar.zst, see https://github.com/facebook/zstd/blob/dev/programs/fileio.h
.webm is the video container created by Google, see https://www.webmproject.org/docs/container/