### PR TITLE
Introduce Python 3.9 and remove Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ jobs:
       install:
         - docker pull $DOCKER_IMAGE
       script:
-        - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
+        - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh "/opt/python/cp36*/bin" "/opt/python/cp37*/bin" "/opt/python/cp38*/bin" "/opt/python/cp39*/bin"
         - ls dist/
     - os: linux
       services:
@@ -156,7 +156,7 @@ jobs:
       install:
         - docker pull $DOCKER_IMAGE
       script:
-        - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
+        - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh "/opt/python/cp36*/bin" "/opt/python/cp37*/bin" "/opt/python/cp38*/bin" "/opt/python/cp39*/bin"
         - ls dist/
     - os: linux
       services:
@@ -167,7 +167,7 @@ jobs:
       install:
         - docker pull $DOCKER_IMAGE
       script:
-        - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh
+        - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/tools/build_wheels.sh "/opt/python/cp36*/bin" "/opt/python/cp37*/bin" "/opt/python/cp38*/bin" "/opt/python/cp39*/bin"
         - ls dist/
 
     #--- Build Debian packages ---

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ dist: bionic
 install: pip3 install --upgrade pip tox pyxattr pylibacl setuptools-scm
 
 python:
-  - 3.5
+  - 3.7  # default version, used under Windows
   - 3.6
-  - 3.7
   - 3.8
+  - 3.9-dev  # FIXME Python 3.9 is still only release candidate
 
 #=== DEPLOYMENTS ===
 # - everything to GitHub releases

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ sudo pip3 install rdiff-backup
 
 You need to make sure that the following requirements are met:
 
-* Python 3.5 or higher
+* Python 3.6 or higher
 * librsync 1.0.0 or higher
 * pylibacl (optional, to support ACLs)
 * pyxattr (optional, to support extended attributes) - the xattr library (without py) isn't regularly tested but should work and you will be helped

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -132,7 +132,7 @@ There is no prior release schedule – they are made when deemed fit.
 
 The same pre-requisites as for the installation of rdiff-backup also apply for building:
 
-* Python 3.5 or higher
+* Python 3.6 or higher
 * librsync 1.0.0 or higher
 
 Further python dependencies are documented in [requirements.txt](../requirements.txt).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -91,7 +91,7 @@ rdiff-backup FAQ
     If you wish to run rdiff-backup under Cygwin, use at least version
     1.1.12. The setup under Cygwin is the same as under other Unix-like
     operating systems. From the Cygwin installer you will need Python
-    3.5 or higher (under Interpreters), autoconf, automake, binutils,
+    3.6 or higher (under Interpreters), autoconf, automake, binutils,
     gcc, make, and patchutils (all under Devel). Then you will need to
     compile and install librsync, which can be downloaded [from
     Sourceforge](https://sourceforge.net/project/showfiles.php?group_id=56125).

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ setup(
     # maintainer and maintainer_email could be used to differentiate the package owner
     url="https://rdiff-backup.net/",
     download_url="https://github.com/rdiff-backup/rdiff-backup/releases",
-    python_requires='~=3.5',
+    python_requires='~=3.6',
     platforms=['linux', 'win32'],
     packages=["rdiff_backup"],
     package_dir={"": "src"},  # tell distutils packages are under src

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-pybindirs="/opt/python/cp36*/bin /opt/python/cp37*/bin /opt/python/cp38*/bin /opt/python/cp39*/bin"
+pybindirs="$*"
 
 # Install a system package required by our library
 yum install -y librsync-devel

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-pybindirs="/opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin /opt/python/cp38*/bin"
+pybindirs="/opt/python/cp36*/bin /opt/python/cp37*/bin /opt/python/cp38*/bin /opt/python/cp39*/bin"
 
 # Install a system package required by our library
 yum install -y librsync-devel

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # Use tox_slow.ini for longer running tests.
 
 [tox]
-envlist = py35, py36, py37, py38, flake8
+envlist = py36, py37, py38, py39, flake8
 
 [testenv]
 # make sure those variables are passed down; you should define 

--- a/tox_dist.ini
+++ b/tox_dist.ini
@@ -6,7 +6,7 @@
 # Configuration file for creating binary packages, esp. wheels
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38, py39
 
 [testenv]
 # make sure those variables are passed down; you should define 

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -8,7 +8,7 @@
 # Use tox_slow.ini for longer running tests and tox.ini for normal tests.
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38, py39
 # some directories to avoid creating files with root rights that
 # couldn't be overwritten by the non-root tests:
 toxworkdir = {toxinidir}/.tox.root

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -7,7 +7,7 @@
 # Call with `tox -c tox_slow.ini`
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38, py39
 
 [testenv]
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*


### PR DESCRIPTION
CHG: rdiff-backup now supports the newly released Python 3.9 and stops supporting the obsolete Python 3.5.
It's not completely true now but it'll be true once the changelog is written on this basis.
The order of versions in Travis-CI has also been changed to have the supported Windows version be first;
I think this will allow to simplify the setup in an upcoming step.