### PR TITLE
Add api version handling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,24 +9,27 @@ assignees: ''
 
 ## Bug summary
 
-A clear and concise description of what the bug is.
+REPLACE THIS LINE - A clear and concise description of what the bug is
 
 ## Version, Python, Operating System
 
-Call `rdiff-backup -v9` and paste the output between the backquotes below, repeat for each environment impacted:
+Call `rdiff-backup --version --api-version 201` or `rdiff-backup -v9` and replace the following line with the output, repeat for each environment impacted:
 
-```
+```yaml
+<REPLACE THIS LINE - version info>
 ```
 
 ## rdiff-backup call
 
-How did you call rdiff-backup, with which parameter:
+How did you call rdiff-backup, with which parameters:
 
 ```
+<REPLACE THIS LINE - parameters>
 ```
 
 ## What happened and what did you expect?
 
+REPLACE THIS LINE - what happened, what did you expect?
 
 ## More information
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,16 +9,16 @@ assignees: ''
 
 ## Is your feature request related to a problem? Please describe.
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+REPLACE THIS LINE - A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Describe the solution you'd like
 
-A clear and concise description of what you want to happen.
+REPLACE THIS LINE - A clear and concise description of what you want to happen.
 
 ## Describe alternatives you've considered
 
-A clear and concise description of any alternative solutions or features you've considered.
+REPLACE THIS LINE - A clear and concise description of any alternative solutions or features you've considered.
 
 ## Additional context
 
-Add any other context or screenshots about the feature request here.
+REPLACE THIS LINE - Add any other context or screenshots about the feature request here.

--- a/docs/api/v201.md
+++ b/docs/api/v201.md
@@ -1,0 +1,119 @@
+# rdiff-backup API description v200
+
+## Format
+
+* the --version option outputs YAML instead of simply "rdiff-backup <version>"
+
+## Sources
+
+
+### Internal
+
+* `backup.DestinationStruct`
+* `backup.SourceStruct`
+* `backup.SourceStruct.set_source_select`
+* `compare.DataSide`
+* `compare.RepoSide`
+* `compare.Verify`
+* `conn_number`
+* `quit`
+* `reval`
+* `eas_acls.get_acl_lists_from_rp`
+* `eas_acls.set_rp_acl`
+* `FilenameMapping.set_init_quote_vals`
+* `FilenameMapping.set_init_quote_vals_local`
+* `fs_abilities.backup_set_globals`
+* `fs_abilities.get_readonly_fsa`
+* `fs_abilities.restore_set_globals`
+* `fs_abilities.single_set_globals`
+* `Globals.get`
+* `Globals.postset_regexp_local`
+* `Globals.set`
+* `Globals.set_local`
+* `Hardlink.initialize_dictionaries`
+* `log.Log.close_logfile_allconn`
+* `log.Log.close_logfile_local`
+* `log.Log.log_to_file`
+* `log.Log.open_logfile_allconn`
+* `log.Log.open_logfile_local`
+* `log.Log.setterm_verbosity`
+* `log.Log.setverbosity`
+* `Main.backup_close_statistics`
+* `Main.backup_remove_curmirror_local`
+* `Main.backup_touch_curmirror_local`
+* `manage.delete_earlier_than_local`
+* `regress.check_pids`
+* `regress.Regress`
+* `restore.ListAtTime`
+* `restore.ListChangedSince`
+* `restore.MirrorStruct`
+* `restore.MirrorStruct.set_mirror_select`
+* `restore.TargetStruct`
+* `restore.TargetStruct.set_target_select`
+* `robust.install_signal_handlers`
+* `rpath.copy_reg_file`
+* `rpath.delete_dir_no_files`
+* `rpath.gzip_open_local_read`
+* `rpath.make_file_dict`
+* `rpath.make_socket_local`
+* `rpath.open_local_read`
+* `rpath.RPath.fsync_local`
+* `rpath.setdata_local`
+* `SetConnections.add_redirected_conn`
+* `SetConnections.init_connection_remote`
+* `statistics.record_error`
+* `Time.setcurtime_local`
+* `Time.setprevtime_local`
+* `user_group.init_group_mapping`
+* `user_group.init_user_mapping`
+* `user_group.map_rpath`
+
+### External
+
+* `gzip.GzipFile`
+* `open`
+* `os.chmod`
+* `os.chown`
+* `os.getuid`
+* `os.lchown`
+* `os.link`
+* `os.listdir`
+* `os.makedev`
+* `os.makedirs`
+* `os.mkdir`
+* `os.mkfifo`
+* `os.mknod`
+* `os.name`
+* `os.rename`
+* `os.rmdir`
+* `os.symlink`
+* `os.unlink`
+* `os.utime`
+* `shutil.rmtree`
+* `sys.stdout.write`
+* `win32security.ConvertSecurityDescriptorToStringSecurityDescriptor`
+* `win32security.ConvertStringSecurityDescriptorToSecurityDescriptor`
+* `win32security.GetNamedSecurityInfo`
+* `win32security.SetNamedSecurityInfo`
+* `xattr.get`
+* `xattr.list`
+* `xattr.remove`
+* `xattr.set`
+
+## Testing
+
+
+### Internal
+
+
+### External
+
+* `hasattr`
+* `int`
+* `ord`
+* `os.lstat`
+* `os.path.join`
+* `os.remove`
+* `pow`
+* `str`
+* `tempfile.mktemp`

--- a/docs/rdiff-backup.1
+++ b/docs/rdiff-backup.1
@@ -75,9 +75,11 @@ parameter.
 .BI "\-\-api-version " api
 Sets the API version to the given integer between minimum and maximum versions
 as given by the
-.B \-\-versions
-option. It is the responsibility of the user to make sure that this version is
-also supported by any server started by this client.
+.B \-\-version
+option, with API above 200, i.e. by calling something like
+.B rdiff-backup \-\-version \-\-api-version 201.
+It is the responsibility of the user to make sure
+that this version is also supported by any server started by this client.
 .TP
 .B \-b, \-\-backup-mode
 Force backup mode even if first argument appears to be an increment or
@@ -536,13 +538,10 @@ Check all the data in the repository at the given time by computing
 the SHA1 hash of all the regular files and comparing them with the
 hashes stored in the metadata file.
 .TP
-.B "-V, \-\-version, \-\-versions"
+.B "-V, \-\-version"
 Print the current version and exit.
-.B \-\-versions
-(plural) is only known
-by rdiff-backup starting with version 2.1 and outputs also information about
-API, call, python and operating system. This is also the default behavior
-of the traditional options if the API version is strictly more than 200.
+Starting with version 201 of the API, it outputs also information about
+API, call, python and operating system.
 
 .SH ENVIRONMENT
 .TP

--- a/docs/rdiff-backup.1
+++ b/docs/rdiff-backup.1
@@ -72,6 +72,13 @@ using the
 .B \-\-remove-older-than
 parameter.
 .TP
+.BI "\-\-api-version " api
+Sets the API version to the given integer between minimum and maximum versions
+as given by the
+.B \-\-versions
+option. It is the responsibility of the user to make sure that this version is
+also supported by any server started by this client.
+.TP
 .B \-b, \-\-backup-mode
 Force backup mode even if first argument appears to be an increment or
 mirror file.
@@ -529,8 +536,13 @@ Check all the data in the repository at the given time by computing
 the SHA1 hash of all the regular files and comparing them with the
 hashes stored in the metadata file.
 .TP
-.B "-V, \-\-version"
-Print the current version and exit
+.B "-V, \-\-version, \-\-versions"
+Print the current version and exit.
+.B \-\-versions
+(plural) is only known
+by rdiff-backup starting with version 2.1 and outputs also information about
+API, call, python and operating system. This is also the default behavior
+of the traditional options if the API version is strictly more than 200.
 
 .SH ENVIRONMENT
 .TP

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@
 setuptools
 setuptools-scm
 importlib-metadata ~= 1.0 ; python_version < "3.8"
+PyYAML  # for rdiff-backup >= 2.1
 
 # optional
 pylibacl

--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,9 @@ setup(
         'build_py': build_py,
         'clean': clean,
     },
-    install_requires=['importlib-metadata ~= 1.0 ; python_version < "3.8"'],
+    install_requires=[
+        'importlib-metadata ~= 1.0 ; python_version < "3.8"',
+        'PyYAML',
+    ],
     setup_requires=['setuptools_scm'],
 )

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -20,6 +20,8 @@
 
 import re
 import os
+import platform
+import sys
 from . import log
 
 # The current version of rdiff-backup
@@ -421,3 +423,25 @@ def get_api_version():
     """Return the actual API version, either set explicitly or the default
     one"""
     return api_version["actual"] or api_version["default"] 
+
+
+def get_runtime_info():
+    """Return a structure containing all relevant runtime information about
+    the executable, Python and the operating system.
+    Beware that additional information might be added at any time."""
+    return {
+        'exec': {
+            'version': version,
+            'api_version': api_version,
+            'argv': sys.argv,
+        },
+        'python': {
+            'name': sys.implementation.name,
+            'executable': sys.executable,
+            'version': platform.python_version(),
+        },
+        'system': {
+            'platform': platform.platform(),
+            'fs_encoding': sys.getfilesystemencoding(),
+        },
+    }

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -412,10 +412,14 @@ def set_api_version(val):
         intval = int(val)
     except ValueError:
         log.Log.FatalError(
-            f"API version must be set to an integer, received {val} instead.")
+            "API version must be set to an integer, "
+            "received {val} instead.".format(val=val))
     if intval < api_version["min"] or intval > api_version["max"]:
-        log.Log.FatalError(f"API version {val} must be between "
-                           f"{api_version['min']} and {api_version['max']}.")
+        log.Log.FatalError(
+            "API version {val} must be between {api_min} and {api_max}.".format(
+                val=val,
+                api_min=api_version["min"],
+                api_max=api_version["max"]))
     api_version["actual"] = intval
 
 

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -42,6 +42,17 @@ try:
 except BaseException:  # if everything else fails...
     version = "DEV-no-metadata"
 
+# The default, supported (min/max) and actual API versions.
+# An actual value of 0 means that the default version is to be used or whatever
+# makes the connection work within the min-max range, depending on the
+# API versions supported by the remote connection.
+api_version = {
+    "default": 200,
+    "min": 200,
+    "max": 200,
+    "actual": 0
+}
+
 # If this is set, use this value in seconds as the current time
 # instead of reading it from the clock.
 current_time = None

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -49,7 +49,7 @@ except BaseException:  # if everything else fails...
 api_version = {
     "default": 200,
     "min": 200,
-    "max": 200,
+    "max": 201,
     "actual": 0
 }
 
@@ -401,3 +401,23 @@ def postset_regexp_local(name, re_string, flags):
         globals()[name] = re.compile(re_string, flags)
     else:
         globals()[name] = re.compile(re_string)
+
+
+def set_api_version(val):
+    """sets the actual API version after having verified that the new
+    value is an integer between mix and max values."""
+    try:
+        intval = int(val)
+    except ValueError:
+        log.Log.FatalError(
+            f"API version must be set to an integer, received {val} instead.")
+    if intval < api_version["min"] or intval > api_version["max"]:
+        log.Log.FatalError(f"API version {val} must be between "
+            f"{api_version['min']} and {api_version['max']}.")
+    api_version["actual"] = intval
+
+
+def get_api_version():
+    """Return the actual API version, either set explicitly or the default
+    one"""
+    return api_version["actual"] or api_version["default"] 

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -415,14 +415,14 @@ def set_api_version(val):
             f"API version must be set to an integer, received {val} instead.")
     if intval < api_version["min"] or intval > api_version["max"]:
         log.Log.FatalError(f"API version {val} must be between "
-            f"{api_version['min']} and {api_version['max']}.")
+                           f"{api_version['min']} and {api_version['max']}.")
     api_version["actual"] = intval
 
 
 def get_api_version():
     """Return the actual API version, either set explicitly or the default
     one"""
-    return api_version["actual"] or api_version["default"] 
+    return api_version["actual"] or api_version["default"]
 
 
 def get_runtime_info():

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -96,7 +96,8 @@ def _parse_cmdlineoptions(arglist):  # noqa: C901
             "restrict-read-only=", "restrict-update-only=", "server",
             "ssh-no-compression", "tempdir=", "terminal-verbosity=",
             "test-server", "use-compatible-timestamps", "user-mapping-file=",
-            "verbosity=", "verify", "verify-at-time=", "version", "no-fsync"
+            "verbosity=", "verify", "verify-at-time=", "version", "no-fsync",
+            "versions", "api-version="
         ])
     except getopt.error as e:
         _commandline_error("Bad commandline options: " + str(e))
@@ -252,18 +253,39 @@ def _parse_cmdlineoptions(arglist):  # noqa: C901
         elif opt == "--verify-at-time":
             _action, _restore_timestr = "verify", arg
         elif opt == "-V" or opt == "--version":
-            print("rdiff-backup " + Globals.version)
-            sys.exit(0)
+            _action = "version"
+            version_format = "legacy"
+        elif opt == "--versions":
+            _action = "version"
+            version_format = "full"
+        elif opt == "--api-version":
+            Globals.set_api_version(arg)
         elif opt == "--no-fsync":
             Globals.do_fsync = False
         else:
             Log.FatalError("Unknown option %s" % opt)
-    Log("Using rdiff-backup version %s" % (Globals.version), 4)
-    Log("\twith %s %s version %s" % (
-        sys.implementation.name,
-        sys.executable,
-        platform.python_version()), 4)
-    Log("\ton %s, fs encoding %s" % (platform.platform(), sys.getfilesystemencoding()), 4)
+    if _action == "version":
+        _output_version(version_format=version_format, exit=True)
+    else:
+        _output_version(version_format="log")
+
+
+def _output_version(version_format, exit=False):
+    if version_format == "legacy" and Globals.get_api_version() == 200:
+        print("rdiff-backup " + Globals.version)
+    else:
+        # FIXME use proper YAML format
+        version_strings = (
+            f"Using rdiff-backup version {Globals.version}",
+            f"API versions are {Globals.api_version}",
+            f"with {sys.implementation.name} {sys.executable} version {platform.python_version()}",
+            f"on {platform.platform()}, fs encoding {sys.getfilesystemencoding()}")
+        if version_format == "log":
+            Log(", ".join(version_strings), 4)
+        else:
+            print("\n\t".join(version_strings))
+    if exit:
+        sys.exit(0)
 
 
 def _check_action():

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -97,7 +97,7 @@ def _parse_cmdlineoptions(arglist):  # noqa: C901
             "ssh-no-compression", "tempdir=", "terminal-verbosity=",
             "test-server", "use-compatible-timestamps", "user-mapping-file=",
             "verbosity=", "verify", "verify-at-time=", "version", "no-fsync",
-            "versions", "api-version="
+            "api-version="
         ])
     except getopt.error as e:
         _commandline_error("Bad commandline options: " + str(e))
@@ -255,9 +255,6 @@ def _parse_cmdlineoptions(arglist):  # noqa: C901
         elif opt == "-V" or opt == "--version":
             _action = "version"
             version_format = "legacy"
-        elif opt == "--versions":
-            _action = "version"
-            version_format = "full"
         elif opt == "--api-version":
             Globals.set_api_version(arg)
         elif opt == "--no-fsync":
@@ -273,7 +270,8 @@ def _parse_cmdlineoptions(arglist):  # noqa: C901
 def _output_version(version_format, exit=False):
     """Output either the 'legacy' version string with 'rdiff-backup <version>'
     or all the runtime information provided as YAML structure, either on
-    one line for the 'log' format or properly for the 'full' format."""
+    one line for the 'log' format or properly for the 'full' format,
+    implictly used when the API version is more than 200."""
 
     if version_format == "legacy" and Globals.get_api_version() == 200:
         print("rdiff-backup " + Globals.version)

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -445,7 +445,7 @@ def _Main(arglist):
     # We continue to test-server so that all connections can be tested at once.
     if any(map(lambda x: x is None, rps)) and _action != "test-server":
         _cleanup()
-        _sys.exit(1)
+        sys.exit(1)
 
     _final_set_action(rps)
     _misc_setup(rps)

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -416,6 +416,13 @@ def _Main(arglist):
     cmdpairs = SetConnections.get_cmd_pairs(_args, _remote_schema, _remote_cmd)
     Security.initialize(_action or "mirror", cmdpairs)
     rps = list(map(SetConnections.cmdpair2rp, cmdpairs))
+
+    # if any of the remote paths is None, we have an error.
+    # We continue to test-server so that all connections can be tested at once.
+    if any(map(lambda x: x is None, rps)) and _action != "test-server":
+        _cleanup()
+        _sys.exit(1)
+
     _final_set_action(rps)
     _misc_setup(rps)
     return_val = _take_action(rps)

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -411,7 +411,7 @@ def _test_connection(conn_number, rp):
         except AttributeError:  # Windows doesn't support os.getuid()
             assert type(conn.os.listdir(rp.path)) is list
     except BaseException as exc:
-        sys.stderr.write(f"- Server tests failed due to {exc}\n")
+        sys.stderr.write("- Server tests failed due to {exc}\n".format(exc=exc))
         return False
     else:
         print("- Server OK")

--- a/testing/api_test.py
+++ b/testing/api_test.py
@@ -35,5 +35,6 @@ class ApiVersionTest(unittest.TestCase):
         out_info = yaml.safe_load(output)
         self.assertEqual(out_info['exec']['api_version']['actual'], api_version['max'])
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/testing/api_test.py
+++ b/testing/api_test.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+import unittest
+import yaml
+from commontest import RBBin
+from rdiff_backup import Globals
+
+
+class ApiVersionTest(unittest.TestCase):
+    """Test api versioning functionality"""
+
+    def test_runtime_info_calling(self):
+        """make sure that the --versions output can be read back as YAML"""
+        output = subprocess.check_output([RBBin, b'--versions'])
+        out_info = yaml.safe_load(output)
+        info = Globals.get_runtime_info()
+
+        # because the current test will have a different call than rdiff-backup itself
+        # we can't compare certain keys
+        self.assertIn('exec', out_info)
+        self.assertIn('argv', out_info['exec'])
+        out_info['exec'].pop('argv')
+        info['exec'].pop('argv')
+        # info['python']['executable'] could also be different but I think that our test
+        # environments make sure that it doesn't happen
+        self.assertEqual(info, out_info)
+
+    def test_default_actual_api(self):
+        """validate that the default version is the actual one or the one explicitly set"""
+        output = subprocess.check_output([RBBin, b'--versions'])
+        api_version = yaml.safe_load(output)['exec']['api_version']
+        self.assertEqual(Globals.get_api_version(), api_version['default'])
+        api_param = os.fsencode(str(api_version['max']))
+        output = subprocess.check_output([RBBin, b'--versions', b'--api-version', api_param])
+        out_info = yaml.safe_load(output)
+        self.assertEqual(out_info['exec']['api_version']['actual'], api_version['max'])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/api_test.py
+++ b/testing/api_test.py
@@ -10,9 +10,11 @@ class ApiVersionTest(unittest.TestCase):
     """Test api versioning functionality"""
 
     def test_runtime_info_calling(self):
-        """make sure that the --versions output can be read back as YAML"""
-        output = subprocess.check_output([RBBin, b'--versions'])
+        """make sure that the --version output can be read back as YAML when API is 201"""
+        output = subprocess.check_output([RBBin, b'--version', b'--api-version', b'201'])
         out_info = yaml.safe_load(output)
+
+        Globals.api_version['actual'] = 201
         info = Globals.get_runtime_info()
 
         # because the current test will have a different call than rdiff-backup itself
@@ -27,11 +29,11 @@ class ApiVersionTest(unittest.TestCase):
 
     def test_default_actual_api(self):
         """validate that the default version is the actual one or the one explicitly set"""
-        output = subprocess.check_output([RBBin, b'--versions'])
+        output = subprocess.check_output([RBBin, b'--version', b'--api-version', b'201'])
         api_version = yaml.safe_load(output)['exec']['api_version']
         self.assertEqual(Globals.get_api_version(), api_version['default'])
         api_param = os.fsencode(str(api_version['max']))
-        output = subprocess.check_output([RBBin, b'--versions', b'--api-version', api_param])
+        output = subprocess.check_output([RBBin, b'--version', b'--api-version', api_param])
         out_info = yaml.safe_load(output)
         self.assertEqual(out_info['exec']['api_version']['actual'], api_version['max'])
 

--- a/tools/bash-completion/rdiff-backup
+++ b/tools/bash-completion/rdiff-backup
@@ -30,7 +30,7 @@ _rdiff_backup ()
 		|--restrict-update-only|--tempdir"
 
 	# These options will be completed by a number, from 0 to 9.
-	wnumarg="--terminal-verbosity|--verbosity|-v"
+	wnumarg="--terminal-verbosity|--verbosity|-v|--api-version"
 
 	# These options requires a non-completable argument.
 	# They won't be completed at all.
@@ -41,7 +41,7 @@ _rdiff_backup ()
 		|--remove-older-than|--verify-at-time"
 
 	# Available long options
-	longopts="--allow-duplicate-timestamps --backup-mode \
+	longopts="--allow-duplicate-timestamps --api-version --backup-mode \
 		--calculate-average --carbonfile --check-destination-dir \
 		--compare --compare-at-time --compare-full --compare-full-at-time \
 		--compare-hash --compare-hash-at-time --create-full-path --current-time \
@@ -60,7 +60,7 @@ _rdiff_backup ()
 		--restrict-read-only --restrict-update-only --ssh-no-compression --tempdir \
 		--terminal-verbosity --test-server --use-compatible-timestamps \
 		--user-mapping-file --verbosity --verify --verify-at-time \
-		--version"
+		--version --versions"
 
 	# Available short options
 	shortopts="-b -l -r -v -V"

--- a/tools/bash-completion/rdiff-backup
+++ b/tools/bash-completion/rdiff-backup
@@ -60,7 +60,7 @@ _rdiff_backup ()
 		--restrict-read-only --restrict-update-only --ssh-no-compression --tempdir \
 		--terminal-verbosity --test-server --use-compatible-timestamps \
 		--user-mapping-file --verbosity --verify --verify-at-time \
-		--version --versions"
+		--version"
 
 	# Available short options
 	shortopts="-b -l -r -v -V"

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -9,7 +9,7 @@ yum install -y librsync-devel
 # Compile wheels
 for PYBIN in $pybindirs; do
     "${PYBIN}/pip" install --user \
-        'importlib-metadata ~= 1.0 ; python_version < "3.8"'
+        'importlib-metadata ~= 1.0 ; python_version < "3.8"' 'PyYAML'
     "${PYBIN}/pip" wheel /io/ -w dist/
 done
 

--- a/tools/crossversion/host_vars/oldrdiffbackup/version.yml
+++ b/tools/crossversion/host_vars/oldrdiffbackup/version.yml
@@ -1,2 +1,2 @@
 ---
-rdiff_backup_old_version: "2.0.0"
+rdiff_backup_old_version: "2.0.5"

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands_pre =
 # also for sub-processes, like for "client/server" rdiff-backup
 	python -c 'with open("{envsitepackagesdir}/coverage.pth","w") as fd: fd.write("import coverage; coverage.process_startup()\n")'
 commands =
+	coverage run testing/api_test.py
 	coverage run testing/ctest.py
 	coverage run testing/timetest.py
 	coverage run testing/librsynctest.py

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ setenv =
 	COVERAGE_PROCESS_START = {toxinidir}/tox.ini
 deps =
 	importlib-metadata ~= 1.0 ; python_version < "3.8"
+	PyYAML
 	pyxattr
 	pylibacl
 	coverage

--- a/tox_dist.ini
+++ b/tox_dist.ini
@@ -16,6 +16,7 @@ passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 skip_install = true
 deps =
     setuptools-scm
+    PyYAML
     pyxattr
     pylibacl
     wheel

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -21,6 +21,7 @@ isolated_build_env = .package.root
 passenv = SUDO_USER SUDO_UID SUDO_GID RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
     importlib-metadata ~= 1.0 ; python_version < "3.8"
+    PyYAML
     pyxattr
     pylibacl
 #whitelist_externals = env

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -13,6 +13,7 @@ envlist = py35, py36, py37, py38
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
     importlib-metadata ~= 1.0 ; python_version < "3.8"
+    PyYAML
     pyxattr
     pylibacl
 # whitelist_externals =


### PR DESCRIPTION
Based on the documentation created previously, I've added the concept of API version with min, max, default and actual one. The actual one can be "agreed" between client and server based on their respective default/min/max values.
I've also added an option `--api-version` to change the default version used (currently 200, which is equivalent to version v2.0.x), and an option `--versions` to output this API version and more information, in YAML format for easier parsing by potential scripts.
Last but not least, I've added few tests to cover the new functionality.