### PR TITLE
Replace assert through unittest's self.assertSOMETHING in testing

### DIFF
--- a/testing/FilenameMappingtest.py
+++ b/testing/FilenameMappingtest.py
@@ -20,7 +20,7 @@ class FilenameMappingTest(unittest.TestCase):
         ]
         for filename in filenames:
             quoted = FilenameMapping.quote(filename)
-            assert FilenameMapping.unquote(quoted) == filename, filename
+            self.assertEqual(FilenameMapping.unquote(quoted), filename)
 
     def testQuotedRPath(self):
         """Test the QuotedRPath class"""
@@ -28,9 +28,10 @@ class FilenameMappingTest(unittest.TestCase):
                 b".1969-12-31;08421;05833;05820-07;05800.data.gz")
         qrp = FilenameMapping.get_quotedrpath(
             rpath.RPath(Globals.local_connection, path), 1)
-        assert qrp.base == b"/usr/local", qrp.base
-        assert len(qrp.index) == 1, qrp.index
-        assert (qrp.index[0] == b"mirror_metadata.1969-12-31T21:33:20-07:00.data.gz")
+        self.assertEqual(qrp.base, b"/usr/local")
+        self.assertEqual(len(qrp.index), 1)
+        self.assertEqual(qrp.index[0],
+                         b"mirror_metadata.1969-12-31T21:33:20-07:00.data.gz")
 
     def testLongFilenames(self):
         """See if long quoted filenames cause crash"""
@@ -53,17 +54,17 @@ class FilenameMappingTest(unittest.TestCase):
                      extra_options=b"--override-chars-to-quote A")
 
         longrp_out = outrp.append(long_filename)
-        assert not longrp_out.lstat()
+        self.assertFalse(longrp_out.lstat())
         shortrp_out = outrp.append('B')
-        assert shortrp_out.lstat()
+        self.assertTrue(shortrp_out.lstat())
 
         rdiff_backup(1, 1, os.path.join(old_test_dir, b"empty"), outrp.path,
                      200000)
         shortrp_out.setdata()
-        assert not shortrp_out.lstat()
+        self.assertFalse(shortrp_out.lstat())
         rdiff_backup(1, 1, inrp.path, outrp.path, 300000)
         shortrp_out.setdata()
-        assert shortrp_out.lstat()
+        self.assertTrue(shortrp_out.lstat())
 
 
 if __name__ == "__main__":

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -95,7 +95,7 @@ class PathSetter(unittest.TestCase):
                      Local.inc1rp.path,
                      Local.rpout.path,
                      current_time=10000)
-        assert compare_recursive(Local.inc1rp, Local.rpout)
+        self.assertTrue(compare_recursive(Local.inc1rp, Local.rpout))
         time.sleep(1)
 
         # Backing up increment2
@@ -104,7 +104,7 @@ class PathSetter(unittest.TestCase):
                      Local.inc2rp.path,
                      Local.rpout.path,
                      current_time=20000)
-        assert compare_recursive(Local.inc2rp, Local.rpout)
+        self.assertTrue(compare_recursive(Local.inc2rp, Local.rpout))
         time.sleep(1)
 
         # Backing up increment3
@@ -113,7 +113,7 @@ class PathSetter(unittest.TestCase):
                      Local.inc3rp.path,
                      Local.rpout.path,
                      current_time=30000)
-        assert compare_recursive(Local.inc3rp, Local.rpout)
+        self.assertTrue(compare_recursive(Local.inc3rp, Local.rpout))
         time.sleep(1)
 
         # Backing up increment4
@@ -122,25 +122,25 @@ class PathSetter(unittest.TestCase):
                      Local.inc4rp.path,
                      Local.rpout.path,
                      current_time=40000)
-        assert compare_recursive(Local.inc4rp, Local.rpout)
+        self.assertTrue(compare_recursive(Local.inc4rp, Local.rpout))
 
         # Getting restore rps
         inc_paths = self.getinc_paths(
             b"increments.", os.path.join(Local.rpout.path,
                                          b"rdiff-backup-data"))
-        assert len(inc_paths) == 3
+        self.assertEqual(len(inc_paths), 3)
 
         # Restoring increment1
         rdiff_backup(from_local, to_local, inc_paths[0], Local.rpout1.path)
-        assert compare_recursive(Local.inc1rp, Local.rpout1)
+        self.assertTrue(compare_recursive(Local.inc1rp, Local.rpout1))
 
         # Restoring increment2
         rdiff_backup(from_local, to_local, inc_paths[1], Local.rpout2.path)
-        assert compare_recursive(Local.inc2rp, Local.rpout2)
+        self.assertTrue(compare_recursive(Local.inc2rp, Local.rpout2))
 
         # Restoring increment3
         rdiff_backup(from_local, to_local, inc_paths[2], Local.rpout3.path)
-        assert compare_recursive(Local.inc3rp, Local.rpout3)
+        self.assertTrue(compare_recursive(Local.inc3rp, Local.rpout3))
 
         # Test restoration of a few random files
         vft_paths = self.getinc_paths(
@@ -149,7 +149,7 @@ class PathSetter(unittest.TestCase):
                          b"increments"))
         rdiff_backup(from_local, to_local, vft_paths[1], Local.vft_out.path)
         self.refresh(Local.vft_in, Local.vft_out)
-        assert compare_recursive(Local.vft_in, Local.vft_out)
+        self.assertTrue(compare_recursive(Local.vft_in, Local.vft_out))
 
         timbar_paths = self.getinc_paths(
             b"timbar.pyc.",
@@ -158,7 +158,7 @@ class PathSetter(unittest.TestCase):
         rdiff_backup(from_local, to_local, timbar_paths[0],
                      Local.timbar_out.path)
         self.refresh(Local.timbar_in, Local.timbar_out)
-        assert Local.timbar_in.equal_loose(Local.timbar_out)
+        self.assertTrue(Local.timbar_in.equal_loose(Local.timbar_out))
 
         rdiff_backup(from_local,
                      to_local,
@@ -166,20 +166,16 @@ class PathSetter(unittest.TestCase):
                      Local.vft_recover.path,
                      extra_options=b"--restore-as-of 25000")
         self.refresh(Local.vft_recover, Local.vft_in)
-        assert compare_recursive(Local.vft_recover, Local.vft_in)
+        self.assertTrue(compare_recursive(Local.vft_recover, Local.vft_in))
 
         # Make sure too many increment files not created
-        assert len(
-            self.getinc_paths(
-                b"nochange.",
-                os.path.join(Local.rpout.path, b"rdiff-backup-data",
-                             b"increments"))) == 0
-        nochange_incs = len(
-            self.getinc_paths(
-                b"",
-                os.path.join(Local.rpout.path, b"rdiff-backup-data",
-                             b"increments", b"nochange")))
-        assert nochange_incs == 1 or nochange_incs == 0, nochange_incs
+        self.assertEqual(len(self.getinc_paths(
+            b"nochange.", os.path.join(Local.rpout.path, b"rdiff-backup-data",
+                                       b"increments"))), 0)
+        nochange_incs = len(self.getinc_paths(
+            b"", os.path.join(Local.rpout.path, b"rdiff-backup-data",
+                              b"increments", b"nochange")))
+        self.assertIn(nochange_incs, (0, 1))
 
     def getinc_paths(self, basename, directory, quoted=0):
         """Returns a sorted list of files which starts with basename
@@ -236,7 +232,7 @@ class Final(PathSetter):
                      Local.inc1rp.path,
                      procout.path,
                      current_time=30000)
-        assert compare_recursive(Local.inc1rp, procout)
+        self.assertTrue(compare_recursive(Local.inc1rp, procout))
         time.sleep(1)
         rdiff_backup(True, True, '/proc', procout.path, current_time=40000)
 
@@ -255,7 +251,7 @@ class Final(PathSetter):
                      Local.inc1rp.path,
                      procout.path,
                      current_time=30000)
-        assert compare_recursive(Local.inc1rp, procout)
+        self.assertTrue(compare_recursive(Local.inc1rp, procout))
         time.sleep(1)
         rdiff_backup(True, False, '/proc', procout.path, current_time=40000)
 
@@ -307,25 +303,23 @@ class Final(PathSetter):
         popen_fp = os.popen(b"find testfiles/output -name '*:*' | wc")
         wc_output = popen_fp.read()
         popen_fp.close()
-        assert wc_output.split() == [b"0", b"0", b"0"], wc_output
+        self.assertEqual(wc_output.split(), [b"0", b"0", b"0"])
 
         # Start restore of increment 2
         Globals.chars_to_quote = b'^a-z0-9_ -.'
         inc_paths = self.getinc_paths(b"increments.",
                                       b"testfiles/output/rdiff-backup-data", 1)
         Globals.chars_to_quote = None
-        assert len(inc_paths) == 1, inc_paths
+        self.assertEqual(len(inc_paths), 1)
         self.exec_rb(None, inc_paths[0], b'testfiles/restoretarget2')
-        assert compare_recursive(Local.wininc2,
-                                 Local.rpout2,
-                                 compare_hardlinks=0)
+        self.assertTrue(
+            compare_recursive(Local.wininc2, Local.rpout2, compare_hardlinks=0))
 
         # Restore increment 3 again, using different syntax
         self.rb_schema = old_schema + b'-r 30000 '
         self.exec_rb(None, b'testfiles/output', b'testfiles/restoretarget3')
-        assert compare_recursive(Local.wininc3,
-                                 Local.rpout3,
-                                 compare_hardlinks=0)
+        self.assertTrue(
+            compare_recursive(Local.wininc3, Local.rpout3, compare_hardlinks=0))
         self.rb_schema = old_schema
 
     def testLegacy(self):
@@ -352,7 +346,8 @@ class Final(PathSetter):
                      Local.rpout.path,
                      Local.rpout1.path,
                      extra_options=b'-r0')
-        assert compare_recursive(Local.vftrp, Local.rpout1, compare_hardlinks=0)
+        self.assertTrue(
+            compare_recursive(Local.vftrp, Local.rpout1, compare_hardlinks=0))
 
 
 class FinalMisc(PathSetter):
@@ -434,7 +429,7 @@ class FinalMisc(PathSetter):
 
     def get_all_increments(self, rp):
         """Iterate all increments at or below given directory"""
-        assert rp.isdir()
+        self.assertTrue(rp.isdir())
         dirlist = rp.listdir()
         dirlist.sort()
         for filename in dirlist:
@@ -448,8 +443,9 @@ class FinalMisc(PathSetter):
     def testRemoveOlderThan(self):
         """Test --remove-older-than.  Uses restoretest3"""
         Myrm(Local.rpout.path)
-        assert not os.system(b"cp -a %b %b" %
-                             (Local.backup3rp.path, Local.rpout.path))
+        self.assertEqual(
+            os.system(b"cp -a %b %b" %
+                      (Local.backup3rp.path, Local.rpout.path)), 0)
         rdiff_backup(True,
                      True,
                      Local.rpout.path,
@@ -457,13 +453,14 @@ class FinalMisc(PathSetter):
                      extra_options=b"--remove-older-than 20000")
         rbdir = Local.rpout.append("rdiff-backup-data")
         for inc in self.get_all_increments(rbdir):
-            assert inc.getinctime() >= 20000
+            self.assertGreaterEqual(inc.getinctime(), 20000)
 
     def testRemoveOlderThan2(self):
         """Test --remove-older-than, but '1B'.  Uses restoretest3"""
         Myrm(Local.rpout.path)
-        assert not os.system(b"cp -a %b %b" %
-                             (Local.backup3rp.path, Local.rpout.path))
+        self.assertEqual(
+            os.system(b"cp -a %b %b" %
+                      (Local.backup3rp.path, Local.rpout.path)), 0)
         rdiff_backup(True,
                      True,
                      Local.rpout.path,
@@ -471,13 +468,14 @@ class FinalMisc(PathSetter):
                      extra_options=b"--remove-older-than 1B --force")
         rbdir = Local.rpout.append("rdiff-backup-data")
         for inc in self.get_all_increments(rbdir):
-            assert inc.getinctime() >= 30000
+            self.assertGreaterEqual(inc.getinctime(), 30000)
 
     def testRemoveOlderThanCurrent(self):
         """Make sure --remove-older-than doesn't delete current incs"""
         Myrm(Local.rpout.path)
-        assert not os.system(b"cp -a %b %b" %
-                             (Local.backup3rp.path, Local.rpout.path))
+        self.assertEqual(
+            os.system(b"cp -a %b %b" %
+                      (Local.backup3rp.path, Local.rpout.path)), 0)
         rdiff_backup(True,
                      True,
                      Local.rpout.path,
@@ -491,7 +489,8 @@ class FinalMisc(PathSetter):
                 has_cur_mirror = 1
             elif inc.getincbase().index[-1] == b'mirror_metadata':
                 has_metadata = 1
-        assert has_cur_mirror and has_metadata, (has_cur_mirror, has_metadata)
+        self.assertTrue(has_cur_mirror)
+        self.assertTrue(has_metadata)
 
     def testRemoveOlderThanQuoting(self):
         """Test --remove-older-than when dest directory is quoted"""
@@ -517,8 +516,9 @@ class FinalMisc(PathSetter):
     def testRemoveOlderThanRemote(self):
         """Test --remove-older-than remotely"""
         Myrm(Local.rpout.path)
-        assert not os.system(b"cp -a %b %b" %
-                             (Local.backup3rp.path, Local.rpout.path))
+        self.assertEqual(
+            os.system(b"cp -a %b %b" %
+                      (Local.backup3rp.path, Local.rpout.path)), 0)
         rdiff_backup(False,
                      True,
                      Local.rpout.path,
@@ -526,7 +526,7 @@ class FinalMisc(PathSetter):
                      extra_options=b"--remove-older-than 20000")
         rbdir = Local.rpout.append("rdiff-backup-data")
         for inc in self.get_all_increments(rbdir):
-            assert inc.getinctime() >= 20000
+            self.assertGreaterEqual(inc.getinctime(), 20000)
 
     def testNonExistingTempDir(self):
         """Test that a missing tempdir is properly catched as an error"""
@@ -561,8 +561,8 @@ class FinalSelection(PathSetter):
             os.path.join(inc2_rel, b"various_file_types"))
 
         # check that one included file exists and one excluded doesn't
-        assert os.lstat(
-            os.path.join(out_rel, b"various_file_types", b"regular_file"))
+        self.assertTrue(os.lstat(
+            os.path.join(out_rel, b"various_file_types", b"regular_file")))
         self.assertRaises(OSError, os.lstat, os.path.join(out_rel, b"test.py"))
 
         # Now try reading list of files
@@ -575,8 +575,8 @@ class FinalSelection(PathSetter):
                                           os.path.join(inc2_rel, b"changed_dir")))
 
         # check that two included files exist and two excluded don't
-        assert os.lstat(os.path.join(out_rel, b"changed_dir"))
-        assert os.lstat(os.path.join(out_rel, b"test.py"))
+        self.assertTrue(os.lstat(os.path.join(out_rel, b"changed_dir")))
+        self.assertTrue(os.lstat(os.path.join(out_rel, b"test.py")))
         self.assertRaises(OSError, os.lstat,
                           os.path.join(out_rel, b"various_file_types"))
         self.assertRaises(OSError, os.lstat,
@@ -594,8 +594,8 @@ class FinalSelection(PathSetter):
             extra_options=b"--include-filelist-stdin " + b" --exclude '**'",
             input=b"\n%b" % os.path.join(rest1_rel, b"various_file_types", b"regular_file"))
 
-        assert os.lstat(
-            os.path.join(rest1_rel, b"various_file_types", b"regular_file"))
+        self.assertTrue(os.lstat(
+            os.path.join(rest1_rel, b"various_file_types", b"regular_file")))
         self.assertRaises(OSError, os.lstat,
                           os.path.join(rest1_rel, b"tester"))
         self.assertRaises(
@@ -633,8 +633,8 @@ class FinalSelection(PathSetter):
                      Local.rpout.path,
                      Local.rpout1.path,
                      extra_options=b"--restore-as-of now")
-        assert os.lstat(Local.rpout1.append('executable').path)
-        assert os.lstat(Local.rpout1.append('symbolic_link').path)
+        self.assertTrue(os.lstat(Local.rpout1.append('executable').path))
+        self.assertTrue(os.lstat(Local.rpout1.append('symbolic_link').path))
         self.assertRaises(OSError, os.lstat,
                           Local.rpout1.append('regular_file').path)
         self.assertRaises(OSError, os.lstat,
@@ -663,9 +663,10 @@ class FinalSelection(PathSetter):
                      extra_options=b"--restore-as-of now " + excludes)
         for rp in (file1_target, file2_target, existing_file):
             rp.setdata()
-        assert not file1_target.lstat(), file1_target.lstat()
-        assert file2_target.lstat()
-        assert existing_file.lstat()  # excluded file shouldn't be deleted
+        self.assertFalse(file1_target.lstat())
+        self.assertTrue(file2_target.lstat())
+        # excluded file shouldn't be deleted:
+        self.assertTrue(existing_file.lstat())
 
     def make_restore_sel_dir(self, source_local, dest_local):
         """Create rdiff-backup repository at Local.rpout"""
@@ -708,7 +709,7 @@ class FinalCorrupt(PathSetter):
             Myrm(rp2.path)
         os.system(b'cp -a %b %b' % (rp1.path, rp2.path))
         rp2_2_1 = rp2.append('dir', 'regfile2')
-        assert rp2_2_1.lstat()
+        self.assertTrue(rp2_2_1.lstat())
         rp2_2_1.delete()
         rp2_2_1.touch()
         return rp1, rp1_2, rp2
@@ -795,7 +796,7 @@ class FinalBugs(PathSetter):
 
         # Check to see if file still there
         rp1_d_f.setdata()
-        assert rp1_d_f.isreg(), 'File %a corrupted' % (rp1_d_f.path, )
+        self.assertTrue(rp1_d_f.isreg())
 
     def test_CCPP_keyerror(self):
         """Test when no change until middle of a directory
@@ -808,7 +809,7 @@ class FinalBugs(PathSetter):
         bigrp = Local.get_src_local_rp('bigdir')
         rdiff_backup(True, True, bigrp.path, Local.rpout.path)
         rp = bigrp.append('subdir3', 'subdir49', 'file49')
-        assert rp.isreg(), rp
+        self.assertTrue(rp.isreg())
         rp.touch()
         rdiff_backup(True, True, bigrp.path, Local.rpout.path)
 

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -5,7 +5,7 @@ import sys
 import time
 import pathlib
 from commontest import rdiff_backup, Myrm, compare_recursive, \
-    old_test_dir, abs_test_dir, get_increment_rp
+    old_test_dir, abs_test_dir, get_increment_rp, xcopytree
 from rdiff_backup import Globals, log, rpath, robust, FilenameMapping, Time, selection
 """Regression tests"""
 
@@ -281,8 +281,8 @@ class Final(PathSetter):
                     rp.delete()
 
         if not Local.wininc2.lstat() or not Local.wininc3.lstat():
-            os.system(b"cp -a testfiles/increment2 testfiles/win-increment2")
-            os.system(b"cp -a testfiles/increment3 testfiles/win-increment3")
+            xcopytree(b"testfiles/increment2", b"testfiles/win-increment2")
+            xcopytree(b"testfiles/increment3", b"testfiles/win-increment3")
             delete_long(Local.wininc2)
             delete_long(Local.wininc3)
 
@@ -443,9 +443,7 @@ class FinalMisc(PathSetter):
     def testRemoveOlderThan(self):
         """Test --remove-older-than.  Uses restoretest3"""
         Myrm(Local.rpout.path)
-        self.assertEqual(
-            os.system(b"cp -a %b %b" %
-                      (Local.backup3rp.path, Local.rpout.path)), 0)
+        xcopytree(Local.backup3rp.path, Local.rpout.path)
         rdiff_backup(True,
                      True,
                      Local.rpout.path,
@@ -458,9 +456,7 @@ class FinalMisc(PathSetter):
     def testRemoveOlderThan2(self):
         """Test --remove-older-than, but '1B'.  Uses restoretest3"""
         Myrm(Local.rpout.path)
-        self.assertEqual(
-            os.system(b"cp -a %b %b" %
-                      (Local.backup3rp.path, Local.rpout.path)), 0)
+        xcopytree(Local.backup3rp.path, Local.rpout.path)
         rdiff_backup(True,
                      True,
                      Local.rpout.path,
@@ -473,9 +469,7 @@ class FinalMisc(PathSetter):
     def testRemoveOlderThanCurrent(self):
         """Make sure --remove-older-than doesn't delete current incs"""
         Myrm(Local.rpout.path)
-        self.assertEqual(
-            os.system(b"cp -a %b %b" %
-                      (Local.backup3rp.path, Local.rpout.path)), 0)
+        xcopytree(Local.backup3rp.path, Local.rpout.path)
         rdiff_backup(True,
                      True,
                      Local.rpout.path,
@@ -516,9 +510,7 @@ class FinalMisc(PathSetter):
     def testRemoveOlderThanRemote(self):
         """Test --remove-older-than remotely"""
         Myrm(Local.rpout.path)
-        self.assertEqual(
-            os.system(b"cp -a %b %b" %
-                      (Local.backup3rp.path, Local.rpout.path)), 0)
+        xcopytree(Local.backup3rp.path, Local.rpout.path)
         rdiff_backup(False,
                      True,
                      Local.rpout.path,
@@ -707,7 +699,7 @@ class FinalCorrupt(PathSetter):
         rp2 = Local.get_tgt_local_rp('final_deleted2')
         if rp2.lstat():
             Myrm(rp2.path)
-        os.system(b'cp -a %b %b' % (rp1.path, rp2.path))
+        xcopytree(rp1.path, rp2.path)
         rp2_2_1 = rp2.append('dir', 'regfile2')
         self.assertTrue(rp2_2_1.lstat())
         rp2_2_1.delete()

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -566,5 +566,22 @@ def iter_map(function, iterator):
         yield function(i)
 
 
+def xcopytree(source, dest, content=False):
+    """copytree can't copy all kind of files but is platform independent
+    hence we use it only if the 'cp' utility doesn't exist.
+    If content is True then dest is created if needed and
+    the content of the source is copied into dest and not source itself."""
+    if content:
+        subs = map(lambda d: os.path.join(source, d), os.listdir(source))
+        os.makedirs(dest, exist_ok=True)
+    else:
+        subs = (source,)
+    for sub in subs:
+        if shutil.which('cp'):
+            subprocess.run((b'cp', b'-a', sub, dest), check=True)
+        else:
+            shutil.copytree(sub, dest, symlinks=True)
+
+
 if __name__ == '__main__':
     os.makedirs(abs_test_dir, exist_ok=True)

--- a/testing/comparetest.py
+++ b/testing/comparetest.py
@@ -19,25 +19,24 @@ class CompareTest(unittest.TestCase):
                      old_inc3_dir,
                      self.outdir,
                      extra_options=compare_option)
-        ret_val = rdiff_backup(local,
-                               local,
-                               old_inc2_dir,
-                               self.outdir,
-                               extra_options=compare_option,
-                               check_return_val=0)
-        assert ret_val, ret_val
+        self.assertTrue(rdiff_backup(local,
+                                     local,
+                                     old_inc2_dir,
+                                     self.outdir,
+                                     extra_options=compare_option,
+                                     check_return_val=0))
         rdiff_backup(local,
                      local,
                      old_inc2_dir,
                      self.outdir,
                      extra_options=compare_option + b"-at-time 10000")
-        ret_val = rdiff_backup(local,
-                               local,
-                               old_inc3_dir,
-                               self.outdir,
-                               extra_options=compare_option + b"-at-time 10000",
-                               check_return_val=0)
-        assert ret_val, ret_val
+        self.assertTrue(
+            rdiff_backup(local,
+                         local,
+                         old_inc3_dir,
+                         self.outdir,
+                         extra_options=compare_option + b"-at-time 10000",
+                         check_return_val=0))
 
     def testBasicLocal(self):
         """Test basic --compare and --compare-at-time modes"""
@@ -70,26 +69,26 @@ class CompareTest(unittest.TestCase):
                      os.path.join(old_inc3_dir, b'various_file_types'),
                      os.path.join(abs_output_dir, b'various_file_types'),
                      extra_options=compare_option)
-        ret_val = rdiff_backup(local,
-                               local,
-                               os.path.join(old_inc2_dir, b'increment1'),
-                               os.path.join(abs_output_dir, b'increment1'),
-                               extra_options=compare_option,
-                               check_return_val=0)
-        assert ret_val, ret_val
+        self.assertTrue(
+            rdiff_backup(local,
+                         local,
+                         os.path.join(old_inc2_dir, b'increment1'),
+                         os.path.join(abs_output_dir, b'increment1'),
+                         extra_options=compare_option,
+                         check_return_val=0))
 
         rdiff_backup(local,
                      local,
                      os.path.join(old_inc2_dir, b'newdir'),
                      os.path.join(abs_output_dir, b'newdir'),
                      extra_options=compare_option + b"-at-time 10000")
-        ret_val = rdiff_backup(local,
-                               local,
-                               os.path.join(old_inc3_dir, b'newdir'),
-                               os.path.join(abs_output_dir, b'newdir'),
-                               extra_options=compare_option + b"-at-time 10000",
-                               check_return_val=0)
-        assert ret_val, ret_val
+        self.assertTrue(
+            rdiff_backup(local,
+                         local,
+                         os.path.join(old_inc3_dir, b'newdir'),
+                         os.path.join(abs_output_dir, b'newdir'),
+                         extra_options=compare_option + b"-at-time 10000",
+                         check_return_val=0))
 
     def testSelLocal(self):
         """Test basic local compare of single subdirectory"""
@@ -141,7 +140,11 @@ class CompareTest(unittest.TestCase):
                 filename for filename in os.listdir(incs_dir)
                 if filename.startswith(b'stph_icons.h')
             ]
-            assert len(templist) == 1, templist
+            self.assertEqual(
+                len(templist), 1,
+                "There should be only one diff file in '{diffs}'. "
+                "Something is wrong with the test setup.".format(
+                    diffs=templist))
             diff_rp = rpath.RPath(Globals.local_connection,
                                   os.path.join(incs_dir, templist[0]))
             change_file(diff_rp)
@@ -157,23 +160,23 @@ class CompareTest(unittest.TestCase):
                      None,
                      extra_options=b"--verify-at-time 10000")
         modify_diff()
-        ret_val = rdiff_backup(local,
-                               local,
-                               abs_output_dir,
-                               None,
-                               extra_options=b"--verify-at-time 10000",
-                               check_return_val=0)
-        assert ret_val, ret_val
+        self.assertTrue(
+            rdiff_backup(local,
+                         local,
+                         abs_output_dir,
+                         None,
+                         extra_options=b"--verify-at-time 10000",
+                         check_return_val=0))
         change_file(
             rpath.RPath(Globals.local_connection,
                         os.path.join(abs_output_dir, b'stph_icons.h')))
-        ret_val = rdiff_backup(local,
-                               local,
-                               abs_output_dir,
-                               None,
-                               extra_options=b"--verify",
-                               check_return_val=0)
-        assert ret_val, ret_val
+        self.assertTrue(
+            rdiff_backup(local,
+                         local,
+                         abs_output_dir,
+                         None,
+                         extra_options=b"--verify",
+                         check_return_val=0))
 
     def testVerifyLocal(self):
         """Test --verify of directory, local"""

--- a/testing/ctest.py
+++ b/testing/ctest.py
@@ -11,21 +11,21 @@ class CTest(unittest.TestCase):
 
     def test_acl_quoting(self):
         """Test the acl_quote and acl_unquote functions"""
-        assert C.acl_quote(b'foo') == b'foo', C.acl_quote(b'foo')
-        assert C.acl_quote(b'\n') == b'\\012', C.acl_quote(b'\n')
-        assert C.acl_unquote(b'\\012') == b'\n'
+        self.assertEqual(C.acl_quote(b'foo'), b'foo')
+        self.assertEqual(C.acl_quote(b'\n'), b'\\012')
+        self.assertEqual(C.acl_unquote(b'\\012'), b'\n')
         s = b'\\\n\t\145\n\01=='
-        assert C.acl_unquote(C.acl_quote(s)) == s
+        self.assertEqual(C.acl_unquote(C.acl_quote(s)), s)
 
     def test_acl_quoting2(self):
         """This string used to segfault the quoting code, try now"""
         s = b'\xd8\xab\xb1Wb\xae\xc5]\x8a\xbb\x15v*\xf4\x0f!\xf9>\xe2Y\x86\xbb\xab\xdbp\xb0\x84\x13k\x1d\xc2\xf1\xf5e\xa5U\x82\x9aUV\xa0\xf4\xdf4\xba\xfdX\x03\x82\x07s\xce\x9e\x8b\xb34\x04\x9f\x17 \xf4\x8f\xa6\xfa\x97\xab\xd8\xac\xda\x85\xdcKvC\xfa#\x94\x92\x9e\xc9\xb7\xc3_\x0f\x84g\x9aB\x11<=^\xdbM\x13\x96c\x8b\xa7|*"\\\'^$@#!(){}?+ ~` '
         quoted = C.acl_quote(s)
-        assert C.acl_unquote(quoted) == s
+        self.assertEqual(C.acl_unquote(quoted), s)
 
     def test_acl_quoting_equals(self):
         """Make sure the equals character is quoted"""
-        assert C.acl_quote(b'=') != b'='
+        self.assertNotEqual(C.acl_quote(b'='), b'=')
 
 
 if __name__ == "__main__":

--- a/testing/fs_abilitiestest.py
+++ b/testing/fs_abilitiestest.py
@@ -52,12 +52,12 @@ class FSAbilitiesTest(unittest.TestCase):
         base_dir = rpath.RPath(Globals.local_connection, self.dir_to_test)
         fsa = fs_abilities.FSAbilities('read-only').init_readonly(base_dir)
         print(fsa)
-        assert fsa.read_only == 1, fsa.read_only
-        assert fsa.eas == self.eas, fsa.eas
-        assert fsa.acls == self.acls, fsa.acls
-        assert fsa.resource_forks == self.resource_forks, fsa.resource_forks
-        assert fsa.carbonfile == self.carbonfile, fsa.carbonfile
-        assert fsa.case_sensitive == self.case_sensitive, fsa.case_sensitive
+        self.assertEqual(fsa.read_only, 1)
+        self.assertEqual(fsa.eas, self.eas)
+        self.assertEqual(fsa.acls, self.acls)
+        self.assertEqual(fsa.resource_forks, self.resource_forks)
+        self.assertEqual(fsa.carbonfile, self.carbonfile)
+        self.assertEqual(fsa.case_sensitive, self.case_sensitive)
 
     def testReadWrite(self):
         """Test basic querying read/write"""
@@ -71,17 +71,17 @@ class FSAbilitiesTest(unittest.TestCase):
         fsa = fs_abilities.FSAbilities('read/write').init_readwrite(new_dir)
         print("Time elapsed = ", time.time() - t)
         print(fsa)
-        assert fsa.read_only == 0, fsa.read_only
-        assert fsa.eas == self.eas, fsa.eas
-        assert fsa.acls == self.acls, fsa.acls
-        assert fsa.ownership == self.ownership, fsa.ownership
-        assert fsa.hardlinks == self.hardlinks, fsa.hardlinks
-        assert fsa.fsync_dirs == self.fsync_dirs, fsa.fsync_dirs
-        assert fsa.dir_inc_perms == self.dir_inc_perms, fsa.dir_inc_perms
-        assert fsa.resource_forks == self.resource_forks, fsa.resource_forks
-        assert fsa.carbonfile == self.carbonfile, fsa.carbonfile
-        assert fsa.high_perms == self.high_perms, fsa.high_perms
-        assert fsa.extended_filenames == self.extended_filenames
+        self.assertEqual(fsa.read_only, 0)
+        self.assertEqual(fsa.eas, self.eas)
+        self.assertEqual(fsa.acls, self.acls)
+        self.assertEqual(fsa.ownership, self.ownership)
+        self.assertEqual(fsa.hardlinks, self.hardlinks)
+        self.assertEqual(fsa.fsync_dirs, self.fsync_dirs)
+        self.assertEqual(fsa.dir_inc_perms, self.dir_inc_perms)
+        self.assertEqual(fsa.resource_forks, self.resource_forks)
+        self.assertEqual(fsa.carbonfile, self.carbonfile)
+        self.assertEqual(fsa.high_perms, self.high_perms)
+        self.assertEqual(fsa.extended_filenames, self.extended_filenames)
 
         new_dir.delete()
 
@@ -93,7 +93,7 @@ class FSAbilitiesTest(unittest.TestCase):
         rp = rpath.RPath(Globals.local_connection, self.case_insensitive_path)
         fsa = fs_abilities.FSAbilities('read-only')
         fsa.set_case_sensitive_readonly(rp)
-        assert fsa.case_sensitive == 0, fsa.case_sensitive
+        self.assertEqual(fsa.case_sensitive, 0)
 
 
 if __name__ == "__main__":

--- a/testing/hardlinktest.py
+++ b/testing/hardlinktest.py
@@ -3,7 +3,7 @@ import unittest
 import time
 from commontest import abs_test_dir, abs_output_dir, old_test_dir, re_init_rpath_dir, \
     compare_recursive, BackupRestoreSeries, InternalBackup, InternalRestore, \
-    MakeOutputDir, reset_hardlink_dicts
+    MakeOutputDir, reset_hardlink_dicts, xcopytree
 from rdiff_backup import Globals, Hardlink, selection, rpath, restore, metadata
 
 
@@ -92,7 +92,7 @@ class HardlinkTest(unittest.TestCase):
         hlout2 = rpath.RPath(Globals.local_connection, hlout2_dir)
         if hlout2.lstat():
             hlout2.delete()
-        self.assertFalse(os.system(b"cp -a %s %s" % (hlout1_dir, hlout2_dir)))
+        xcopytree(hlout1_dir, hlout2_dir)
         hlout2_sub = hlout2.append("subdir")
         hl2_1 = hlout2_sub.append("hardlink1")
         hl2_2 = hlout2_sub.append("hardlink2")

--- a/testing/hardlinktest.py
+++ b/testing/hardlinktest.py
@@ -26,12 +26,12 @@ class HardlinkTest(unittest.TestCase):
 
     def testEquality(self):
         """Test rorp_eq function in conjunction with compare_recursive"""
-        assert compare_recursive(self.hlinks_rp1, self.hlinks_rp1copy)
-        assert compare_recursive(self.hlinks_rp1,
-                                 self.hlinks_rp2,
-                                 compare_hardlinks=None)
-        assert not compare_recursive(
-            self.hlinks_rp1, self.hlinks_rp2, compare_hardlinks=1)
+        self.assertTrue(compare_recursive(self.hlinks_rp1, self.hlinks_rp1copy))
+        self.assertTrue(compare_recursive(self.hlinks_rp1,
+                                          self.hlinks_rp2,
+                                          compare_hardlinks=None))
+        self.assertFalse(compare_recursive(
+            self.hlinks_rp1, self.hlinks_rp2, compare_hardlinks=1))
 
     def testBuildingDict(self):
         """See if the partial inode dictionary is correct"""
@@ -40,8 +40,7 @@ class HardlinkTest(unittest.TestCase):
         for dsrp in selection.Select(self.hlinks_rp3).set_iter():
             Hardlink.add_rorp(dsrp)
 
-        assert len(list(Hardlink._inode_index.keys())) == 3, \
-            Hardlink._inode_index
+        self.assertEqual(len(list(Hardlink._inode_index.keys())), 3)
 
     def testCompletedDict(self):
         """See if the hardlink dictionaries are built correctly"""
@@ -49,13 +48,13 @@ class HardlinkTest(unittest.TestCase):
         for dsrp in selection.Select(self.hlinks_rp1).set_iter():
             Hardlink.add_rorp(dsrp)
             Hardlink.del_rorp(dsrp)
-        assert Hardlink._inode_index == {}, Hardlink._inode_index
+        self.assertEqual(Hardlink._inode_index, {})
 
         reset_hardlink_dicts()
         for dsrp in selection.Select(self.hlinks_rp2).set_iter():
             Hardlink.add_rorp(dsrp)
             Hardlink.del_rorp(dsrp)
-        assert Hardlink._inode_index == {}, Hardlink._inode_index
+        self.assertEqual(Hardlink._inode_index, {})
 
     def testSeries(self):
         """Test hardlink system by backing up and restoring a few dirs"""
@@ -93,7 +92,7 @@ class HardlinkTest(unittest.TestCase):
         hlout2 = rpath.RPath(Globals.local_connection, hlout2_dir)
         if hlout2.lstat():
             hlout2.delete()
-        assert not os.system(b"cp -a %s %s" % (hlout1_dir, hlout2_dir))
+        self.assertFalse(os.system(b"cp -a %s %s" % (hlout1_dir, hlout2_dir)))
         hlout2_sub = hlout2.append("subdir")
         hl2_1 = hlout2_sub.append("hardlink1")
         hl2_2 = hlout2_sub.append("hardlink2")
@@ -111,22 +110,22 @@ class HardlinkTest(unittest.TestCase):
         # Now try backing up twice, making sure hard links are preserved
         InternalBackup(1, 1, hlout1.path, output.path)
         out_subdir = output.append("subdir")
-        assert out_subdir.append("hardlink1").getinode() == \
-            out_subdir.append("hardlink2").getinode()
-        assert out_subdir.append("hardlink3").getinode() == \
-            out_subdir.append("hardlink4").getinode()
-        assert out_subdir.append("hardlink1").getinode() != \
-            out_subdir.append("hardlink3").getinode()
+        self.assertEqual(out_subdir.append("hardlink1").getinode(),
+                         out_subdir.append("hardlink2").getinode())
+        self.assertEqual(out_subdir.append("hardlink3").getinode(),
+                         out_subdir.append("hardlink4").getinode())
+        self.assertNotEqual(out_subdir.append("hardlink1").getinode(),
+                            out_subdir.append("hardlink3").getinode())
 
         time.sleep(1)
         InternalBackup(1, 1, hlout2.path, output.path)
         out_subdir.setdata()
-        assert out_subdir.append("hardlink1").getinode() == \
-            out_subdir.append("hardlink4").getinode()
-        assert out_subdir.append("hardlink2").getinode() == \
-            out_subdir.append("hardlink3").getinode()
-        assert out_subdir.append("hardlink1").getinode() != \
-            out_subdir.append("hardlink2").getinode()
+        self.assertEqual(out_subdir.append("hardlink1").getinode(),
+                         out_subdir.append("hardlink4").getinode())
+        self.assertEqual(out_subdir.append("hardlink2").getinode(),
+                         out_subdir.append("hardlink3").getinode())
+        self.assertNotEqual(out_subdir.append("hardlink1").getinode(),
+                            out_subdir.append("hardlink2").getinode())
 
         # Now try restoring, still checking hard links.
         sub_dir = os.path.join(abs_output_dir, b"subdir")
@@ -143,9 +142,9 @@ class HardlinkTest(unittest.TestCase):
         out2.setdata()
         for rp in [hlout1, hlout2, hlout3, hlout4]:
             rp.setdata()
-        assert hlout1.getinode() == hlout2.getinode()
-        assert hlout3.getinode() == hlout4.getinode()
-        assert hlout1.getinode() != hlout3.getinode()
+        self.assertEqual(hlout1.getinode(), hlout2.getinode())
+        self.assertEqual(hlout3.getinode(), hlout4.getinode())
+        self.assertNotEqual(hlout1.getinode(), hlout3.getinode())
 
         if out2.lstat():
             out2.delete()
@@ -153,10 +152,9 @@ class HardlinkTest(unittest.TestCase):
         out2.setdata()
         for rp in [hlout1, hlout2, hlout3, hlout4]:
             rp.setdata()
-        assert hlout1.getinode() == hlout4.getinode(), \
-            "%a %a" % (hlout1.path, hlout4.path)
-        assert hlout2.getinode() == hlout3.getinode()
-        assert hlout1.getinode() != hlout2.getinode()
+        self.assertEqual(hlout1.getinode(), hlout4.getinode())
+        self.assertEqual(hlout2.getinode(), hlout3.getinode())
+        self.assertNotEqual(hlout1.getinode(), hlout2.getinode())
 
     def extract_metadata(self, metadata_rp):
         """Return lists of hashes and hardlink counts in the metadata_rp"""
@@ -202,8 +200,8 @@ class HardlinkTest(unittest.TestCase):
 
         InternalBackup(1, 1, hlsrc.path, output.path, 10000)
         out_subdir = output.append("subdir")
-        assert out_subdir.append("hardlink1").getinode() == \
-            out_subdir.append("hardlink3").getinode()
+        self.assertEqual(out_subdir.append("hardlink1").getinode(),
+                         out_subdir.append("hardlink3").getinode())
 
         # validate that hashes and link counts are correctly saved in metadata
         meta_prefix = rpath.RPath(
@@ -211,28 +209,28 @@ class HardlinkTest(unittest.TestCase):
             os.path.join(abs_output_dir, b"rdiff-backup-data",
                          b"mirror_metadata"))
         incs = restore.get_inclist(meta_prefix)
-        assert len(incs) == 1
+        self.assertEqual(len(incs), 1)
         metadata_rp = incs[0]
         hashes, link_counts = self.extract_metadata(metadata_rp)
         # hashes for ., ./subdir, ./subdir/hardlink1, ./subdir/hardlink3
         expected_hashes = [None, None, self.hello_str_hash, None]
-        assert expected_hashes == hashes, (expected_hashes, hashes)
+        self.assertEqual(expected_hashes, hashes)
         expected_link_counts = [1, 1, 2, 2]
-        assert expected_link_counts == link_counts, (expected_link_counts, link_counts)
+        self.assertEqual(expected_link_counts, link_counts)
 
         # Create a new hardlinked file between "hardlink1" and "hardlink3" and perform another backup
         hl_file2 = hlsrc_sub.append("hardlink2")
         hl_file2.hardlink(hl_file1.path)
 
         InternalBackup(1, 1, hlsrc.path, output.path, 20000)
-        assert out_subdir.append("hardlink1").getinode() == \
-            out_subdir.append("hardlink2").getinode()
-        assert out_subdir.append("hardlink1").getinode() == \
-            out_subdir.append("hardlink3").getinode()
+        self.assertEqual(out_subdir.append("hardlink1").getinode(),
+                         out_subdir.append("hardlink2").getinode())
+        self.assertEqual(out_subdir.append("hardlink1").getinode(),
+                         out_subdir.append("hardlink3").getinode())
 
         # validate that hashes and link counts are correctly saved in metadata
         incs = restore.get_inclist(meta_prefix)
-        assert len(incs) == 2
+        self.assertEqual(len(incs), 2)
         if incs[0].getinctype() == b'snapshot':
             metadata_rp = incs[0]
         else:
@@ -240,10 +238,10 @@ class HardlinkTest(unittest.TestCase):
         hashes, link_counts = self.extract_metadata(metadata_rp)
         # hashes for ., ./subdir/, ./subdir/hardlink1, ./subdir/hardlink2, ./subdir/hardlink3
         expected_hashes = [None, None, self.hello_str_hash, None, None]
-        assert expected_hashes == hashes, (expected_hashes, hashes)
+        self.assertEqual(expected_hashes, hashes)
         expected_link_counts = [1, 1, 3, 3, 3]
         # The following assertion would fail as a result of bugs that are now fixed
-        assert expected_link_counts == link_counts, (expected_link_counts, link_counts)
+        self.assertEqual(expected_link_counts, link_counts)
 
         # Now try restoring, still checking hard links.
         sub_path = os.path.join(abs_output_dir, b"subdir")
@@ -258,16 +256,16 @@ class HardlinkTest(unittest.TestCase):
         InternalRestore(1, 1, sub_path, restore_path, 10000)
         for rp in [hlrestore_file1, hlrestore_file3]:
             rp.setdata()
-        assert hlrestore_file1.getinode() == hlrestore_file3.getinode()
+        self.assertEqual(hlrestore_file1.getinode(), hlrestore_file3.getinode())
 
         if restore_dir.lstat():
             restore_dir.delete()
         InternalRestore(1, 1, sub_path, restore_path, 20000)
         for rp in [hlrestore_file1, hlrestore_file2, hlrestore_file3]:
             rp.setdata()
-        assert hlrestore_file1.getinode() == hlrestore_file2.getinode()
+        self.assertEqual(hlrestore_file1.getinode(), hlrestore_file2.getinode())
         # The following assertion would fail as a result of bugs that are now fixed
-        assert hlrestore_file1.getinode() == hlrestore_file3.getinode()
+        self.assertEqual(hlrestore_file1.getinode(), hlrestore_file3.getinode())
 
     def test_moving_hardlinks(self):
         """Test moving the first hardlinked file in a series to later place in the series.
@@ -301,8 +299,8 @@ class HardlinkTest(unittest.TestCase):
 
         InternalBackup(1, 1, hlsrc.path, output.path, 10000)
         out_subdir = output.append("subdir")
-        assert out_subdir.append("hardlink1").getinode() == \
-            out_subdir.append("hardlink2").getinode()
+        self.assertEqual(out_subdir.append("hardlink1").getinode(),
+                         out_subdir.append("hardlink2").getinode())
 
         # validate that hashes and link counts are correctly saved in metadata
         meta_prefix = rpath.RPath(
@@ -310,26 +308,26 @@ class HardlinkTest(unittest.TestCase):
             os.path.join(abs_output_dir, b"rdiff-backup-data",
                          b"mirror_metadata"))
         incs = restore.get_inclist(meta_prefix)
-        assert len(incs) == 1
+        self.assertEqual(len(incs), 1)
         metadata_rp = incs[0]
         hashes, link_counts = self.extract_metadata(metadata_rp)
         # hashes for ., ./subdir, ./subdir/hardlink1, ./subdir/hardlink3
         expected_hashes = [None, None, self.hello_str_hash, None]
-        assert expected_hashes == hashes, (expected_hashes, hashes)
+        self.assertEqual(expected_hashes, hashes)
         expected_link_counts = [1, 1, 2, 2]
-        assert expected_link_counts == link_counts, (expected_link_counts, link_counts)
+        self.assertEqual(expected_link_counts, link_counts)
 
         # Move the first hardlinked file to be last
         hl_file3 = hlsrc_sub.append("hardlink3")
         rpath.rename(hl_file1, hl_file3)
 
         InternalBackup(1, 1, hlsrc.path, output.path, 20000)
-        assert out_subdir.append("hardlink2").getinode() == \
-            out_subdir.append("hardlink3").getinode()
+        self.assertEqual(out_subdir.append("hardlink2").getinode(),
+                         out_subdir.append("hardlink3").getinode())
 
         # validate that hashes and link counts are correctly saved in metadata
         incs = restore.get_inclist(meta_prefix)
-        assert len(incs) == 2
+        self.assertEqual(len(incs), 2)
         if incs[0].getinctype() == b'snapshot':
             metadata_rp = incs[0]
         else:
@@ -338,9 +336,9 @@ class HardlinkTest(unittest.TestCase):
         # hashes for ., ./subdir/, ./subdir/hardlink2, ./subdir/hardlink3
         expected_hashes = [None, None, self.hello_str_hash, None]
         # The following assertion would fail as a result of bugs that are now fixed
-        assert expected_hashes == hashes, (expected_hashes, hashes)
+        self.assertEqual(expected_hashes, hashes)
         expected_link_counts = [1, 1, 2, 2]
-        assert expected_link_counts == link_counts, (expected_link_counts, link_counts)
+        self.assertEqual(expected_link_counts, link_counts)
 
         # Now try restoring, still checking hard links.
         sub_path = os.path.join(abs_output_dir, b"subdir")
@@ -355,14 +353,14 @@ class HardlinkTest(unittest.TestCase):
         InternalRestore(1, 1, sub_path, restore_path, 10000)
         for rp in [hlrestore_file1, hlrestore_file2]:
             rp.setdata()
-        assert hlrestore_file1.getinode() == hlrestore_file2.getinode()
+        self.assertEqual(hlrestore_file1.getinode(), hlrestore_file2.getinode())
 
         if restore_dir.lstat():
             restore_dir.delete()
         InternalRestore(1, 1, sub_path, restore_path, 20000)
         for rp in [hlrestore_file2, hlrestore_file3]:
             rp.setdata()
-        assert hlrestore_file2.getinode() == hlrestore_file3.getinode()
+        self.assertEqual(hlrestore_file2.getinode(), hlrestore_file3.getinode())
 
 
 if __name__ == "__main__":

--- a/testing/hashtest.py
+++ b/testing/hashtest.py
@@ -25,16 +25,16 @@ class HashTest(unittest.TestCase):
         b1 = self.s1.encode()
         sfile = io.BytesIO(b1)
         fw = hash.FileWrapper(sfile)
-        assert fw.read() == b1
+        self.assertEqual(fw.read(), b1)
         report = fw.close()
-        assert report.sha1_digest == self.s1_hash, report.sha1_digest
+        self.assertEqual(report.sha1_digest, self.s1_hash)
 
         sfile2 = io.BytesIO(b1)
         fw2 = hash.FileWrapper(sfile2)
-        assert fw2.read(5) == b1[:5]
-        assert fw2.read() == b1[5:]
+        self.assertEqual(fw2.read(5), b1[:5])
+        self.assertEqual(fw2.read(), b1[5:])
         report2 = fw2.close()
-        assert report2.sha1_digest == self.s1_hash, report2.sha1_digest
+        self.assertEqual(report2.sha1_digest, self.s1_hash)
 
     def make_dirs(self):
         """Make two input directories"""
@@ -100,20 +100,20 @@ class HashTest(unittest.TestCase):
             os.path.join(abs_output_dir, b"rdiff-backup-data",
                          b"mirror_metadata"))
         incs = restore.get_inclist(meta_prefix)
-        assert len(incs) == 1
+        self.assertEqual(len(incs), 1)
         metadata_rp = incs[0]
         hashlist = self.extract_hashs(metadata_rp)
-        assert hashlist == hashlist1, (hashlist1, hashlist)
+        self.assertEqual(hashlist, hashlist1)
 
         rdiff_backup(1, 1, in_rp2.path, abs_output_dir, 20000)
         incs = restore.get_inclist(meta_prefix)
-        assert len(incs) == 2
+        self.assertEqual(len(incs), 2)
         if incs[0].getinctype() == 'snapshot':
             inc = incs[0]
         else:
             inc = incs[1]
         hashlist = self.extract_hashs(inc)
-        assert hashlist == hashlist2, (hashlist2, hashlist)
+        self.assertEqual(hashlist, hashlist2)
 
     def test_rorpiter_xfer(self):
         """Test if hashes are transferred in files, rorpiter"""
@@ -121,13 +121,14 @@ class HashTest(unittest.TestCase):
         conn = SetConnections._init_connection(
             b'%b %b/server.py' %
             (os.fsencode(sys.executable), abs_testing_dir))
-        assert conn.reval("lambda x: x+1", 4) == 5  # connection sanity check
+        # make a connection sanity check
+        self.assertEqual(conn.reval("lambda x: x+1", 4), 5)
 
         fp = hash.FileWrapper(io.BytesIO(self.s1.encode()))
         conn.Globals.set('tmp_file', fp)
         fp_remote = conn.Globals.get('tmp_file')
-        assert fp_remote.read() == self.s1.encode()
-        assert fp_remote.close().sha1_digest == self.s1_hash
+        self.assertEqual(fp_remote.read(), self.s1.encode())
+        self.assertEqual(fp_remote.close().sha1_digest, self.s1_hash)
 
         # Tested xfer of file, now test xfer of files in rorpiter
         root = MakeOutputDir()
@@ -145,17 +146,15 @@ class HashTest(unittest.TestCase):
         rorp1 = next(remote_iter)
         fp = hash.FileWrapper(rorp1.open('rb'))
         read_s1 = fp.read().decode()
-        assert read_s1 == self.s1, "Read string 1 %s isn't the same as written string %s" % (
-            read_s1, self.s1)
+        self.assertEqual(read_s1, self.s1)
         ret_val = fp.close()
-        assert isinstance(ret_val, hash.Report), ret_val
-        assert ret_val.sha1_digest == self.s1_hash
+        self.assertIsInstance(ret_val, hash.Report)
+        self.assertEqual(ret_val.sha1_digest, self.s1_hash)
         rorp2 = next(remote_iter)
         fp2 = hash.FileWrapper(rorp2.open('rb'))
         read_s2 = fp2.read().decode()
-        assert read_s2 == self.s2, "Read string 2 %s isn't the same as written string %s" % (
-            read_s2, self.s2)
-        assert fp2.close().sha1_digest == self.s2_hash
+        self.assertEqual(read_s2, self.s2)
+        self.assertEqual(fp2.close().sha1_digest, self.s2_hash)
 
         conn.quit()
 

--- a/testing/incrementtest.py
+++ b/testing/incrementtest.py
@@ -116,9 +116,9 @@ class inctest(unittest.TestCase):
         self.assertTrue(rp.lstat())
         self.assertTrue(target.isdir())
         self.assertTrue(dir._equal_verbose(rp,
-                                  check_index=0,
-                                  compare_size=0,
-                                  compare_type=0))
+                                           check_index=0,
+                                           compare_size=0,
+                                           compare_type=0))
         self.assertTrue(rp.isreg())
         rp.delete()
         target.delete()

--- a/testing/incrementtest.py
+++ b/testing/incrementtest.py
@@ -48,9 +48,9 @@ class inctest(unittest.TestCase):
 
     def check_time(self, rp):
         """Make sure that rp is an inc file, and time is Time.prevtime"""
-        assert rp.isincfile(), rp
+        self.assertTrue(rp.isincfile())
         t = rp.getinctime()
-        assert t == Time.prevtime, (t, Time.prevtime)
+        self.assertEqual(t, Time.prevtime)
 
     def testreg(self):
         """Test increment of regular files"""
@@ -63,17 +63,18 @@ class inctest(unittest.TestCase):
             rpd.delete()
 
         diffrp = increment.Increment(rf, exec1, target)
-        assert diffrp.isreg(), diffrp
-        assert diffrp._equal_verbose(exec1, check_index=0, compare_size=0)
+        self.assertTrue(diffrp.isreg())
+        self.assertTrue(
+            diffrp._equal_verbose(exec1, check_index=0, compare_size=0))
         self.check_time(diffrp)
-        assert diffrp.getinctype() == b'diff', diffrp.getinctype()
+        self.assertEqual(diffrp.getinctype(), b'diff')
         diffrp.delete()
 
     def testmissing(self):
         """Test creation of missing files"""
         missing_rp = increment.Increment(rf, nothing, target)
         self.check_time(missing_rp)
-        assert missing_rp.getinctype() == b'missing', missing_rp.getinctype()
+        self.assertEqual(missing_rp.getinctype(), b'missing')
         missing_rp.delete()
 
     def testsnapshot(self):
@@ -81,14 +82,14 @@ class inctest(unittest.TestCase):
         Globals.compression = None
         snap_rp = increment.Increment(rf, sym, target)
         self.check_time(snap_rp)
-        assert rpath._cmp_file_attribs(snap_rp, sym)
-        assert rpath.cmp(snap_rp, sym)
+        self.assertTrue(rpath._cmp_file_attribs(snap_rp, sym))
+        self.assertTrue(rpath.cmp(snap_rp, sym))
         snap_rp.delete()
 
         snap_rp2 = increment.Increment(sym, rf, target)
         self.check_time(snap_rp2)
-        assert snap_rp2._equal_verbose(rf, check_index=0)
-        assert rpath.cmp(snap_rp2, rf)
+        self.assertTrue(snap_rp2._equal_verbose(rf, check_index=0))
+        self.assertTrue(rpath.cmp(snap_rp2, rf))
         snap_rp2.delete()
 
     def testGzipsnapshot(self):
@@ -96,28 +97,29 @@ class inctest(unittest.TestCase):
         Globals.compression = 1
         rp = increment.Increment(rf, sym, target)
         self.check_time(rp)
-        assert rp._equal_verbose(sym, check_index=0, compare_size=0)
-        assert rpath.cmp(rp, sym)
+        self.assertTrue(rp._equal_verbose(sym, check_index=0, compare_size=0))
+        self.assertTrue(rpath.cmp(rp, sym))
         rp.delete()
 
         rp = increment.Increment(sym, rf, target)
         self.check_time(rp)
-        assert rp._equal_verbose(rf, check_index=0, compare_size=0)
-        assert rpath._cmp_file_obj(rp.open("rb", 1), rf.open("rb"))
-        assert rp.isinccompressed()
+        self.assertTrue(rp._equal_verbose(rf, check_index=0, compare_size=0))
+        with rp.open("rb", 1) as rp_fd, rf.open("rb") as rf_fd:
+            self.assertTrue(rpath._cmp_file_obj(rp_fd, rf_fd))
+        self.assertTrue(rp.isinccompressed())
         rp.delete()
 
     def testdir(self):
         """Test increment on dir"""
         rp = increment.Increment(sym, dir, target)
         self.check_time(rp)
-        assert rp.lstat()
-        assert target.isdir()
-        assert dir._equal_verbose(rp,
+        self.assertTrue(rp.lstat())
+        self.assertTrue(target.isdir())
+        self.assertTrue(dir._equal_verbose(rp,
                                   check_index=0,
                                   compare_size=0,
-                                  compare_type=0)
-        assert rp.isreg()
+                                  compare_type=0))
+        self.assertTrue(rp.isreg())
         rp.delete()
         target.delete()
 
@@ -126,9 +128,9 @@ class inctest(unittest.TestCase):
         Globals.compression = None
         rp = increment.Increment(rf, rf2, target)
         self.check_time(rp)
-        assert rp._equal_verbose(rf2, check_index=0, compare_size=0)
+        self.assertTrue(rp._equal_verbose(rf2, check_index=0, compare_size=0))
         Rdiff.patch_local(rf, rp, out2)
-        assert rpath.cmp(rf2, out2)
+        self.assertTrue(rpath.cmp(rf2, out2))
         rp.delete()
         out2.delete()
 
@@ -137,9 +139,9 @@ class inctest(unittest.TestCase):
         Globals.compression = 1
         rp = increment.Increment(rf, rf2, target)
         self.check_time(rp)
-        assert rp._equal_verbose(rf2, check_index=0, compare_size=0)
+        self.assertTrue(rp._equal_verbose(rf2, check_index=0, compare_size=0))
         Rdiff.patch_local(rf, rp, out2, delta_compressed=1)
-        assert rpath.cmp(rf2, out2)
+        self.assertTrue(rpath.cmp(rf2, out2))
         rp.delete()
         out2.delete()
 
@@ -147,13 +149,14 @@ class inctest(unittest.TestCase):
         """Here a .gz file shouldn't be compressed"""
         Globals.compression = 1
         rpath.copy(rf, out_gz)
-        assert out_gz.lstat()
+        self.assertTrue(out_gz.lstat())
 
         rp = increment.Increment(rf, out_gz, target)
         self.check_time(rp)
-        assert rp._equal_verbose(out_gz, check_index=0, compare_size=0)
+        self.assertTrue(
+            rp._equal_verbose(out_gz, check_index=0, compare_size=0))
         Rdiff.patch_local(rf, rp, out2)
-        assert rpath.cmp(out_gz, out2)
+        self.assertTrue(rpath.cmp(out_gz, out2))
         rp.delete()
         out2.delete()
         out_gz.delete()

--- a/testing/iterfiletest.py
+++ b/testing/iterfiletest.py
@@ -32,7 +32,8 @@ class testIterFile(unittest.TestCase):
     def testConversion(self):
         """Test iter to file conversion"""
         for itm in [self.iter1maker, self.iter2maker]:
-            assert iter_equal(itm(), IterWrappingFile(FileWrappingIter(itm())))
+            self.assertTrue(
+                iter_equal(itm(), IterWrappingFile(FileWrappingIter(itm()))))
 
     def testFile(self):
         """Test sending files through iters"""
@@ -43,8 +44,8 @@ class testIterFile(unittest.TestCase):
         file_iter = FileWrappingIter(iter([file1, file2]))
 
         new_iter = IterWrappingFile(file_iter)
-        assert next(new_iter).read() == buf1
-        assert next(new_iter).read() == buf2
+        self.assertEqual(next(new_iter).read(), buf1)
+        self.assertEqual(next(new_iter).read(), buf2)
 
         self.assertRaises(StopIteration, new_iter.__next__)
 
@@ -53,15 +54,11 @@ class testIterFile(unittest.TestCase):
         f = FileException(200 * 1024)  # size depends on buffer size
         new_iter = IterWrappingFile(FileWrappingIter(iter([f, b"foo"])))
         f_out = next(new_iter)
-        assert f_out.read(50000) == b"a" * 50000
-        try:
+        self.assertEqual(f_out.read(50000), b"a" * 50000)
+        with self.assertRaises(IOError):
             buf = f_out.read(190 * 1024)
-        except IOError:
-            pass
-        else:
-            assert 0, len(buf)
 
-        assert next(new_iter) == b"foo"
+        self.assertEqual(next(new_iter), b"foo")
         self.assertRaises(StopIteration, new_iter.__next__)
 
 
@@ -78,17 +75,15 @@ class testMiscIters(unittest.TestCase):
 
         self.outputrp.mkdir()
 
-        fp = self.regfile1.open("wb")
-        fp.write(b"hello")
-        fp.close()
+        with self.regfile1.open("wb") as fp:
+            fp.write(b"hello")
         self.regfile1.setfile(self.regfile1.open("rb"))
 
         self.regfile2.touch()
         self.regfile2.setfile(self.regfile2.open("rb"))
 
-        fp = self.regfile3.open("wb")
-        fp.write(b"goodbye")
-        fp.close()
+        with self.regfile3.open("wb") as fp:
+            fp.write(b"goodbye")
         self.regfile3.setfile(self.regfile3.open("rb"))
 
         self.regfile1.setdata()
@@ -109,19 +104,19 @@ class testMiscIters(unittest.TestCase):
         i_out = FileToMiscIter(MiscIterToFile(iter(rplist)))
 
         out1 = next(i_out)
-        assert out1 == self.outputrp
+        self.assertEqual(out1, self.outputrp)
 
         out2 = next(i_out)
-        assert out2 == self.regfile1
+        self.assertEqual(out2, self.regfile1)
         fp = out2.open("rb")
-        assert fp.read() == b"hello"
-        assert not fp.close()
+        self.assertEqual(fp.read(), b"hello")
+        self.assertFalse(fp.close())
 
         out3 = next(i_out)
-        assert out3 == self.regfile2
+        self.assertEqual(out3, self.regfile2)
         fp = out3.open("rb")
-        assert fp.read() == b""
-        assert not fp.close()
+        self.assertEqual(fp.read(), b"")
+        self.assertFalse(fp.close())
 
         next(i_out)
         self.assertRaises(StopIteration, i_out.__next__)
@@ -133,16 +128,16 @@ class testMiscIters(unittest.TestCase):
         i_out = FileToMiscIter(io.BytesIO(s))
 
         out1 = next(i_out)
-        assert out1 == 5, out1
+        self.assertEqual(out1, 5)
 
         out2 = next(i_out)
-        assert out2 == self.regfile3
+        self.assertEqual(out2, self.regfile3)
         fp = out2.open("rb")
-        assert fp.read() == b"goodbye"
-        assert not fp.close()
+        self.assertEqual(fp.read(), b"goodbye")
+        self.assertFalse(fp.close())
 
         out3 = next(i_out)
-        assert out3 == "hello", out3
+        self.assertEqual(out3, "hello")
 
         self.assertRaises(StopIteration, i_out.__next__)
 
@@ -154,11 +149,11 @@ class testMiscIters(unittest.TestCase):
             (filelike.read() + b"z" + filelike._i2b(0, 7)))
 
         i_out = FileToMiscIter(new_filelike)
-        assert next(i_out) == self.outputrp
+        self.assertEqual(next(i_out), self.outputrp)
         self.assertRaises(StopIteration, i_out.__next__)
 
         i_out2 = FileToMiscIter(filelike)
-        assert next(i_out2) == self.outputrp
+        self.assertEqual(next(i_out2), self.outputrp)
         self.assertRaises(StopIteration, i_out2.__next__)
 
     def testFlushRepeat(self):
@@ -169,12 +164,12 @@ class testMiscIters(unittest.TestCase):
             (filelike.read() + b"z" + filelike._i2b(0, 7)))
 
         i_out = FileToMiscIter(new_filelike)
-        assert next(i_out) == self.outputrp
-        assert next(i_out) is MiscIterFlushRepeat
+        self.assertEqual(next(i_out), self.outputrp)
+        self.assertIs(next(i_out), MiscIterFlushRepeat)
         self.assertRaises(StopIteration, i_out.__next__)
 
         i_out2 = FileToMiscIter(filelike)
-        assert next(i_out2) == self.outputrp
+        self.assertEqual(next(i_out2), self.outputrp)
         self.assertRaises(StopIteration, i_out2.__next__)
 
 

--- a/testing/iterfiletest.py
+++ b/testing/iterfiletest.py
@@ -56,7 +56,7 @@ class testIterFile(unittest.TestCase):
         f_out = next(new_iter)
         self.assertEqual(f_out.read(50000), b"a" * 50000)
         with self.assertRaises(IOError):
-            buf = f_out.read(190 * 1024)
+            buf = f_out.read(190 * 1024)  # noqa: F841
 
         self.assertEqual(next(new_iter), b"foo")
         self.assertRaises(StopIteration, new_iter.__next__)

--- a/testing/killtest.py
+++ b/testing/killtest.py
@@ -1,11 +1,11 @@
 import unittest
 import os
-import shutil
 import signal
 import sys
 import random
 import time
-from commontest import abs_test_dir, old_test_dir, compare_recursive, RBBin
+from commontest import abs_test_dir, old_test_dir, compare_recursive, RBBin, \
+    xcopytree
 from rdiff_backup import Globals, restore, rpath, Time
 """Test consistency by killing rdiff-backup as it is backing up"""
 
@@ -113,11 +113,9 @@ class ProcessFuncs(unittest.TestCase):
 
         def copy_thrice(input, output):
             """Copy input directory to output directory three times"""
-            shutil.copytree(input, output, symlinks=True)
-            shutil.copytree(input, os.path.join(output, b"killtesta"),
-                            symlinks=True)
-            shutil.copytree(input, os.path.join(output, b"killtestb"),
-                            symlinks=True)
+            xcopytree(input, output)
+            xcopytree(input, os.path.join(output, b"killtesta"))
+            xcopytree(input, os.path.join(output, b"killtestb"))
 
         for i in range(len(Local.ktrp)):
             Local.ktrp[i].setdata()

--- a/testing/killtest.py
+++ b/testing/killtest.py
@@ -181,7 +181,8 @@ class KillTest(ProcessFuncs):
         """
         rbdir = rp.append_path("rdiff-backup-data")
         inclist = restore.get_inclist(rbdir.append("current_mirror"))
-        self.assertIn(len(inclist), (1, 2),
+        self.assertIn(
+            len(inclist), (1, 2),
             "There must be 1 or 2 elements in '{paths_list}'.".format(
                 paths_list=str([x.path for x in inclist])))
 

--- a/testing/librsynctest.py
+++ b/testing/librsynctest.py
@@ -30,17 +30,17 @@ class LibrsyncTest(unittest.TestCase):
             self._clean_file(self.sig)
             rdiff_help_text = subprocess.check_output(["rdiff", "--help"])
             if b'-R' in rdiff_help_text:
-                assert not os.system(
+                self.assertEqual(os.system(
                     b"rdiff -b %i -R rollsum -S 8 -H md4 signature %b %b" %
-                    (blocksize, self.basis.path, self.sig.path))
+                    (blocksize, self.basis.path, self.sig.path)), 0)
             elif b'-H' in rdiff_help_text:
-                assert not os.system(
+                self.assertEqual(os.system(
                     b"rdiff -b %i -H md4 signature %b %b" %
-                    (blocksize, self.basis.path, self.sig.path))
+                    (blocksize, self.basis.path, self.sig.path)), 0)
             else:
-                assert not os.system(
+                self.assertEqual(os.system(
                     b"rdiff -b %i signature %b %b" %
-                    (blocksize, self.basis.path, self.sig.path))
+                    (blocksize, self.basis.path, self.sig.path)), 0)
             with self.sig.open("rb") as fp:
                 rdiff_sig = fp.read()
 
@@ -48,8 +48,7 @@ class LibrsyncTest(unittest.TestCase):
             librsync_sig = sf.read()
             sf.close()
 
-            assert rdiff_sig == librsync_sig, \
-                (len(rdiff_sig), len(librsync_sig))
+            self.assertEqual(rdiff_sig, librsync_sig)
 
     def _clean_file(self, rp):
         """Make sure the given rpath is properly cleaned"""
@@ -85,19 +84,18 @@ class LibrsyncTest(unittest.TestCase):
                     sig_gen.update(buf)
                 siggen_string = sig_gen.get_sig()
 
-            assert sigfile_string == siggen_string, \
-                (len(sigfile_string), len(siggen_string))
+            self.assertEqual(sigfile_string, siggen_string)
 
     def OldtestDelta(self):
         """Test delta generation against Rdiff"""
         MakeRandomFile(self.basis.path)
-        assert not os.system(b"rdiff signature %s %s" %
-                             (self.basis.path, self.sig.path))
+        self.assertEqual(os.system(
+            b"rdiff signature %s %s" % (self.basis.path, self.sig.path)), 0)
         for i in range(5):
             MakeRandomFile(self.new.path)
-            assert not os.system(
+            self.assertEqual(os.system(
                 b"rdiff delta %b %b %b" %
-                (self.sig.path, self.new.path, self.delta.path))
+                (self.sig.path, self.new.path, self.delta.path)), 0)
             fp = self.delta.open("rb")
             rdiff_delta = fp.read()
             fp.close()
@@ -109,7 +107,7 @@ class LibrsyncTest(unittest.TestCase):
             print(len(rdiff_delta), len(librsync_delta))
             print(repr(rdiff_delta[:100]))
             print(repr(librsync_delta[:100]))
-            assert rdiff_delta == librsync_delta
+            self.assertEqual(rdiff_delta, librsync_delta)
 
     def testDelta(self):
         """Test delta generation by making sure rdiff can process output
@@ -120,8 +118,8 @@ class LibrsyncTest(unittest.TestCase):
         """
         MakeRandomFile(self.basis.path)
         self._clean_file(self.sig)
-        assert not os.system(b"rdiff signature %s %s" %
-                             (self.basis.path, self.sig.path))
+        self.assertEqual(os.system(
+            b"rdiff signature %s %s" % (self.basis.path, self.sig.path)), 0)
         for i in range(5):
             MakeRandomFile(self.new.path)
             df = librsync.DeltaFile(self.sig.open("rb"), self.new.open("rb"))
@@ -132,9 +130,9 @@ class LibrsyncTest(unittest.TestCase):
             fp.close()
 
             self._clean_file(self.new2)
-            assert not os.system(
+            self.assertEqual(os.system(
                 b"rdiff patch %s %s %s" %
-                (self.basis.path, self.delta.path, self.new2.path))
+                (self.basis.path, self.delta.path, self.new2.path)), 0)
             new_fp = self.new.open("rb")
             new = new_fp.read()
             new_fp.close()
@@ -143,20 +141,20 @@ class LibrsyncTest(unittest.TestCase):
             new2 = new2_fp.read()
             new2_fp.close()
 
-            assert new == new2, (len(new), len(new2))
+            self.assertEqual(new, new2)
 
     def testPatch(self):
         """Test patching against Rdiff"""
         MakeRandomFile(self.basis.path)
         self._clean_file(self.sig)
-        assert not os.system(b"rdiff signature %s %s" %
-                             (self.basis.path, self.sig.path))
+        self.assertEqual(os.system(
+            b"rdiff signature %s %s" % (self.basis.path, self.sig.path)), 0)
         for i in range(5):
             MakeRandomFile(self.new.path)
             self._clean_file(self.delta)
-            assert not os.system(
+            self.assertEqual(os.system(
                 b"rdiff delta %s %s %s" %
-                (self.sig.path, self.new.path, self.delta.path))
+                (self.sig.path, self.new.path, self.delta.path)), 0)
             fp = self.new.open("rb")
             real_new = fp.read()
             fp.close()
@@ -166,8 +164,7 @@ class LibrsyncTest(unittest.TestCase):
             librsync_new = pf.read()
             pf.close()
 
-            assert real_new == librsync_new, \
-                (len(real_new), len(librsync_new))
+            self.assertEqual(real_new, librsync_new)
 
 
 if __name__ == "__main__":

--- a/testing/metadatatest.py
+++ b/testing/metadatatest.py
@@ -26,9 +26,9 @@ class MetadataTest(unittest.TestCase):
         ]
         for filename in filenames:
             quoted = quote_path(filename)
-            assert b"\n" not in quoted, quoted
+            self.assertNotIn(b"\n", quoted)
             result = unquote_path(quoted)
-            assert result == filename, (quoted, result, filename)
+            self.assertEqual(result, filename)
 
     def get_rpaths(self):
         """Return list of rorps"""
@@ -46,7 +46,7 @@ class MetadataTest(unittest.TestCase):
         for rp in self.get_rpaths():
             record = MetadataFile._object_to_record(rp)
             new_rorp = RorpExtractor._record_to_object(record)
-            assert new_rorp == rp, (new_rorp, rp, record)
+            self.assertEqual(new_rorp, rp)
 
     def testIterator(self):
         """Test writing RORPs to file and iterating them back"""
@@ -62,10 +62,9 @@ class MetadataTest(unittest.TestCase):
         fp.read()
         fp.seek(0)
         outlist = list(RorpExtractor(fp).iterate())
-        assert len(rplist) == len(outlist), (len(rplist), len(outlist))
+        self.assertEqual(len(rplist), len(outlist))
         for i in range(len(rplist)):
-            if not rplist[i]._equal_verbose(outlist[i]):
-                assert 0, (i, str(rplist[i]), str(outlist[i]))
+            self.assertTrue(rplist[i]._equal_verbose(outlist[i]))
         fp.close()
 
     def write_metadata_to_temp(self):
@@ -126,7 +125,7 @@ class MetadataTest(unittest.TestCase):
             i += 1
         print("Reading %s metadata entries took %s seconds." %
               (i, time.time() - start_time))
-        assert i == 51
+        self.assertEqual(i, 51)
 
     def test_write(self):
         """Test writing to metadata file, then reading back contents"""
@@ -144,17 +143,17 @@ class MetadataTest(unittest.TestCase):
         sel.parse_selection_args((), ())
         rps = list(sel.set_iter())
 
-        assert not temprp.lstat()
+        self.assertFalse(temprp.lstat())
         write_mf = MetadataFile(temprp, 'w')
         for rp in rps:
             write_mf.write_object(rp)
         write_mf.close()
-        assert temprp.lstat()
+        self.assertTrue(temprp.lstat())
 
         reread_rps = list(MetadataFile(temprp, 'r').get_objects())
-        assert len(reread_rps) == len(rps), (len(reread_rps), len(rps))
+        self.assertEqual(len(reread_rps), len(rps))
         for i in range(len(reread_rps)):
-            assert reread_rps[i] == rps[i], i
+            self.assertEqual(reread_rps[i], rps[i])
 
     def test_patch(self):
         """Test combining 3 iters of metadata rorps"""
@@ -182,11 +181,11 @@ class MetadataTest(unittest.TestCase):
             [iter(current), iter(diff1),
              iter(diff2)])
         out1 = next(output)
-        assert out1 is rp1new, out1
+        self.assertIs(out1, rp1new)
         out2 = next(output)
-        assert out2 is rp2, out2
+        self.assertIs(out2, rp2)
         out3 = next(output)
-        assert out3 is rp3, out3
+        self.assertIs(out3, rp3)
         self.assertRaises(StopIteration, output.__next__)
 
     def test_meta_patch_cycle(self):
@@ -204,7 +203,8 @@ class MetadataTest(unittest.TestCase):
         def compare(man, rootrp, time):
             sel = selection.Select(rootrp)
             sel.parse_selection_args((), ())  # make sure incorrect files are filtered out
-            assert iter_equal(sel.set_iter(), man.get_meta_at_time(time, None))
+            self.assertTrue(iter_equal(
+                sel.set_iter(), man.get_meta_at_time(time, None)))
 
         self.make_temp()
         Globals.rbdir = tempdir
@@ -234,14 +234,14 @@ class MetadataTest(unittest.TestCase):
 
         man = PatchDiffMan()
         rplist = man.sorted_prefix_inclist(b'mirror_metadata')
-        assert rplist[0].getinctype() == b'snapshot'
-        assert rplist[0].getinctime() == 40000
-        assert rplist[1].getinctype() == b'snapshot'
-        assert rplist[1].getinctime() == 30000
-        assert rplist[2].getinctype() == b'diff'
-        assert rplist[2].getinctime() == 20000
-        assert rplist[3].getinctype() == b'diff'
-        assert rplist[3].getinctime() == 10000
+        self.assertEqual(rplist[0].getinctype(), b'snapshot')
+        self.assertEqual(rplist[0].getinctime(), 40000)
+        self.assertEqual(rplist[1].getinctype(), b'snapshot')
+        self.assertEqual(rplist[1].getinctime(), 30000)
+        self.assertEqual(rplist[2].getinctype(), b'diff')
+        self.assertEqual(rplist[2].getinctime(), 20000)
+        self.assertEqual(rplist[3].getinctype(), b'diff')
+        self.assertEqual(rplist[3].getinctime(), 10000)
 
         compare(man, inc1, 10000)
         compare(man, inc2, 20000)

--- a/testing/metadatatest.py
+++ b/testing/metadatatest.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import io
 import time
-from commontest import old_test_dir, abs_output_dir, iter_equal
+from commontest import old_test_dir, abs_output_dir, iter_equal, xcopytree
 from rdiff_backup import rpath, Globals, selection
 from rdiff_backup.metadata import MetadataFile, PatchDiffMan, \
     quote_path, unquote_path, RorpExtractor
@@ -158,10 +158,8 @@ class MetadataTest(unittest.TestCase):
     def test_patch(self):
         """Test combining 3 iters of metadata rorps"""
         self.make_temp()
-        # shutil.copytree fails on the fifo file in the directory
-        os.system(
-            b'cp -a %s/* %s' %
-            (os.path.join(old_test_dir, b"various_file_types"), tempdir.path))
+        xcopytree(os.path.join(old_test_dir, b"various_file_types"),
+                  tempdir.path, content=True)
 
         rp1 = tempdir.append('regular_file')
         rp2 = tempdir.append('subdir')

--- a/testing/rdiffbackupdeletetest.py
+++ b/testing/rdiffbackupdeletetest.py
@@ -10,31 +10,34 @@ PY2 = sys.version_info < (3,)
 PY3 = sys.version_info > (3,)
 
 
-# Lookup for rdiff-backup-delete location.
-def rdiff_backup_delete(to_delete=None, extra_args=[], expected_ret_val=0, expected_output=None):
-    bin = spawn.find_executable(u"rdiff-backup-delete")
-    assert bin, "can't find rdiff-backup-delete"
-    cmdargs = [bin.encode('utf8')]
-    if extra_args:
-        cmdargs.extend(extra_args)
-    if to_delete:
-        cmdargs.append(to_delete)
-    cmdline = b" ".join(cmdargs)
-    print("Executing: %r" % (cmdline,))
-    p = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    output, error = p.communicate()
-    ret_val = p.poll()
-    if expected_ret_val is not None:
-        assert ret_val == expected_ret_val, "Return code %d of command '%s' doesn't match expected value: %d.\n%s\n%s" % \
-            (ret_val, cmdline, expected_ret_val, output, error)
-    if expected_output is not None:
-        assert expected_output in output or expected_output in error, "Output %s %s of command '%s' doesn't match expected output:\n'%s'" % \
-            (output, error, cmdline, expected_output)
-
-
 class RdiffBackupDeleteTest(unittest.TestCase):
 
     repo = ""
+
+    # Lookup for rdiff-backup-delete location.
+    def _rdiff_backup_delete(self, to_delete=None, extra_args=[], expected_ret_val=0, expected_output=None):
+        bin = spawn.find_executable(u"rdiff-backup-delete")
+        self.assertTrue(bin, "can't find rdiff-backup-delete")
+        cmdargs = [bin.encode('utf8')]
+        if extra_args:
+            cmdargs.extend(extra_args)
+        if to_delete:
+            cmdargs.append(to_delete)
+        cmdline = b" ".join(cmdargs)
+        print("Executing: %r" % (cmdline,))
+        p = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, error = p.communicate()
+        ret_val = p.poll()
+        if expected_ret_val is not None:
+            self.assertEqual(
+                ret_val, expected_ret_val,
+                "Return code %d of command '%s' doesn't match expected value: %d.\n%s\n%s" %
+                (ret_val, cmdline, expected_ret_val, output, error))
+        if expected_output is not None:
+            self.assertIn(
+                expected_output, output + error,
+                "Output %s %s of command '%s' doesn't match expected output:\n'%s'" %
+                (output, error, cmdline, expected_output))
 
     def _copy_repo(self, reponame):
         # Copy the required repo to a temporary location.
@@ -56,11 +59,11 @@ class RdiffBackupDeleteTest(unittest.TestCase):
 
     def assertFound(self, search):
         found = list(self._find(search))
-        assert found, "%r can't be found" % (search,)
+        self.assertTrue(found)
 
     def assertNotFound(self, search):
         found = list(self._find(search))
-        assert not found, "%r should not be found" % (found,)
+        self.assertFalse(found)
 
     def tearDown(self):
         if os.path.exists(self.repo):
@@ -68,88 +71,102 @@ class RdiffBackupDeleteTest(unittest.TestCase):
 
     def test_arguments(self):
         # Call with --help or -h should return 0 and print the usage.
-        rdiff_backup_delete(extra_args=[b'--help'],
-                            expected_output=b'Usage:')
-        rdiff_backup_delete(extra_args=[b'-h'],
-                            expected_output=b'Usage:')
+        self._rdiff_backup_delete(
+            extra_args=[b'--help'], expected_output=b'Usage:')
+        self._rdiff_backup_delete(
+            extra_args=[b'-h'], expected_output=b'Usage:')
         # Call without arguments
-        rdiff_backup_delete(extra_args=[], expected_ret_val=1,
-                            expected_output=b'fatal: missing arguments')
+        self._rdiff_backup_delete(
+            extra_args=[], expected_ret_val=1,
+            expected_output=b'fatal: missing arguments')
         # Call with invalid arguments
-        rdiff_backup_delete(extra_args=[b'--invalid'], expected_ret_val=1,
-                            expected_output=b'fatal: bad command line: option --invalid not recognized')
+        self._rdiff_backup_delete(
+            extra_args=[b'--invalid'], expected_ret_val=1,
+            expected_output=b'fatal: bad command line: option --invalid not recognized')
 
     def test_rdiff_backup_dir(self):
         # without rdiff-backup-dir
-        rdiff_backup_delete(to_delete=b'somefile', expected_ret_val=1,
-                            expected_output=b'fatal: not a rdiff-backup repository (or any parent up to mount point /)')
+        self._rdiff_backup_delete(
+            to_delete=b'somefile', expected_ret_val=1,
+            expected_output=b'fatal: not a rdiff-backup repository (or any parent up to mount point /)')
 
     def test_delete_with_file(self):
         self._copy_repo(b'restoretest4')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'tmp/changed'))
+        self._rdiff_backup_delete(
+            to_delete=os.path.join(self.repo, b'tmp/changed'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'changed')
 
     def test_delete_with_directory(self):
         self._copy_repo(b'restoretest4')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'tmp'))
+        self._rdiff_backup_delete(to_delete=os.path.join(self.repo, b'tmp'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'tmp')
 
     def test_delete_with_deleted_directory(self):
         self._copy_repo(b'restoretest3')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'increment1'))
+        self._rdiff_backup_delete(
+            to_delete=os.path.join(self.repo, b'increment1'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'increment1')
 
     def test_delete_with_symlink(self):
         self._copy_repo(b'restoretest3')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'various_file_types/symbolic_link'))
+        self._rdiff_backup_delete(
+            to_delete=os.path.join(self.repo,
+                                   b'various_file_types/symbolic_link'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'symbolic_link')
 
     def test_delete_with_hardlink(self):
         self._copy_repo(b'restoretest3')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'various_file_types/two_hardlinked_files1'))
+        self._rdiff_backup_delete(
+            to_delete=os.path.join(self.repo,
+                                   b'various_file_types/two_hardlinked_files1'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'two_hardlinked_files1')
 
     def test_delete_with_fifo(self):
         self._copy_repo(b'restoretest5')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'fifo'))
+        self._rdiff_backup_delete(to_delete=os.path.join(self.repo, b'fifo'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'fifo')
 
     def test_delete_with_non_utf8(self):
         self._copy_repo(b'restoretest5')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'various_file_types/\xd8\xab\xb1Wb\xae\xc5]\x8a\xbb\x15v*\xf4\x0f!\xf9>\xe2Y\x86\xbb\xab\xdbp\xb0\x84\x13k\x1d\xc2\xf1\xf5e\xa5U\x82\x9aUV\xa0\xf4\xdf4\xba\xfdX\x03\x82\x07s\xce\x9e\x8b\xb34\x04\x9f\x17 \xf4\x8f\xa6\xfa\x97\xab\xd8\xac\xda\x85\xdcKvC\xfa#\x94\x92\x9e\xc9\xb7\xc3_\x0f\x84g\x9aB\x11<=^\xdbM\x13\x96c\x8b\xa7|*"\\\'^$@#!(){}?+ ~` '))
+        self._rdiff_backup_delete(to_delete=os.path.join(self.repo, b'various_file_types/\xd8\xab\xb1Wb\xae\xc5]\x8a\xbb\x15v*\xf4\x0f!\xf9>\xe2Y\x86\xbb\xab\xdbp\xb0\x84\x13k\x1d\xc2\xf1\xf5e\xa5U\x82\x9aUV\xa0\xf4\xdf4\xba\xfdX\x03\x82\x07s\xce\x9e\x8b\xb34\x04\x9f\x17 \xf4\x8f\xa6\xfa\x97\xab\xd8\xac\xda\x85\xdcKvC\xfa#\x94\x92\x9e\xc9\xb7\xc3_\x0f\x84g\x9aB\x11<=^\xdbM\x13\x96c\x8b\xa7|*"\\\'^$@#!(){}?+ ~` '))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
 
     def test_delete_access_control_lists(self):
         self._copy_repo(b'restoretest3')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'increment1'))
+        self._rdiff_backup_delete(
+            to_delete=os.path.join(self.repo, b'increment1'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'increment1')
 
     def test_extended_attributes(self):
         self._copy_repo(b'restoretest3')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'newdir2'))
+        self._rdiff_backup_delete(to_delete=os.path.join(self.repo, b'newdir2'))
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertNotFound(b'newdir2')
 
     def test_delete_with_dryrun(self):
         self._copy_repo(b'restoretest4')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'tmp'), extra_args=[b'--dry-run'])
+        self._rdiff_backup_delete(to_delete=os.path.join(self.repo, b'tmp'),
+                                  extra_args=[b'--dry-run'])
         rdiff_backup(1, 1, self.repo, None, extra_options=b"--verify")
         self.assertFound(b'tmp')
 
     def test_delete_with_running_backup(self):
         self._copy_repo(b'restoretest4')
-        current_mirror = os.path.join(self.repo, b'rdiff-backup-data', b'current_mirror.2020-01-01T00:20:00-07:00.snapshot')
+        current_mirror = os.path.join(
+            self.repo, b'rdiff-backup-data',
+            b'current_mirror.2020-01-01T00:20:00-07:00.snapshot')
         with open(current_mirror, 'wb') as f:
             f.write(b'PID 1234')
-        rdiff_backup_delete(to_delete=os.path.join(self.repo, b'tmp'), expected_ret_val=1,
-                            expected_output=b'fail to acquired repository lock. A backup may be running.')
+        self._rdiff_backup_delete(
+            to_delete=os.path.join(self.repo, b'tmp'), expected_ret_val=1,
+            expected_output=b'fail to acquired repository lock. A backup may be running.')
 
 
 if __name__ == "__main__":

--- a/testing/rdifftest.py
+++ b/testing/rdifftest.py
@@ -36,7 +36,7 @@ class RdiffTest(unittest.TestCase):
                 self.lc,
                 os.path.join(old_test_dir, b"various_file_types",
                              b"regular_file")), 2048)
-        assert rpath._cmp_file_obj(sigfp, rfsig)
+        self.assertTrue(rpath._cmp_file_obj(sigfp, rfsig))
         sigfp.close()
         rfsig.close()
 
@@ -53,14 +53,14 @@ class RdiffTest(unittest.TestCase):
             MakeRandomFile(self.basis.path)
             MakeRandomFile(self.new.path)
             list(map(rpath.RPath.setdata, [self.basis, self.new]))
-            assert self.basis.lstat() and self.new.lstat()
+            self.assertTrue(self.basis.lstat() and self.new.lstat())
             self.signature.write_from_fileobj(Rdiff.get_signature(self.basis))
-            assert self.signature.lstat()
+            self.assertTrue(self.signature.lstat())
             self.delta.write_from_fileobj(
                 Rdiff.get_delta_sigrp_hash(self.signature, self.new))
-            assert self.delta.lstat()
+            self.assertTrue(self.delta.lstat())
             Rdiff.patch_local(self.basis, self.delta, self.output)
-            assert rpath.cmp(self.new, self.output)
+            self.assertTrue(rpath.cmp(self.new, self.output))
             list(map(rpath.RPath.delete, rplist))
 
     def testRdiffDeltaPatchGzip(self):
@@ -75,12 +75,12 @@ class RdiffTest(unittest.TestCase):
         MakeRandomFile(self.basis.path)
         MakeRandomFile(self.new.path)
         list(map(rpath.RPath.setdata, [self.basis, self.new]))
-        assert self.basis.lstat() and self.new.lstat()
+        self.assertTrue(self.basis.lstat() and self.new.lstat())
         self.signature.write_from_fileobj(Rdiff.get_signature(self.basis))
-        assert self.signature.lstat()
+        self.assertTrue(self.signature.lstat())
         self.delta.write_from_fileobj(
             Rdiff.get_delta_sigrp_hash(self.signature, self.new))
-        assert self.delta.lstat()
+        self.assertTrue(self.delta.lstat())
         os.system(b"gzip %s" % self.delta.path)
         os.system(b"mv %s.gz %s" % (self.delta.path, self.delta.path))
         self.delta.setdata()
@@ -89,7 +89,7 @@ class RdiffTest(unittest.TestCase):
                           self.delta,
                           self.output,
                           delta_compressed=1)
-        assert rpath.cmp(self.new, self.output)
+        self.assertTrue(rpath.cmp(self.new, self.output))
         list(map(rpath.RPath.delete, rplist))
 
     def testWriteDelta(self):
@@ -100,12 +100,12 @@ class RdiffTest(unittest.TestCase):
         MakeRandomFile(self.basis.path)
         MakeRandomFile(self.new.path)
         list(map(rpath.RPath.setdata, [self.basis, self.new]))
-        assert self.basis.lstat() and self.new.lstat()
+        self.assertTrue(self.basis.lstat() and self.new.lstat())
 
         Rdiff.write_delta(self.basis, self.new, self.delta)
-        assert self.delta.lstat()
+        self.assertTrue(self.delta.lstat())
         Rdiff.patch_local(self.basis, self.delta, self.output)
-        assert rpath.cmp(self.new, self.output)
+        self.assertTrue(rpath.cmp(self.new, self.output))
         list(map(rpath.RPath.delete, rplist))
 
     def testWriteDeltaGzip(self):
@@ -114,18 +114,18 @@ class RdiffTest(unittest.TestCase):
         MakeRandomFile(self.basis.path)
         MakeRandomFile(self.new.path)
         list(map(rpath.RPath.setdata, [self.basis, self.new]))
-        assert self.basis.lstat() and self.new.lstat()
+        self.assertTrue(self.basis.lstat() and self.new.lstat())
         delta_gz = rpath.RPath(self.delta.conn, self.delta.path + b".gz")
         if delta_gz.lstat():
             delta_gz.delete()
 
         Rdiff.write_delta(self.basis, self.new, delta_gz, 1)
-        assert delta_gz.lstat()
+        self.assertTrue(delta_gz.lstat())
         os.system(b"gunzip %s" % delta_gz.path)
         delta_gz.setdata()
         self.delta.setdata()
         Rdiff.patch_local(self.basis, self.delta, self.output)
-        assert rpath.cmp(self.new, self.output)
+        self.assertTrue(rpath.cmp(self.new, self.output))
         list(map(rpath.RPath.delete, rplist))
 
     def testRdiffRename(self):
@@ -138,14 +138,14 @@ class RdiffTest(unittest.TestCase):
         MakeRandomFile(self.basis.path)
         MakeRandomFile(self.new.path)
         list(map(rpath.RPath.setdata, [self.basis, self.new]))
-        assert self.basis.lstat() and self.new.lstat()
+        self.assertTrue(self.basis.lstat() and self.new.lstat())
         self.signature.write_from_fileobj(Rdiff.get_signature(self.basis))
-        assert self.signature.lstat()
+        self.assertTrue(self.signature.lstat())
         self.delta.write_from_fileobj(
             Rdiff.get_delta_sigrp_hash(self.signature, self.new))
-        assert self.delta.lstat()
+        self.assertTrue(self.delta.lstat())
         Rdiff.patch_local(self.basis, self.delta)
-        assert rpath.cmp(self.basis, self.new)
+        self.assertTrue(rpath.cmp(self.basis, self.new))
         list(map(rpath.RPath.delete, rplist))
 
 

--- a/testing/regresstest.py
+++ b/testing/regresstest.py
@@ -40,43 +40,40 @@ class RegressTest(unittest.TestCase):
                      self.incrp[0].path,
                      self.output_rp.path,
                      current_time=10000)
-        assert compare_recursive(self.incrp[0], self.output_rp)
+        self.assertTrue(compare_recursive(self.incrp[0], self.output_rp))
 
         rdiff_backup(1,
                      1,
                      self.incrp[1].path,
                      self.output_rp.path,
                      current_time=20000)
-        assert compare_recursive(self.incrp[1], self.output_rp)
+        self.assertTrue(compare_recursive(self.incrp[1], self.output_rp))
 
         rdiff_backup(1,
                      1,
                      self.incrp[2].path,
                      self.output_rp.path,
                      current_time=30000)
-        assert compare_recursive(self.incrp[2], self.output_rp)
+        self.assertTrue(compare_recursive(self.incrp[2], self.output_rp))
 
         rdiff_backup(1,
                      1,
                      self.incrp[3].path,
                      self.output_rp.path,
                      current_time=40000)
-        assert compare_recursive(self.incrp[3], self.output_rp)
+        self.assertTrue(compare_recursive(self.incrp[3], self.output_rp))
 
         Globals.rbdir = self.output_rbdir_rp
 
         regress_function(30000)
-        assert compare_recursive(self.incrp[2],
-                                 self.output_rp,
-                                 compare_hardlinks=0)
+        self.assertTrue(compare_recursive(self.incrp[2], self.output_rp,
+                                          compare_hardlinks=0))
         regress_function(20000)
-        assert compare_recursive(self.incrp[1],
-                                 self.output_rp,
-                                 compare_hardlinks=0)
+        self.assertTrue(compare_recursive(self.incrp[1], self.output_rp,
+                                          compare_hardlinks=0))
         regress_function(10000)
-        assert compare_recursive(self.incrp[0],
-                                 self.output_rp,
-                                 compare_hardlinks=0)
+        self.assertTrue(compare_recursive(self.incrp[0], self.output_rp,
+                                          compare_hardlinks=0))
 
     def regress_to_time_local(self, time):
         """Regress self.output_rp to time by running regress locally"""
@@ -130,7 +127,7 @@ class RegressTest(unittest.TestCase):
 
         cmd = b"rdiff-backup --check-destination-dir %s" % self.output_rp.path
         print("Executing:", cmd)
-        assert not os.system(cmd)
+        self.assertEqual(os.system(cmd), 0)
 
     def make_unreadable(self):
         """Make unreadable input directory
@@ -155,7 +152,7 @@ class RegressTest(unittest.TestCase):
     def change_unreadable(self):
         """Change attributes in directory, so regress will request fp"""
         subdir = self.output_rp.append('unreadable_dir')
-        assert subdir.lstat()
+        self.assertTrue(subdir.lstat())
         rp1_1 = subdir.append('to_be_unreadable')
         rp1_1.chmod(0)
         subdir.chmod(0)

--- a/testing/resourceforktest.py
+++ b/testing/resourceforktest.py
@@ -30,15 +30,15 @@ class ResourceForkTest(unittest.TestCase):
         self.make_temp()
         rp = self.tempdir.append('test')
         rp.touch()
-        assert rp.get_resource_fork() == '', rp.get_resource_fork()
+        self.assertEqual(rp.get_resource_fork(), '')
 
         s = 'new resource fork data'
         rp.write_resource_fork(s)
-        assert rp.get_resource_fork() == s, rp.get_resource_fork()
+        self.assertEqual(rp.get_resource_fork(), s)
 
         rp2 = self.tempdir.append('test')
-        assert rp2.isreg()
-        assert rp2.get_resource_fork() == s, rp2.get_resource_fork()
+        self.assertTrue(rp2.isreg())
+        self.assertEqual(rp2.get_resource_fork(), s)
 
     def testRecord(self):
         """Test reading, writing, and comparing of records with rforks"""
@@ -49,8 +49,8 @@ class ResourceForkTest(unittest.TestCase):
 
         record = metadata.RORP2Record(rp)
         rorp_out = metadata.Record2RORP(record)
-        assert rorp_out == rp, (rorp_out, rp)
-        assert rorp_out.get_resource_fork() == 'hello'
+        self.assertEqual(rorp_out, rp)
+        self.assertEqual(rorp_out.get_resource_fork(), 'hello')
 
     def make_backup_dirs(self):
         """Create testfiles/resource_fork_test[12] dirs for testing"""

--- a/testing/robusttest.py
+++ b/testing/robusttest.py
@@ -16,13 +16,9 @@ class RobustTest(unittest.TestCase):
             ansoethusaotneuhsaotneuhsaontehuaou  # noqa: F821 undefined name
 
         result = robust.check_common_error(None, cause_catchable_error, [1])
-        assert result is None, result
-        try:
+        self.assertIsNone(result)
+        with self.assertRaises(NameError):
             robust.check_common_error(None, cause_uncatchable_error)
-        except NameError:
-            pass
-        else:
-            assert 0, "Key error not raised"
 
 
 if __name__ == '__main__':

--- a/testing/roottest.py
+++ b/testing/roottest.py
@@ -94,8 +94,8 @@ class RootTest(BaseRootTest):
         BackupRestoreSeries(1, 1, dirlist, compare_ownership=1)
         symrp = rpath.RPath(Globals.local_connection,
                             os.path.join(abs_output_dir, b'symlink'))
-        assert symrp.issym(), symrp
-        assert symrp.getuidgid() == (2004, 2004), symrp.getuidgid()
+        self.assertTrue(symrp.issym())
+        self.assertEqual(symrp.getuidgid(), (2004, 2004))
 
     def test_ownership_mapping(self):
         """Test --user-mapping-file and --group-mapping-file options"""
@@ -123,7 +123,8 @@ class RootTest(BaseRootTest):
         def get_ownership(dir_rp):
             """Return pair (ids of dir_rp/1, ids of dir_rp2) of ids"""
             rp1, rp2 = list(map(dir_rp.append, ('1', '2')))
-            assert rp1.isreg() and rp2.isreg(), (rp1.isreg(), rp2.isreg())
+            self.assertTrue(rp1.isreg())
+            self.assertTrue(rp2.isreg())
             return (rp1.getuidgid(), rp2.getuidgid())
 
         in_rp = write_ownership_dir()
@@ -132,8 +133,8 @@ class RootTest(BaseRootTest):
         if out_rp.lstat():
             Myrm(out_rp.path)
 
-        assert get_ownership(in_rp) == ((0, 0), (userid, 1)), \
-            get_ownership(in_rp)
+        self.assertEqual(get_ownership(in_rp), ((0, 0), (userid, 1)))
+
         rdiff_backup(1,
                      0,
                      in_rp.path,
@@ -141,8 +142,7 @@ class RootTest(BaseRootTest):
                      extra_options=(b"--user-mapping-file %b "
                                     b"--group-mapping-file %b" %
                                     (user_map, group_map)))
-        assert get_ownership(out_rp) == ((userid, 0), (0, 1)), \
-            get_ownership(out_rp)
+        self.assertEqual(get_ownership(out_rp), ((userid, 0), (0, 1)))
 
     def test_numerical_mapping(self):
         """Test --preserve-numerical-ids option
@@ -167,7 +167,8 @@ class RootTest(BaseRootTest):
         def get_ownership(dir_rp):
             """Return pair (ids of dir_rp/1, ids of dir_rp2) of ids"""
             rp1, rp2 = list(map(dir_rp.append, ('1', '2')))
-            assert rp1.isreg() and rp2.isreg(), (rp1.isreg(), rp2.isreg())
+            self.assertTrue(rp1.isreg())
+            self.assertTrue(rp2.isreg())
             return (rp1.getuidgid(), rp2.getuidgid())
 
         in_rp = write_ownership_dir()
@@ -175,15 +176,14 @@ class RootTest(BaseRootTest):
         if out_rp.lstat():
             Myrm(out_rp.path)
 
-        assert get_ownership(in_rp) == ((0, 0), (userid, 1)), \
-            get_ownership(in_rp)
+        self.assertEqual(get_ownership(in_rp), ((0, 0), (userid, 1)))
+
         rdiff_backup(1,
                      0,
                      in_rp.path,
                      out_rp.path,
                      extra_options=(b"--preserve-numerical-ids"))
-        assert get_ownership(out_rp) == ((0, 0), (userid, 1)), \
-            get_ownership(in_rp)
+        self.assertEqual(get_ownership(out_rp), ((0, 0), (userid, 1)))
 
     def tearDown(self):
         # especially the logfile might still appear opened if a test was interrupted
@@ -266,7 +266,8 @@ class HalfRoot(BaseRootTest):
         rp_new = rp.append('lala')
         rp_new.write_string('asoentuh')
         rp_new.chmod(0)
-        assert not os.system(b'chown %s %s' % (user.encode(), rp_new.path))
+        self.assertEqual(
+            os.system(b'chown %s %s' % (user.encode(), rp_new.path)), 0)
         rp1_3 = rp.append('unreadable_dir')
         rp1_3.chmod(0o700)
         rp1_3_1 = rp1_3.append('file_inside')
@@ -300,21 +301,21 @@ class HalfRoot(BaseRootTest):
         cmd3 = restore_schema % (b'10000', remote_schema, outrp.path,
                                  rout_rp.path)
         self._run_cmd(cmd3)
-        assert compare_recursive(in_rp1, rout_rp)
+        self.assertTrue(compare_recursive(in_rp1, rout_rp))
         rout_perms = rout_rp.append('unreadable_dir').getperms()
         outrp_perms = outrp.append('unreadable_dir').getperms()
-        assert rout_perms == 0, rout_perms
-        assert outrp_perms == 0, outrp_perms
+        self.assertEqual(rout_perms, 0)
+        self.assertEqual(outrp_perms, 0)
 
         Myrm(rout_rp.path)
         cmd4 = restore_schema % (b"now", remote_schema, outrp.path,
                                  rout_rp.path)
         self._run_cmd(cmd4)
-        assert compare_recursive(in_rp2, rout_rp)
+        self.assertTrue(compare_recursive(in_rp2, rout_rp))
         rout_perms = rout_rp.append('unreadable_dir').getperms()
         outrp_perms = outrp.append('unreadable_dir').getperms()
-        assert rout_perms == 0, rout_perms
-        assert outrp_perms == 0, outrp_perms
+        self.assertEqual(rout_perms, 0)
+        self.assertEqual(outrp_perms, 0)
 
         self.cause_regress(outrp)
         cmd5 = (b'su -c "%s --check-destination-dir %s" %s' %
@@ -356,7 +357,7 @@ class NonRoot(BaseRootTest):
         rp2.chown(2, 2)
         rp3 = sp.append("3")
         rp3.chown(1, 1)
-        assert not compare_recursive(rp, sp, compare_ownership=1)
+        self.assertFalse(compare_recursive(rp, sp, compare_ownership=1))
 
         return rp, sp
 
@@ -388,21 +389,26 @@ class NonRoot(BaseRootTest):
 
         self.backup(input_rp1, output_rp, 1000000)
         self.restore(output_rp, restore_rp)
-        assert compare_recursive(input_rp1, restore_rp, compare_ownership=1)
+        self.assertTrue(
+            compare_recursive(input_rp1, restore_rp, compare_ownership=1))
 
         self.backup(input_rp2, output_rp, 2000000)
         self.restore(output_rp, restore_rp)
-        assert compare_recursive(input_rp2, restore_rp, compare_ownership=1)
+        self.assertTrue(
+            compare_recursive(input_rp2, restore_rp, compare_ownership=1))
 
         self.backup(empty_rp, output_rp, 3000000)
         self.restore(output_rp, restore_rp)
-        assert compare_recursive(empty_rp, restore_rp, compare_ownership=1)
+        self.assertTrue(
+            compare_recursive(empty_rp, restore_rp, compare_ownership=1))
 
         self.restore(output_rp, restore_rp, 1000000)
-        assert compare_recursive(input_rp1, restore_rp, compare_ownership=1)
+        self.assertTrue(
+            compare_recursive(input_rp1, restore_rp, compare_ownership=1))
 
         self.restore(output_rp, restore_rp, 2000000)
-        assert compare_recursive(input_rp2, restore_rp, compare_ownership=1)
+        self.assertTrue(
+            compare_recursive(input_rp2, restore_rp, compare_ownership=1))
 
 
 if __name__ == "__main__":

--- a/testing/roottest.py
+++ b/testing/roottest.py
@@ -2,7 +2,7 @@ import unittest
 import os
 from commontest import old_test_dir, abs_test_dir, abs_output_dir, Myrm, \
     abs_restore_dir, re_init_rpath_dir, compare_recursive, \
-    BackupRestoreSeries, rdiff_backup, RBBin
+    BackupRestoreSeries, rdiff_backup, RBBin, xcopytree
 from rdiff_backup import Globals, rpath, Main
 """Root tests - contain tests which need to be run as root.
 
@@ -352,7 +352,7 @@ class NonRoot(BaseRootTest):
                          os.path.join(abs_test_dir, b"root_out2"))
         if sp.lstat():
             Myrm(sp.path)
-        self._run_cmd(b"cp -a %s %s" % (rp.path, sp.path))
+        xcopytree(rp.path, sp.path)
         rp2 = sp.append("2")
         rp2.chown(2, 2)
         rp3 = sp.append("3")

--- a/testing/rorpitertest.py
+++ b/testing/rorpitertest.py
@@ -35,22 +35,24 @@ class RORPIterTest(unittest.TestCase):
         makeiter3 = lambda: iter(map(helper, [1, 2]))  # noqa: E731 use def instead of lambda
 
         outiter = rorpiter.CollateIterators(makeiter1(), makeiter2())
-        assert iter_equal(
+        self.assertTrue(iter_equal(
             outiter,
             iter([(indices[0], indices[0]), (indices[1], indices[1]),
-                  (indices[2], None), (indices[3], indices[3])]))
+                  (indices[2], None), (indices[3], indices[3])])))
 
-        assert iter_equal(
+        self.assertTrue(iter_equal(
             rorpiter.CollateIterators(makeiter1(), makeiter2(), makeiter3()),
             iter([(indices[0], indices[0], None),
                   (indices[1], indices[1], indices[1]),
                   (indices[2], None, indices[2]),
-                  (indices[3], indices[3], None)]))
+                  (indices[3], indices[3], None)])))
 
-        assert iter_equal(rorpiter.CollateIterators(makeiter1(), iter([])),
-                          iter([(i, None) for i in indices]))
-        assert iter_equal(iter([(i, None) for i in indices]),
-                          rorpiter.CollateIterators(makeiter1(), iter([])))
+        self.assertTrue(
+            iter_equal(rorpiter.CollateIterators(makeiter1(), iter([])),
+                       iter([(i, None) for i in indices])))
+        self.assertTrue(
+            iter_equal(iter([(i, None) for i in indices]),
+                       rorpiter.CollateIterators(makeiter1(), iter([]))))
 
     def compare_no_times(self, src_rp, dest_rp):
         """Compare but disregard directories attributes"""
@@ -68,17 +70,16 @@ class IndexedTupleTest(unittest.TestCase):
         i = rorpiter.IndexedTuple((1, 2, 3), ("a", "b"))
         i2 = rorpiter.IndexedTuple((), ("hello", "there", "how are you"))
 
-        assert i[0] == "a"
-        assert i[1] == "b"
-        assert i2[1] == "there"
-        assert len(i) == 2 and len(i2) == 3
-        assert i2 < i, i2 < i
+        self.assertEqual(i[0], "a")
+        self.assertEqual(i[1], "b")
+        self.assertEqual(i2[1], "there")
+        self.assertEqual(len(i), 2)
+        self.assertEqual(len(i2), 3)
+        self.assertLess(i2, i)
 
     def testTupleAssignment(self):
         a, b, c = rorpiter.IndexedTuple((), (1, 2, 3))
-        assert a == 1
-        assert b == 2
-        assert c == 3
+        self.assertEqual((a, b, c), (1, 2, 3))
 
 
 class FillTest(unittest.TestCase):
@@ -95,8 +96,9 @@ class FillTest(unittest.TestCase):
         filled_in = rorpiter.FillInIter(get_rpiter(), rootrp)
         rp_list = list(filled_in)
         index_list = [tuple(map(int, rp.index)) for rp in rp_list]
-        assert index_list == [(), (1, ), (1, 2), (1, 3), (1, 4), (2, ), (2, 1),
-                              (3, ), (3, 4), (3, 4, 5), (3, 6)], index_list
+        self.assertEqual(index_list,
+                         [(), (1, ), (1, 2), (1, 3), (1, 4), (2, ), (2, 1),
+                             (3, ), (3, 4), (3, 4, 5), (3, 6)])
 
 
 class ITRBadder(rorpiter.ITRBranch):
@@ -149,56 +151,56 @@ class TreeReducerTest(unittest.TestCase):
         itm = rorpiter.IterTreeReducer(ITRBadder, [])
         for index in self.i1:
             val = itm(index)
-            assert val, (val, index)
+            self.assertTrue(val)
         itm.Finish()
-        assert itm.root_branch.total == 6, itm.root_branch.total
+        self.assertEqual(itm.root_branch.total, 6)
 
         itm2 = rorpiter.IterTreeReducer(ITRBadder2, [])
         for index in self.i2:
             val = itm2(index)
             if index == ():
-                assert not val
+                self.assertFalse(val)
             else:
-                assert val
+                self.assertTrue(val)
         itm2.Finish()
-        assert itm2.root_branch.total == 12, itm2.root_branch.total
+        self.assertEqual(itm2.root_branch.total, 12)
 
     def testTreeReducerState(self):
         """Test saving and recreation of an IterTreeReducer"""
         itm1a = rorpiter.IterTreeReducer(ITRBadder, [])
         for index in self.i1a:
             val = itm1a(index)
-            assert val, index
+            self.assertTrue(val)
         itm1b = pickle.loads(pickle.dumps(itm1a))
         for index in self.i1b:
             val = itm1b(index)
-            assert val, index
+            self.assertTrue(val)
         itm1b.Finish()
-        assert itm1b.root_branch.total == 6, itm1b.root_branch.total
+        self.assertEqual(itm1b.root_branch.total, 6)
 
         itm2a = rorpiter.IterTreeReducer(ITRBadder2, [])
         for index in self.i2a:
             val = itm2a(index)
             if index == ():
-                assert not val
+                self.assertFalse(val)
             else:
-                assert val
+                self.assertTrue(val)
         itm2b = pickle.loads(pickle.dumps(itm2a))
         for index in self.i2b:
             val = itm2b(index)
             if index == ():
-                assert not val
+                self.assertFalse(val)
             else:
-                assert val
+                self.assertTrue(val)
         itm2c = pickle.loads(pickle.dumps(itm2b))
         for index in self.i2c:
             val = itm2c(index)
             if index == ():
-                assert not val
+                self.assertFalse(val)
             else:
-                assert val
+                self.assertTrue(val)
         itm2c.Finish()
-        assert itm2c.root_branch.total == 12, itm2c.root_branch.total
+        self.assertEqual(itm2c.root_branch.total, 12)
 
 
 class CacheIndexableTest(unittest.TestCase):
@@ -217,15 +219,15 @@ class CacheIndexableTest(unittest.TestCase):
         for i in range(3):  # call 3 times next
             next(ci)
 
-        assert ci.get((1, )) == self.d[(1, )]
-        assert ci.get((3, )) is None
+        self.assertEqual(ci.get((1, )), self.d[(1, )])
+        self.assertIsNone(ci.get((3, )))
 
         for i in range(3):  # call 3 times next
             next(ci)
 
-        assert ci.get((3, )) == self.d[(3, )]
-        assert ci.get((4, )) == self.d[(4, )]
-        assert ci.get((3, 5)) is None
+        self.assertEqual(ci.get((3, )), self.d[(3, )])
+        self.assertEqual(ci.get((4, )), self.d[(4, )])
+        self.assertIsNone(ci.get((3, 5)))
         self.assertRaises(AssertionError, ci.get, (1, ))
 
     def testEqual(self):
@@ -233,7 +235,7 @@ class CacheIndexableTest(unittest.TestCase):
         self.d = {}
         l1 = list(self.get_iter())
         l2 = list(rorpiter.CacheIndexable(iter(l1), 10))
-        assert l1 == l2, (l1, l2)
+        self.assertEqual(l1, l2)
 
 
 if __name__ == "__main__":

--- a/testing/rpathtest.py
+++ b/testing/rpathtest.py
@@ -22,10 +22,11 @@ class RORPStateTest(RPathTest):
     def testPickle(self):
         rorp = rpath.RPath(self.lc, self.prefix, ("regular_file", )).getRORPath()
         rorp.file = sys.stdin  # try to confuse pickler
-        assert rorp.isreg()
+        self.assertTrue(rorp.isreg())
         rorp2 = pickle.loads(pickle.dumps(rorp, 1))
-        assert rorp2.isreg()
-        assert rorp2.data == rorp.data and rorp.index == rorp2.index
+        self.assertTrue(rorp2.isreg())
+        self.assertEqual(rorp2.data, rorp.data)
+        self.assertEqual(rorp2.index, rorp.index)
 
 
 class CheckTypes(RPathTest):
@@ -33,34 +34,39 @@ class CheckTypes(RPathTest):
 
     def testExist(self):
         """Can tell if files exist"""
-        assert rpath.RPath(self.lc, self.prefix, ()).lstat()
-        assert not rpath.RPath(self.lc, "asuthasetuouo", ()).lstat()
+        self.assertTrue(rpath.RPath(self.lc, self.prefix, ()).lstat())
+        self.assertFalse(rpath.RPath(self.lc, "asuthasetuouo", ()).lstat())
 
     def testDir(self):
         """Directories identified correctly"""
-        assert rpath.RPath(self.lc, self.prefix, ()).isdir()
-        assert not rpath.RPath(self.lc, self.prefix, ("regular_file", )).isdir()
+        self.assertTrue(rpath.RPath(self.lc, self.prefix, ()).isdir())
+        self.assertFalse(
+            rpath.RPath(self.lc, self.prefix, ("regular_file", )).isdir())
 
     def testSym(self):
         """Symbolic links identified"""
-        assert rpath.RPath(self.lc, self.prefix, ("symbolic_link", )).issym()
-        assert not rpath.RPath(self.lc, self.prefix, ()).issym()
+        self.assertTrue(
+            rpath.RPath(self.lc, self.prefix, ("symbolic_link", )).issym())
+        self.assertFalse(rpath.RPath(self.lc, self.prefix, ()).issym())
 
     def testReg(self):
         """Regular files identified"""
-        assert rpath.RPath(self.lc, self.prefix, ("regular_file", )).isreg()
-        assert not rpath.RPath(self.lc, self.prefix, ("symbolic_link", )).isreg()
+        self.assertTrue(
+            rpath.RPath(self.lc, self.prefix, ("regular_file", )).isreg())
+        self.assertFalse(
+            rpath.RPath(self.lc, self.prefix, ("symbolic_link", )).isreg())
 
     def testFifo(self):
         """Fifo's identified"""
-        assert rpath.RPath(self.lc, self.prefix, ("fifo", )).isfifo()
-        assert not rpath.RPath(self.lc, self.prefix, ()).isfifo()
+        self.assertTrue(rpath.RPath(self.lc, self.prefix, ("fifo", )).isfifo())
+        self.assertFalse(rpath.RPath(self.lc, self.prefix, ()).isfifo())
 
     @unittest.skipUnless(os.path.exists('/dev/tty2'), "Test requires /dev/tty2")
     def testCharDev(self):
         """Char special files identified"""
-        assert rpath.RPath(self.lc, "/dev/tty2", ()).ischardev()
-        assert not rpath.RPath(self.lc, self.prefix, ("regular_file", )).ischardev()
+        self.assertTrue(rpath.RPath(self.lc, "/dev/tty2", ()).ischardev())
+        self.assertFalse(
+            rpath.RPath(self.lc, self.prefix, ("regular_file", )).ischardev())
 
     @unittest.skipUnless(
         os.path.exists('/dev/sda') or os.path.exists('/dev/nvme0n1'),
@@ -72,10 +78,11 @@ class CheckTypes(RPathTest):
         # somediskdev = os.path.realpath(psutil.disk_partitions()[0].device)
         # We assume that anybody must have a hard drive, SSD or NVMe
         if (os.path.exists('/dev/sda')):
-            assert rpath.RPath(self.lc, '/dev/sda', ()).isblkdev()
+            self.assertTrue(rpath.RPath(self.lc, '/dev/sda', ()).isblkdev())
         else:
-            assert rpath.RPath(self.lc, '/dev/nvme0n1', ()).isblkdev()
-        assert not rpath.RPath(self.lc, self.prefix, ("regular_file", )).isblkdev()
+            self.assertTrue(rpath.RPath(self.lc, '/dev/nvme0n1', ()).isblkdev())
+        self.assertFalse(
+            rpath.RPath(self.lc, self.prefix, ("regular_file", )).isblkdev())
 
 
 class CheckPerms(RPathTest):
@@ -83,28 +90,29 @@ class CheckPerms(RPathTest):
 
     def testExecReport(self):
         """Check permissions for executable files"""
-        assert self.rp_prefix.append('executable').getperms() == 0o755
-        assert self.rp_prefix.append('executable2').getperms() == 0o700
+        self.assertEqual(self.rp_prefix.append('executable').getperms(), 0o755)
+        self.assertEqual(self.rp_prefix.append('executable2').getperms(), 0o700)
 
     def testhighbits(self):
         """Test reporting of highbit permissions"""
         p = rpath.RPath(self.lc, os.path.join(self.mainprefix, b"rpath2",
                                               b"foobar")).getperms()
-        assert p == 0o4100, p
+        self.assertEqual(p, 0o4100)
 
     def testOrdinaryReport(self):
         """Ordinary file permissions..."""
-        assert self.rp_prefix.append("regular_file").getperms() == 0o644
-        assert self.rp_prefix.append(
-            'two_hardlinked_files1').getperms() == 0o640
+        self.assertEqual(
+            self.rp_prefix.append("regular_file").getperms(), 0o644)
+        self.assertEqual(
+            self.rp_prefix.append('two_hardlinked_files1').getperms(), 0o640)
 
     def testChmod(self):
         """Test changing file permission"""
         rp = self.rp_prefix.append("changeable_permission")
         rp.chmod(0o700)
-        assert rp.getperms() == 0o700
+        self.assertEqual(rp.getperms(), 0o700)
         rp.chmod(0o644)
-        assert rp.getperms() == 0o644
+        self.assertEqual(rp.getperms(), 0o644)
 
     def testExceptions(self):
         """What happens when file absent"""
@@ -122,8 +130,8 @@ class CheckTimes(RPathTest):
         rp.touch()
         rp.settime(10000, 20000)
         rp.setdata()
-        assert rp.getatime() == 10000
-        assert rp.getmtime() == 20000
+        self.assertEqual(rp.getatime(), 10000)
+        self.assertEqual(rp.getmtime(), 20000)
         rp.delete()
 
     def testCtime(self):
@@ -133,14 +141,14 @@ class CheckTimes(RPathTest):
         rp.touch()
         rp.chmod(0o700)
         rpath.copy_with_attribs(rp, rp2)
-        assert rpath._cmp_file_attribs(rp, rp2)
+        self.assertTrue(rpath._cmp_file_attribs(rp, rp2))
 
         time.sleep(1)
         rp2.chmod(0o755)
         rp2.chmod(0o700)
         rp2.setdata()
-        assert rp2.getctime() > rp.getctime()
-        assert not rpath._cmp_file_attribs(rp, rp2)
+        self.assertGreater(rp2.getctime(), rp.getctime())
+        self.assertFalse(rpath._cmp_file_attribs(rp, rp2))
         rp.delete()
         rp2.delete()
 
@@ -151,11 +159,11 @@ class CheckDir(RPathTest):
     def testCreation(self):
         """Test directory creation and deletion"""
         d = self.rp_prefix.append("tempdir")
-        assert not d.lstat()
+        self.assertFalse(d.lstat())
         d.mkdir()
-        assert d.isdir()
+        self.assertTrue(d.isdir())
         d.rmdir()
-        assert not d.lstat()
+        self.assertFalse(d.lstat())
 
     def testExceptions(self):
         """Should raise os.errors when no files"""
@@ -167,9 +175,10 @@ class CheckDir(RPathTest):
 
     def testListdir(self):
         """Checking dir listings"""
-        dirlist = rpath.RPath(self.lc, self.mainprefix, ("sampledir", )).listdir()
+        dirlist = rpath.RPath(self.lc, self.mainprefix,
+                              ("sampledir", )).listdir()
         dirlist.sort()
-        assert dirlist == [b"1", b"2", b"3", b"4"], dirlist
+        self.assertEqual(dirlist, [b"1", b"2", b"3", b"4"])
 
 
 class CheckSyms(RPathTest):
@@ -177,16 +186,17 @@ class CheckSyms(RPathTest):
 
     def testRead(self):
         """symlink read"""
-        assert (rpath.RPath(self.lc, self.prefix,
-                            ("symbolic_link", )).readlink() == b"regular_file")
+        self.assertEqual(
+            rpath.RPath(self.lc, self.prefix, ("symbolic_link", )).readlink(),
+            b"regular_file")
 
     def testMake(self):
         """Creating symlink"""
         link = rpath.RPath(self.lc, self.write_dir, ("symlink", ))
-        assert not link.lstat()
+        self.assertFalse(link.lstat())
         link.symlink("abcdefg")
-        assert link.issym()
-        assert link.readlink() == b"abcdefg"
+        self.assertTrue(link.issym())
+        self.assertEqual(link.readlink(), b"abcdefg")
         link.delete()
 
 
@@ -196,32 +206,22 @@ class CheckSockets(RPathTest):
     def testMake(self):
         """Create socket, then read it"""
         sock = rpath.RPath(self.lc, self.write_dir, ("socket", ))
-        assert not sock.lstat()
+        self.assertFalse(sock.lstat())
         sock.mksock()
-        assert sock.issock()
+        self.assertTrue(sock.issock())
         sock.delete()
 
     def testLongSock(self):
-        """Test making a socket with a long name
-
-        On some systems, the name of a socket is restricted, and
-        cannot be as long as a regular file.  When this happens, a
-        SkipFileException should be raised.
-
-        """
+        """Test making a socket with a long name.
+        It shouldn't be an issue anymore on modern systems"""
         sock = rpath.RPath(self.lc, self.write_dir, (
             "socketaoeusthaoeaoeutnhaonseuhtansoeuthasoneuthasoeutnhasonuthaoensuhtasoneuhtsanouhonetuhasoneuthsaoenaonsetuaosenuhtaoensuhaoeu",
         ))
-        assert not sock.lstat()
-        try:
-            sock.mksock()
-        except rpath.SkipFileException:
-            pass
-        else:
-            print("Warning, making long socket did not fail")
+        self.assertFalse(sock.lstat())
+        sock.mksock()
         sock.setdata()
-        if sock.lstat():
-            sock.delete()
+        self.assertTrue(sock.lstat())
+        sock.delete()
 
 
 class TouchDelete(RPathTest):
@@ -230,18 +230,18 @@ class TouchDelete(RPathTest):
     def testTouch(self):
         """Creation of 0 length files"""
         t = rpath.RPath(self.lc, self.write_dir, ("testtouch", ))
-        assert not t.lstat()
+        self.assertFalse(t.lstat())
         t.touch()
-        assert t.lstat()
+        self.assertTrue(t.lstat())
         t.delete()
 
     def testDelete(self):
         """Deletion of files"""
         d = rpath.RPath(self.lc, self.write_dir, ("testdelete", ))
         d.touch()
-        assert d.lstat()
+        self.assertTrue(d.lstat())
         d.delete()
-        assert not d.lstat()
+        self.assertFalse(d.lstat())
 
 
 class MiscFileInfo(RPathTest):
@@ -249,8 +249,9 @@ class MiscFileInfo(RPathTest):
 
     def testFileLength(self):
         """File length = getsize()"""
-        assert (rpath.RPath(self.lc, self.prefix,
-                            ("regular_file", )).getsize() == 75650)
+        self.assertEqual(
+            rpath.RPath(self.lc, self.prefix, ("regular_file", )).getsize(),
+            75650)
 
 
 class FilenameOps(RPathTest):
@@ -286,23 +287,22 @@ class FilenameOps(RPathTest):
         """See if filename quoting works"""
         wtf = rpath.RPath(self.lc, self.prefix, (self.weirdfilename, ))
         reg = rpath.RPath(self.lc, self.prefix, (b"regular_file", ))
-        assert wtf.lstat()
-        assert reg.lstat()
-        assert not os.system(b"ls %s >/dev/null 2>&1" % wtf.quote())
-        assert not os.system(b"ls %s >/dev/null 2>&1" % reg.quote())
+        self.assertTrue(wtf.lstat())
+        self.assertTrue(reg.lstat())
+        self.assertEqual(os.system(b"ls %s >/dev/null 2>&1" % wtf.quote()), 0)
+        self.assertEqual(os.system(b"ls %s >/dev/null 2>&1" % reg.quote()), 0)
 
     def testNormalize(self):
         """rpath.normalize() dictionary test"""
         for (before, after) in list(self.normdict.items()):
-            assert rpath.RPath(self.lc, before, ()).normalize().path == after, \
-                "Normalize fails for %a => %a" % (before, after)
+            self.assertEqual(
+                rpath.RPath(self.lc, before, ()).normalize().path, after)
 
     def testDirsplit(self):
         """Test splitting of various directories"""
         for full, split in list(self.dirsplitdict.items()):
             result = rpath.RPath(self.lc, full, ()).dirsplit()
-            assert result == split, \
-                "%s => %s instead of %s" % (full, result, split)
+            self.assertEqual(result, split)
 
     @unittest.skipUnless(
         (os.path.exists('/dev/sda') or os.path.exists('/dev/nvme0n1'))
@@ -326,7 +326,7 @@ class FileIO(RPathTest):
     def testRead(self):
         """File reading"""
         with rpath.RPath(self.lc, self.prefix, ("executable", )).open("r") as fp:
-            assert fp.read(6) == "#!/bin"
+            self.assertEqual(fp.read(6), "#!/bin")
 
     def testWrite(self):
         """File writing"""
@@ -334,7 +334,7 @@ class FileIO(RPathTest):
         with rp.open("w") as fp:
             fp.write("hello")
         with rp.open("r") as fp_input:
-            assert fp_input.read() == "hello"
+            self.assertEqual(fp_input.read(), "hello")
         rp.delete()
 
     def testGzipWrite(self):
@@ -353,9 +353,9 @@ class FileIO(RPathTest):
 
         with rp_gz.open("wb", compress=1) as fp_out:
             fp_out.write(s)
-        assert not os.system(b"gunzip %s" % file_gz)
+        self.assertEqual(os.system(b"gunzip %s" % file_gz), 0)
         with rp_nogz.open("rb") as fp_in:
-            assert fp_in.read() == s
+            self.assertEqual(fp_in.read(), s)
 
     def testGzipRead(self):
         """Test reading of gzipped files"""
@@ -374,17 +374,16 @@ class FileIO(RPathTest):
         with rp_nogz.open("w") as fp_out:
             fp_out.write(s)
         rp_nogz.setdata()
-        assert rp_nogz.lstat()
+        self.assertTrue(rp_nogz.lstat())
 
-        assert not os.system(b"gzip %s" % file_nogz)
+        self.assertEqual(os.system(b"gzip %s" % file_nogz), 0)
         rp_nogz.setdata()
         rp_gz.setdata()
-        assert not rp_nogz.lstat()
-        assert rp_gz.lstat()
+        self.assertFalse(rp_nogz.lstat())
+        self.assertTrue(rp_gz.lstat())
         with rp_gz.open("r", compress=1) as fp_in:
             read_s = fp_in.read().decode()  # zip is always binary hence bytes
-            assert read_s == s, "Read string %s not like written %s." % (
-                read_s, s)
+            self.assertEqual(read_s, s)
 
 
 class FileCopying(RPathTest):
@@ -400,22 +399,23 @@ class FileCopying(RPathTest):
         self.dest = rpath.RPath(self.lc, self.mainprefix, ("dest", ))
         if self.dest.lstat():
             self.dest.delete()
-        assert not self.dest.lstat()
+        self.assertFalse(self.dest.lstat())
 
     def testComp(self):
         """Test comparisons involving regular files"""
-        assert rpath.cmp(self.hl1, self.hl2)
-        assert not rpath.cmp(self.rf, self.hl1)
-        assert not rpath.cmp(self.dir, self.rf)
+        self.assertTrue(rpath.cmp(self.hl1, self.hl2))
+        self.assertFalse(rpath.cmp(self.rf, self.hl1))
+        self.assertFalse(rpath.cmp(self.dir, self.rf))
 
     def testCompMisc(self):
         """Test miscellaneous comparisons"""
-        assert rpath.cmp(self.dir, rpath.RPath(self.lc, self.mainprefix, ()))
+        self.assertTrue(
+            rpath.cmp(self.dir, rpath.RPath(self.lc, self.mainprefix, ())))
         self.dest.symlink("regular_file")
-        assert rpath.cmp(self.sl, self.dest)
+        self.assertTrue(rpath.cmp(self.sl, self.dest))
         self.dest.delete()
-        assert not rpath.cmp(self.sl, self.fifo)
-        assert not rpath.cmp(self.dir, self.sl)
+        self.assertFalse(rpath.cmp(self.sl, self.fifo))
+        self.assertFalse(rpath.cmp(self.dir, self.sl))
 
     def testDirSizeComp(self):
         """Make sure directories can be equal,
@@ -425,16 +425,16 @@ class FileCopying(RPathTest):
         bigdir = rpath.RPath(Globals.local_connection,
                              os.path.join(old_test_dir, b"dircomptest", b"2"))
         # Can guarantee below by adding files to bigdir
-        assert bigdir.getsize() > smalldir.getsize()
-        assert smalldir == bigdir
+        self.assertGreater(bigdir.getsize(), smalldir.getsize())
+        self.assertEqual(smalldir, bigdir)
 
     def testCopy(self):
         """Test copy of various files"""
         for rp in [self.sl, self.rf, self.fifo, self.dir]:
             rpath.copy(rp, self.dest)
-            assert self.dest.lstat(), "%a doesn't exist" % self.dest.path
-            assert rpath.cmp(rp, self.dest)
-            assert rpath.cmp(self.dest, rp)
+            self.assertTrue(self.dest.lstat())
+            self.assertTrue(rpath.cmp(rp, self.dest))
+            self.assertTrue(rpath.cmp(self.dest, rp))
             self.dest.delete()
 
 
@@ -455,16 +455,16 @@ class FileAttributes(FileCopying):
         """Test attribute comparison success"""
         testpairs = [(self.hl1, self.hl2)]
         for a, b in testpairs:
-            assert a.equal_loose(b), "Err with %a %a" % (a.path, b.path)
-            assert b.equal_loose(a), "Err with %a %a" % (b.path, a.path)
+            self.assertTrue(a.equal_loose(b))
+            self.assertTrue(b.equal_loose(a))
 
     def testCompFail(self):
         """Test attribute comparison failures"""
         testpairs = [(self.nowrite, self.noperms), (self.exec1, self.exec2),
                      (self.rf, self.hl1)]
         for a, b in testpairs:
-            assert not a.equal_loose(b), "Err with %a %a" % (a.path, b.path)
-            assert not b.equal_loose(a), "Err with %a %a" % (b.path, a.path)
+            self.assertFalse(a.equal_loose(b))
+            self.assertFalse(b.equal_loose(a))
 
     def testCheckRaise(self):
         """Should raise exception when file missing"""
@@ -484,8 +484,7 @@ class FileAttributes(FileCopying):
         ]:
             rpath.copy(rp, t)
             rpath.copy_attribs(rp, t)
-            assert t.equal_loose(rp), \
-                "Attributes for file %s not copied successfully" % rp.path
+            self.assertTrue(t.equal_loose(rp))
             t.delete()
 
     def testCopyWithAttribs(self):
@@ -498,8 +497,8 @@ class FileAttributes(FileCopying):
                 self.hl1, self.dir, self.sym
         ]:
             rpath.copy_with_attribs(rp, out)
-            assert rpath.cmp(rp, out)
-            assert rp.equal_loose(out)
+            self.assertTrue(rpath.cmp(rp, out))
+            self.assertTrue(rp.equal_loose(out))
             out.delete()
 
     def testCopyRaise(self):
@@ -516,11 +515,11 @@ class CheckPath(unittest.TestCase):
     def testpath(self):
         """Test root paths"""
         root = rpath.RPath(Globals.local_connection, "/")
-        assert root.path == b"/", root.path
+        self.assertEqual(root.path, b"/")
         bin = root.append("bin")
-        assert bin.path == b"/bin", bin.path
+        self.assertEqual(bin.path, b"/bin")
         bin2 = rpath.RPath(Globals.local_connection, "/bin")
-        assert bin2.path == b"/bin", bin2.path
+        self.assertEqual(bin2.path, b"/bin")
 
 
 class Gzip(RPathTest):
@@ -535,21 +534,21 @@ class Gzip(RPathTest):
         fileobj = rpath.MaybeGzip(base_rp)
         fileobj.close()
         base_rp.setdata()
-        assert base_rp.isreg(), base_rp
-        assert base_rp.getsize() == 0
+        self.assertTrue(base_rp.isreg())
+        self.assertEqual(base_rp.getsize(), 0)
         base_rp.delete()
 
         base_gz = dirrp.append('foo.gz')
-        assert not base_gz.lstat()
+        self.assertFalse(base_gz.lstat())
         fileobj = rpath.MaybeGzip(base_rp)
         fileobj.write(b"lala")
         fileobj.close()
         base_rp.setdata()
         base_gz.setdata()
-        assert not base_rp.lstat()
-        assert base_gz.isreg(), base_gz
+        self.assertFalse(base_rp.lstat())
+        self.assertTrue(base_gz.isreg())
         data = base_gz.get_bytes(compressed=1)
-        assert data == b"lala", data
+        self.assertEqual(data, b"lala")
 
 
 if __name__ == "__main__":

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -28,14 +28,14 @@ class MatchingTest(unittest.TestCase):
     def testRegexp(self):
         """Test regular expression selection func"""
         sf1 = self.Select._regexp_get_sf(".*\\.py", 1)
-        assert sf1(self.makeext("1.py")) == 1
-        assert sf1(self.makeext("usr/foo.py")) == 1
-        assert sf1(self.root.append("1.doc")) is None
+        self.assertEqual(sf1(self.makeext("1.py")), 1)
+        self.assertEqual(sf1(self.makeext("usr/foo.py")), 1)
+        self.assertIsNone(sf1(self.root.append("1.doc")))
 
         sf2 = self.Select._regexp_get_sf("hello", 0)
-        assert sf2(self.makerp("hello")) == 0
-        assert sf2(self.makerp("foohello_there")) == 0
-        assert sf2(self.makerp("foo")) is None
+        self.assertEqual(sf2(self.makerp("hello")), 0)
+        self.assertEqual(sf2(self.makerp("foohello_there")), 0)
+        self.assertIsNone(sf2(self.makerp("foo")))
 
     def testTupleInclude(self):
         """Test include selection function made from a regular filename"""
@@ -48,12 +48,12 @@ class MatchingTest(unittest.TestCase):
 
         sf2 = self.Select._glob_get_sf(
             "rdiff-backup_testfiles/select/usr/local/bin/", 1)
-        assert sf2(self.makeext("usr")) == 1
-        assert sf2(self.makeext("usr/local")) == 1
-        assert sf2(self.makeext("usr/local/bin")) == 1
-        assert sf2(self.makeext("usr/local/doc")) is None
-        assert sf2(self.makeext("usr/local/bin/gzip")) == 1
-        assert sf2(self.makeext("usr/local/bingzip")) is None
+        self.assertEqual(sf2(self.makeext("usr")), 1)
+        self.assertEqual(sf2(self.makeext("usr/local")), 1)
+        self.assertEqual(sf2(self.makeext("usr/local/bin")), 1)
+        self.assertIsNone(sf2(self.makeext("usr/local/doc")))
+        self.assertEqual(sf2(self.makeext("usr/local/bin/gzip")), 1)
+        self.assertIsNone(sf2(self.makeext("usr/local/bingzip")))
 
     def testTupleExclude(self):
         """Test exclude selection function made from a regular filename"""
@@ -66,35 +66,35 @@ class MatchingTest(unittest.TestCase):
 
         sf2 = self.Select._glob_get_sf(
             "rdiff-backup_testfiles/select/usr/local/bin/", 0)
-        assert sf2(self.makeext("usr")) is None
-        assert sf2(self.makeext("usr/local")) is None
-        assert sf2(self.makeext("usr/local/bin")) == 0
-        assert sf2(self.makeext("usr/local/doc")) is None
-        assert sf2(self.makeext("usr/local/bin/gzip")) == 0
-        assert sf2(self.makeext("usr/local/bingzip")) is None
+        self.assertIsNone(sf2(self.makeext("usr")))
+        self.assertIsNone(sf2(self.makeext("usr/local")))
+        self.assertEqual(sf2(self.makeext("usr/local/bin")), 0)
+        self.assertIsNone(sf2(self.makeext("usr/local/doc")))
+        self.assertEqual(sf2(self.makeext("usr/local/bin/gzip")), 0)
+        self.assertIsNone(sf2(self.makeext("usr/local/bingzip")))
 
     def testGlobStarInclude(self):
         """Test a few globbing patterns, including **"""
         sf1 = self.Select._glob_get_sf("**", 1)
-        assert sf1(self.makeext("foo")) == 1
-        assert sf1(self.makeext("")) == 1
+        self.assertEqual(sf1(self.makeext("foo")), 1)
+        self.assertEqual(sf1(self.makeext("")), 1)
 
         sf2 = self.Select._glob_get_sf("**.py", 1)
-        assert sf2(self.makeext("foo")) == 2
-        assert sf2(self.makeext("usr/local/bin")) == 2
-        assert sf2(self.makeext("what/ever.py")) == 1
-        assert sf2(self.makeext("what/ever.py/foo")) == 1
+        self.assertEqual(sf2(self.makeext("foo")), 2)
+        self.assertEqual(sf2(self.makeext("usr/local/bin")), 2)
+        self.assertEqual(sf2(self.makeext("what/ever.py")), 1)
+        self.assertEqual(sf2(self.makeext("what/ever.py/foo")), 1)
 
     def testGlobStarExclude(self):
         """Test a few glob excludes, including **"""
         sf1 = self.Select._glob_get_sf("**", 0)
-        assert sf1(self.makeext("/usr/local/bin")) == 0
+        self.assertEqual(sf1(self.makeext("/usr/local/bin")), 0)
 
         sf2 = self.Select._glob_get_sf("**.py", 0)
-        assert sf2(self.makeext("foo")) is None, sf2(self.makeext("foo"))
-        assert sf2(self.makeext("usr/local/bin")) is None
-        assert sf2(self.makeext("what/ever.py")) == 0
-        assert sf2(self.makeext("what/ever.py/foo")) == 0
+        self.assertIsNone(sf2(self.makeext("foo")))
+        self.assertIsNone(sf2(self.makeext("usr/local/bin")))
+        self.assertEqual(sf2(self.makeext("what/ever.py")), 0)
+        self.assertEqual(sf2(self.makeext("what/ever.py/foo")), 0)
 
     def testFilelistInclude(self):
         """Test included filelist"""
@@ -104,14 +104,14 @@ rdiff-backup_testfiles/select/1
 rdiff-backup_testfiles/select/1/2/3
 rdiff-backup_testfiles/select/3/3/2""")
         sf = self.Select._filelist_get_sf(fp, 1, "test")
-        assert sf(self.root) == 1
-        assert sf(self.makeext("1")) == 1
-        assert sf(self.makeext("1/1")) is None
-        assert sf(self.makeext("1/2/3")) == 1
-        assert sf(self.makeext("2/2")) is None
-        assert sf(self.makeext("3")) == 1
-        assert sf(self.makeext("3/3")) == 1
-        assert sf(self.makeext("3/3/3")) is None
+        self.assertEqual(sf(self.root), 1)
+        self.assertEqual(sf(self.makeext("1")), 1)
+        self.assertIsNone(sf(self.makeext("1/1")))
+        self.assertEqual(sf(self.makeext("1/2/3")), 1)
+        self.assertIsNone(sf(self.makeext("2/2")))
+        self.assertEqual(sf(self.makeext("3")), 1)
+        self.assertEqual(sf(self.makeext("3/3")), 1)
+        self.assertIsNone(sf(self.makeext("3/3/3")))
 
     def testFilelistWhitespaceInclude(self):
         """Test included filelist, with some whitespace"""
@@ -120,11 +120,11 @@ rdiff-backup_testfiles/select/3/3/2""")
 - rdiff-backup_testfiles/select/2  
 rdiff-backup_testfiles/select/3\t""")  # noqa: W291 trailing whitespaces
         sf = self.Select._filelist_get_sf(fp, 1, "test")
-        assert sf(self.root) == 1
-        assert sf(self.makeext("1  ")) == 1
-        assert sf(self.makeext("2  ")) == 0
-        assert sf(self.makeext("3\t")) == 1
-        assert sf(self.makeext("4")) is None
+        self.assertEqual(sf(self.root), 1)
+        self.assertEqual(sf(self.makeext("1  ")), 1)
+        self.assertEqual(sf(self.makeext("2  ")), 0)
+        self.assertEqual(sf(self.makeext("3\t")), 1)
+        self.assertIsNone(sf(self.makeext("4")))
 
     def testFilelistIncludeNullSep(self):
         """Test included filelist but with null_separator set"""
@@ -133,15 +133,15 @@ rdiff-backup_testfiles/select/3\t""")  # noqa: W291 trailing whitespaces
         )
         Globals.null_separator = 1
         sf = self.Select._filelist_get_sf(fp, 1, "test")
-        assert sf(self.root) == 1
-        assert sf(self.makeext("1")) == 1
-        assert sf(self.makeext("1/1")) is None
-        assert sf(self.makeext("1/2/3")) == 1
-        assert sf(self.makeext("2/2")) is None
-        assert sf(self.makeext("3")) == 1
-        assert sf(self.makeext("3/3")) == 1
-        assert sf(self.makeext("3/3/3")) is None
-        assert sf(self.makeext("hello\nthere")) == 1
+        self.assertEqual(sf(self.root), 1)
+        self.assertEqual(sf(self.makeext("1")), 1)
+        self.assertIsNone(sf(self.makeext("1/1")))
+        self.assertEqual(sf(self.makeext("1/2/3")), 1)
+        self.assertIsNone(sf(self.makeext("2/2")))
+        self.assertEqual(sf(self.makeext("3")), 1)
+        self.assertEqual(sf(self.makeext("3/3")), 1)
+        self.assertIsNone(sf(self.makeext("3/3/3")))
+        self.assertEqual(sf(self.makeext("hello\nthere")), 1)
         Globals.null_separator = 0
 
     def testFilelistExclude(self):
@@ -154,14 +154,14 @@ this is a badly formed line which should be ignored
 rdiff-backup_testfiles/select/1/2/3
 rdiff-backup_testfiles/select/3/3/2""")
         sf = self.Select._filelist_get_sf(fp, 0, "test")
-        assert sf(self.root) is None
-        assert sf(self.makeext("1")) == 0
-        assert sf(self.makeext("1/1")) == 0
-        assert sf(self.makeext("1/2/3")) == 0
-        assert sf(self.makeext("2/2")) is None
-        assert sf(self.makeext("3")) is None
-        assert sf(self.makeext("3/3/2")) == 0
-        assert sf(self.makeext("3/3/3")) is None
+        self.assertIsNone(sf(self.root))
+        self.assertEqual(sf(self.makeext("1")), 0)
+        self.assertEqual(sf(self.makeext("1/1")), 0)
+        self.assertEqual(sf(self.makeext("1/2/3")), 0)
+        self.assertIsNone(sf(self.makeext("2/2")))
+        self.assertIsNone(sf(self.makeext("3")))
+        self.assertEqual(sf(self.makeext("3/3/2")), 0)
+        self.assertIsNone(sf(self.makeext("3/3/3")))
 
     def testFilelistInclude2(self):
         """testFilelistInclude2 - with modifiers"""
@@ -171,14 +171,14 @@ rdiff-backup_testfiles/select/1/1
 + rdiff-backup_testfiles/select/1/3
 - rdiff-backup_testfiles/select/3""")
         sf = self.Select._filelist_get_sf(fp, 1, "test1")
-        assert sf(self.makeext("1")) == 1
-        assert sf(self.makeext("1/1")) == 1
-        assert sf(self.makeext("1/1/2")) is None
-        assert sf(self.makeext("1/2")) == 0
-        assert sf(self.makeext("1/2/3")) == 0
-        assert sf(self.makeext("1/3")) == 1
-        assert sf(self.makeext("2")) is None
-        assert sf(self.makeext("3")) == 0
+        self.assertEqual(sf(self.makeext("1")), 1)
+        self.assertEqual(sf(self.makeext("1/1")), 1)
+        self.assertIsNone(sf(self.makeext("1/1/2")))
+        self.assertEqual(sf(self.makeext("1/2")), 0)
+        self.assertEqual(sf(self.makeext("1/2/3")), 0)
+        self.assertEqual(sf(self.makeext("1/3")), 1)
+        self.assertIsNone(sf(self.makeext("2")))
+        self.assertEqual(sf(self.makeext("3")), 0)
 
     def testFilelistExclude2(self):
         """testFilelistExclude2 - with modifiers"""
@@ -189,16 +189,16 @@ rdiff-backup_testfiles/select/1/1
 - rdiff-backup_testfiles/select/3""")
         sf = self.Select._filelist_get_sf(fp, 0, "test1")
         sf_val1 = sf(self.root)
-        assert sf_val1 == 1 or sf_val1 is None  # either is OK
+        self.assertTrue(sf_val1 == 1 or sf_val1 is None)
         sf_val2 = sf(self.makeext("1"))
-        assert sf_val2 == 1 or sf_val2 is None
-        assert sf(self.makeext("1/1")) == 0
-        assert sf(self.makeext("1/1/2")) == 0
-        assert sf(self.makeext("1/2")) == 0
-        assert sf(self.makeext("1/2/3")) == 0
-        assert sf(self.makeext("1/3")) == 1
-        assert sf(self.makeext("2")) is None
-        assert sf(self.makeext("3")) == 0
+        self.assertTrue(sf_val2 == 1 or sf_val2 is None)
+        self.assertEqual(sf(self.makeext("1/1")), 0)
+        self.assertEqual(sf(self.makeext("1/1/2")), 0)
+        self.assertEqual(sf(self.makeext("1/2")), 0)
+        self.assertEqual(sf(self.makeext("1/2/3")), 0)
+        self.assertEqual(sf(self.makeext("1/3")), 1)
+        self.assertIsNone(sf(self.makeext("2")))
+        self.assertEqual(sf(self.makeext("3")), 0)
 
     def testGlobRE(self):
         """testGlobRE - test translation of shell pattern to regular exp"""
@@ -232,15 +232,15 @@ rdiff-backup_testfiles/select/1/1
                           b"rdiff-backup_testfiles/whatever", 1)
         self.assertRaises(FilePrefixError, self.Select._glob_get_sf,
                           b"rdiff-backup_testfiles/?hello", 0)
-        assert self.Select._glob_get_normal_sf(b"**", 1)
+        self.assertTrue(self.Select._glob_get_normal_sf(b"**", 1))
 
     def testIgnoreCase(self):
         """testIgnoreCase - try a few expressions with ignorecase:"""
         sf = self.Select._glob_get_sf(
             "ignorecase:rdiff-backup_testfiles/SeLect/foo/bar", 1)
-        assert sf(self.makeext("FOO/BAR")) == 1
-        assert sf(self.makeext("foo/bar")) == 1
-        assert sf(self.makeext("fOo/BaR")) == 1
+        self.assertEqual(sf(self.makeext("FOO/BAR")), 1)
+        self.assertEqual(sf(self.makeext("foo/bar")), 1)
+        self.assertEqual(sf(self.makeext("fOo/BaR")), 1)
         self.assertRaises(FilePrefixError, self.Select._glob_get_sf,
                           b"ignorecase:testfiles/sect/foo/bar", 1)
 
@@ -248,82 +248,88 @@ rdiff-backup_testfiles/select/1/1
         """Test device and special file selection"""
         dir = self.root.append("filetypes")
         fifo = dir.append("fifo")
-        assert fifo.isfifo(), fifo
+        self.assertTrue(fifo.isfifo())
         sym = dir.append("symlink")
-        assert sym.issym(), sym
+        self.assertTrue(sym.issym())
         reg = dir.append("regular_file")
-        assert reg.isreg(), reg
+        self.assertTrue(reg.isreg())
         sock = dir.append("replace_with_socket")
         if not sock.issock():
             if sock.lstat():
                 sock.delete()
             sock.mksock()
-            assert sock.issock(), sock
+            self.assertTrue(sock.issock())
         dev = dir.append("ttyS1")
         # only root can create a (tty) device hence must exist
         # sudo mknod ../rdiff-backup_testfiles/select/filetypes/ttyS1 c 4 65
-        assert dev.isdev(), dev
+        self.assertTrue(dev.isdev())
 
         sf = self.Select._devfiles_get_sf(0)
-        assert sf(dir) is None
-        assert sf(dev) == 0
-        assert sf(sock) is None
+        self.assertIsNone(sf(dir))
+        self.assertEqual(sf(dev), 0)
+        self.assertIsNone(sf(sock))
 
         sf2 = self.Select._special_get_sf(0)
-        assert sf2(dir) is None
-        assert sf2(reg) is None
-        assert sf2(dev) == 0
-        assert sf2(sock) == 0
-        assert sf2(fifo) == 0
-        assert sf2(sym) == 0
+        self.assertIsNone(sf2(dir))
+        self.assertIsNone(sf2(reg))
+        self.assertEqual(sf2(dev), 0)
+        self.assertEqual(sf2(sock), 0)
+        self.assertEqual(sf2(fifo), 0)
+        self.assertEqual(sf2(sym), 0)
 
         sf3 = self.Select._symlinks_get_sf(0)
-        assert sf3(dir) is None
-        assert sf3(reg) is None
-        assert sf3(dev) is None
-        assert sf3(sock) is None
-        assert sf3(fifo) is None
-        assert sf3(sym) == 0
+        self.assertIsNone(sf3(dir))
+        self.assertIsNone(sf3(reg))
+        self.assertIsNone(sf3(dev))
+        self.assertIsNone(sf3(sock))
+        self.assertIsNone(sf3(fifo))
+        self.assertEqual(sf3(sym), 0)
 
     def testRoot(self):
         """testRoot - / may be a counterexample to several of these.."""
         root = rpath.RPath(Globals.local_connection, "/")
         select = Select(root)
 
-        assert select._glob_get_sf("/", 1)(root) == 1
-        assert select._glob_get_sf("/foo", 1)(root) == 1
-        assert select._glob_get_sf("/foo/bar", 1)(root) == 1
-        assert select._glob_get_sf("/", 0)(root) == 0
-        assert select._glob_get_sf("/foo", 0)(root) is None
+        self.assertEqual(select._glob_get_sf("/", 1)(root), 1)
+        self.assertEqual(select._glob_get_sf("/foo", 1)(root), 1)
+        self.assertEqual(select._glob_get_sf("/foo/bar", 1)(root), 1)
+        self.assertEqual(select._glob_get_sf("/", 0)(root), 0)
+        self.assertIsNone(select._glob_get_sf("/foo", 0)(root))
 
-        assert select._glob_get_sf("**.py", 1)(root) == 2
-        assert select._glob_get_sf("**", 1)(root) == 1
-        assert select._glob_get_sf("ignorecase:/", 1)(root) == 1
-        assert select._glob_get_sf("**.py", 0)(root) is None
-        assert select._glob_get_sf("**", 0)(root) == 0
-        assert select._glob_get_sf("/foo/*", 0)(root) is None
+        self.assertEqual(select._glob_get_sf("**.py", 1)(root), 2)
+        self.assertEqual(select._glob_get_sf("**", 1)(root), 1)
+        self.assertEqual(select._glob_get_sf("ignorecase:/", 1)(root), 1)
+        self.assertIsNone(select._glob_get_sf("**.py", 0)(root))
+        self.assertEqual(select._glob_get_sf("**", 0)(root), 0)
+        self.assertIsNone(select._glob_get_sf("/foo/*", 0)(root))
 
-        assert select._filelist_get_sf(io.BytesIO(b"/"), 1, "test")(root) == 1
-        assert select._filelist_get_sf(io.BytesIO(b"/foo/bar"), 1, "test")(root) == 1
-        assert select._filelist_get_sf(io.BytesIO(b"/"), 0, "test")(root) == 0
-        assert select._filelist_get_sf(io.BytesIO(b"/foo/bar"), 0, "test")(root) is None
+        self.assertEqual(
+            select._filelist_get_sf(io.BytesIO(b"/"), 1, "test")(root), 1)
+        self.assertEqual(
+            select._filelist_get_sf(io.BytesIO(b"/foo/bar"), 1, "test")(root), 1)
+        self.assertEqual(
+            select._filelist_get_sf(io.BytesIO(b"/"), 0, "test")(root), 0)
+        self.assertIsNone(
+            select._filelist_get_sf(io.BytesIO(b"/foo/bar"), 0, "test")(root))
 
     def testOtherFilesystems(self):
         """Test to see if --exclude-other-filesystems works correctly"""
         root = rpath.RPath(Globals.local_connection, "/")
         select = Select(root)
         sf = select._other_filesystems_get_sf(0)
-        assert sf(root) is None
-        assert sf(rpath.RPath(Globals.local_connection, "/usr/bin")) is None, \
-            "Assumption: /usr/bin is on the same filesystem as /"
-        assert sf(rpath.RPath(Globals.local_connection, "/proc")) == 0, \
-            "Assumption: /proc is on a different filesystem"
-        if b' /boot ' in subprocess.check_output('mount'):
-            assert sf(rpath.RPath(Globals.local_connection, "/boot")) == 0, \
-                "Assumption: /boot is on a different filesystem"
-        if b' /boot/efi ' in subprocess.check_output('mount'):
-            assert sf(rpath.RPath(Globals.local_connection, "/boot/efi")) == 0, \
-                "Assumption: /boot/efi is on a different filesystem"
+        self.assertIsNone(sf(root))
+        self.assertIsNone(
+            sf(rpath.RPath(Globals.local_connection, "/usr/bin")),
+            "Assumption: /usr/bin is on the same filesystem as /")
+        self.assertEqual(
+            sf(rpath.RPath(Globals.local_connection, "/proc")), 0,
+            "Assumption: /proc is on a different filesystem")
+        for check_dir in (b'/boot', b'/boot/efi', b'/tmp'):
+            if (b' ' + check_dir + b' ') in subprocess.check_output('mount'):
+                self.assertEqual(
+                    sf(rpath.RPath(Globals.local_connection, check_dir)), 0,
+                    "Assumption: {dir} is on a different filesystem".format(
+                        dir=check_dir))
 
 
 class ParseSelectionArgsTest(unittest.TestCase):
@@ -340,10 +346,10 @@ class ParseSelectionArgsTest(unittest.TestCase):
                                     "rdiff-backup_testfiles/select")
         self.Select = Select(self.root)
         self.Select.parse_selection_args(tuplelist, self.remake_filelists(filelists))
-        assert iter_equal(iter_map(lambda dsrp: dsrp.index,
-                                   self.Select.set_iter()),
-                          map(tuple_fsencode, indices),
-                          verbose=1)
+        self.assertTrue(
+            iter_equal(iter_map(lambda dsrp: dsrp.index,
+                                self.Select.set_iter()),
+                       map(tuple_fsencode, indices), verbose=1))
 
     def remake_filelists(self, filelist):
         """Turn strings in filelist into fileobjs"""
@@ -502,7 +508,7 @@ class CommandTest(unittest.TestCase):
                                     b"--exclude testfiles/seltest/YYYY"))
 
         outempty = outrp.append('emptydir')
-        assert outempty.isdir(), outempty
+        self.assertTrue(outempty.isdir())
 
     def test_overlapping_dirs(self):
         """Test if we can backup a directory containing the backup repo
@@ -521,9 +527,10 @@ class CommandTest(unittest.TestCase):
                      backuprp.path,
                      extra_options=b"--exclude %s" % backuprp.path)
 
-        assert backuprp.append('rdiff-backup-data').isdir() and \
-            backuprp.append('empty').isdir(), \
-            "Backup to %s didn't happen properly." % backuprp.getsafepath()
+        self.assertTrue(
+            backuprp.append('rdiff-backup-data').isdir()
+            and backuprp.append('empty').isdir(),
+            "Backup to %s didn't happen properly." % backuprp.get_safepath())
 
 
 if __name__ == "__main__":

--- a/testing/statisticstest.py
+++ b/testing/statisticstest.py
@@ -29,18 +29,18 @@ class StatsObjTest(unittest.TestCase):
     def test_get_stats(self):
         """Test reading and writing stat objects"""
         s = statistics.StatsObj()
-        assert s.get_stat('SourceFiles') is None
+        self.assertIsNone(s.get_stat('SourceFiles'))
         self.set_obj(s)
-        assert s.get_stat('SourceFiles') == 1
+        self.assertEqual(s.get_stat('SourceFiles'), 1)
 
         s1 = statistics.StatFileObj()
-        assert s1.get_stat('SourceFiles') == 0
+        self.assertEqual(s1.get_stat('SourceFiles'), 0)
 
     def test_get_stats_string(self):
         """Test conversion of stat object into string"""
         s = statistics.StatsObj()
         stats_string = s._get_stats_string()
-        assert stats_string == "", stats_string
+        self.assertEqual(stats_string, "")
 
         self.set_obj(s)
         stats_string = s._get_stats_string()
@@ -48,7 +48,7 @@ class StatsObjTest(unittest.TestCase):
         tail = "\n".join(ss_list[2:])  # Time varies by time zone, don't check
         # """StartTime 11.00 (Wed Dec 31 16:00:11 1969)
         # EndTime 12.00 (Wed Dec 31 16:00:12 1969)"
-        assert tail == """ElapsedTime 1.00 (1 second)
+        self.assertEqual(tail, """ElapsedTime 1.00 (1 second)
 SourceFiles 1
 SourceFileSize 2 (2 bytes)
 MirrorFiles 13
@@ -63,34 +63,36 @@ ChangedMirrorSize 9 (9 bytes)
 IncrementFiles 15
 IncrementFileSize 10 (10 bytes)
 TotalDestinationSizeChange 7 (7 bytes)
-""", "'%s'" % stats_string
+""")
 
     def test_line_string(self):
         """Test conversion to a single line"""
         s = statistics.StatsObj()
         self.set_obj(s)
         statline = s._get_stats_line(("sample", "index", "w", "new\nline"))
-        assert statline == "sample/index/w/new\\nline 1 2 13 14 " \
-            "3 4 5 6 7 8 9 15 10", repr(statline)
+        self.assertEqual(
+            statline,
+            "sample/index/w/new\\nline 1 2 13 14 3 4 5 6 7 8 9 15 10")
 
         statline = s._get_stats_line(())
-        assert statline == ". 1 2 13 14 3 4 5 6 7 8 9 15 10"
+        self.assertEqual(statline, ". 1 2 13 14 3 4 5 6 7 8 9 15 10")
 
         statline = s._get_stats_line(("file name with spaces", ))
-        assert statline == "file\\x20name\\x20with\\x20spaces 1 2 13 14 " \
-            "3 4 5 6 7 8 9 15 10", repr(statline)
+        self.assertEqual(
+            statline,
+            "file\\x20name\\x20with\\x20spaces 1 2 13 14 3 4 5 6 7 8 9 15 10")
 
     def test_byte_summary(self):
         """Test conversion of bytes to strings like 7.23MB"""
         s = statistics.StatsObj()
         f = s.get_byte_summary_string
-        assert f(1) == "1 byte"
-        assert f(234.34) == "234 bytes"
-        assert f(2048) == "2.00 KB"
-        assert f(3502243) == "3.34 MB"
-        assert f(314992230) == "300 MB"
-        assert f(36874871216) == "34.3 GB", f(36874871216)
-        assert f(3775986812573450) == "3434 TB"
+        self.assertEqual(f(1), "1 byte")
+        self.assertEqual(f(234.34), "234 bytes")
+        self.assertEqual(f(2048), "2.00 KB")
+        self.assertEqual(f(3502243), "3.34 MB")
+        self.assertEqual(f(314992230), "300 MB")
+        self.assertEqual(f(36874871216), "34.3 GB")
+        self.assertEqual(f(3775986812573450), "3434 TB")
 
     def test_init_stats(self):
         """Test setting stat object from string"""
@@ -98,17 +100,17 @@ TotalDestinationSizeChange 7 (7 bytes)
         s._set_stats_from_string("NewFiles 3 hello there")
         for attr in s._stat_attrs:
             if attr == 'NewFiles':
-                assert s.get_stat(attr) == 3
+                self.assertEqual(s.get_stat(attr), 3)
             else:
-                assert s.get_stat(attr) is None, (attr, s.__dict__[attr])
+                self.assertIsNone(s.get_stat(attr))
 
         s1 = statistics.StatsObj()
         self.set_obj(s1)
-        assert not s1._stats_equal(s)
+        self.assertFalse(s1._stats_equal(s))
 
         s2 = statistics.StatsObj()
         s2._set_stats_from_string(s1._get_stats_string())
-        assert s1._stats_equal(s2)
+        self.assertTrue(s1._stats_equal(s2))
 
     def test_write_rp(self):
         """Test reading and writing of statistics object"""
@@ -121,9 +123,9 @@ TotalDestinationSizeChange 7 (7 bytes)
         s.write_stats_to_rp(rp)
 
         s2 = statistics.StatsObj()
-        assert not s2._stats_equal(s)
+        self.assertFalse(s2._stats_equal(s))
         s2.read_stats_from_rp(rp)
-        assert s2._stats_equal(s)
+        self.assertTrue(s2._stats_equal(s))
 
     def testAverage(self):
         """Test making an average statsobj"""
@@ -144,12 +146,13 @@ TotalDestinationSizeChange 7 (7 bytes)
         s2.DeletedFiles = 0
 
         s3 = statistics.StatsObj().set_to_average([s1, s2])
-        assert s3.StartTime is s3.EndTime is None
-        assert s3.ElapsedTime == 7.5
-        assert s3.DeletedFiles is s3.NewFileSize is None, (s3.DeletedFiles,
-                                                           s3.NewFileSize)
-        assert s3.ChangedFiles == 1.5
-        assert s3.SourceFiles == 75
+        self.assertIsNone(s3.StartTime)
+        self.assertIsNone(s3.EndTime)
+        self.assertEqual(s3.ElapsedTime, 7.5)
+        self.assertIsNone(s3.DeletedFiles)
+        self.assertIsNone(s3.NewFileSize)
+        self.assertEqual(s3.ChangedFiles, 1.5)
+        self.assertEqual(s3.SourceFiles, 75)
 
 
 class IncStatTest(unittest.TestCase):
@@ -162,15 +165,18 @@ class IncStatTest(unittest.TestCase):
         exists in the below examples.
 
         """
-        assert s.MirrorFiles == 1 or s.MirrorFiles == 0
-        assert s.MirrorFileSize < 20000
-        assert s.NewFiles <= s.SourceFiles <= s.NewFiles + 1
-        assert s.NewFileSize <= s.SourceFileSize <= s.NewFileSize + 20000
-        assert s.ChangedFiles == 1 or s.ChangedFiles == 0
-        assert s.ChangedSourceSize < 20000
-        assert s.ChangedMirrorSize < 20000
-        assert s.DeletedFiles == s.DeletedFileSize == 0
-        assert s.IncrementFileSize == 0
+        self.assertIn(s.MirrorFiles, (0, 1))
+        self.assertLess(s.MirrorFileSize, 20000)
+        self.assertLessEqual(s.NewFiles, s.SourceFiles)
+        self.assertLessEqual(s.SourceFiles, s.NewFiles + 1)
+        self.assertLessEqual(s.NewFileSize, s.SourceFileSize)
+        self.assertLessEqual(s.SourceFileSize, s.NewFileSize + 20000)
+        self.assertIn(s.ChangedFiles, (0, 1))
+        self.assertLess(s.ChangedSourceSize, 20000)
+        self.assertLess(s.ChangedMirrorSize, 20000)
+        self.assertEqual(s.DeletedFiles, 0)
+        self.assertEqual(s.DeletedFileSize, 0)
+        self.assertEqual(s.IncrementFileSize, 0)
 
     def testStatistics(self):
         """Test the writing of statistics
@@ -197,26 +203,32 @@ class IncStatTest(unittest.TestCase):
                             os.path.join(abs_output_dir, b"rdiff-backup-data"))
 
         incs = sorti(restore.get_inclist(rbdir.append("session_statistics")))
-        assert len(incs) == 2
+        self.assertEqual(len(incs), 2)
         s2 = statistics.StatsObj().read_stats_from_rp(incs[0])
-        assert s2.SourceFiles == 7
-        assert 700000 <= s2.SourceFileSize < 750000, s2.SourceFileSize
+        self.assertEqual(s2.SourceFiles, 7)
+        self.assertLessEqual(700000, s2.SourceFileSize)
+        self.assertLess(s2.SourceFileSize, 750000)
         self.stats_check_initial(s2)
 
         root_stats = statistics.StatsObj().read_stats_from_rp(incs[1])
-        assert root_stats.SourceFiles == 7, root_stats.SourceFiles
-        assert 550000 <= root_stats.SourceFileSize < 570000
-        assert root_stats.MirrorFiles == 7
-        assert 700000 <= root_stats.MirrorFileSize < 750000
-        assert root_stats.NewFiles == 1
-        assert root_stats.NewFileSize == 0
-        assert root_stats.DeletedFiles == 1, root_stats.DeletedFiles
-        assert root_stats.DeletedFileSize == 200000
-        assert 3 <= root_stats.ChangedFiles <= 4, root_stats.ChangedFiles
-        assert 450000 <= root_stats.ChangedSourceSize < 470000
-        assert 400000 <= root_stats.ChangedMirrorSize < 420000, \
-            root_stats.ChangedMirrorSize
-        assert 10 < root_stats.IncrementFileSize < 30000
+        self.assertEqual(root_stats.SourceFiles, 7)
+        self.assertLessEqual(550000, root_stats.SourceFileSize)
+        self.assertLess(root_stats.SourceFileSize, 570000)
+        self.assertEqual(root_stats.MirrorFiles, 7)
+        self.assertLessEqual(700000, root_stats.MirrorFileSize)
+        self.assertLess(root_stats.MirrorFileSize, 750000)
+        self.assertEqual(root_stats.NewFiles, 1)
+        self.assertEqual(root_stats.NewFileSize, 0)
+        self.assertEqual(root_stats.DeletedFiles, 1)
+        self.assertEqual(root_stats.DeletedFileSize, 200000)
+        self.assertLessEqual(3, root_stats.ChangedFiles)
+        self.assertLessEqual(root_stats.ChangedFiles, 4)
+        self.assertLessEqual(450000, root_stats.ChangedSourceSize)
+        self.assertLess(root_stats.ChangedSourceSize, 470000)
+        self.assertLessEqual(400000, root_stats.ChangedMirrorSize)
+        self.assertLess(root_stats.ChangedMirrorSize, 420000)
+        self.assertLess(10, root_stats.IncrementFileSize)
+        self.assertLess(root_stats.IncrementFileSize, 30000)
 
 
 if __name__ == "__main__":

--- a/testing/timetest.py
+++ b/testing/timetest.py
@@ -4,34 +4,36 @@ from commontest import *  # noqa: F403, F401 some side effect or test fails
 from rdiff_backup import Globals, Time
 
 
-def cmp_times(time1, time2):
-    """Compare time1 and time2 and return -1, 0, or 1"""
-    if type(time1) is str:
-        time1 = Time.stringtotime(time1)
-        assert time1 is not None
-    if type(time2) is str:
-        time2 = Time.stringtotime(time2)
-        assert time2 is not None
-
-    if time1 < time2:
-        return -1
-    elif time1 == time2:
-        return 0
-    else:
-        return 1
-
-
 class TimeTest(unittest.TestCase):
+
+    def cmp_times(self, time1, time2):
+        """Compare time1 and time2 and return -1, 0, or 1"""
+        if type(time1) is str:
+            time1 = Time.stringtotime(time1)
+            self.assertIsNotNone(time1)
+        if type(time2) is str:
+            time2 = Time.stringtotime(time2)
+            self.assertIsNotNone(time2)
+
+        if time1 < time2:
+            return -1
+        elif time1 == time2:
+            return 0
+        else:
+            return 1
+
     def testConversion(self):
         """test timetostring and stringtotime"""
         Time.setcurtime()
-        assert type(Time.curtime) is float or int, Time.curtime
-        assert type(Time.curtimestr) is str, Time.curtimestr
-        assert (cmp_times(int(Time.curtime), Time.curtimestr) == 0
-                or cmp_times(int(Time.curtime) + 1, Time.curtimestr) == 0)
+        self.assertIsInstance(Time.curtime, (float, int))
+        self.assertIsInstance(Time.curtimestr, str)
+        self.assertTrue(
+            self.cmp_times(int(Time.curtime), Time.curtimestr) == 0
+            or self.cmp_times(int(Time.curtime) + 1, Time.curtimestr) == 0)
         time.sleep(1.05)
-        assert cmp_times(time.time(), Time.curtime) == 1
-        assert cmp_times(Time.timetostring(time.time()), Time.curtimestr) == 1
+        self.assertEqual(self.cmp_times(time.time(), Time.curtime), 1)
+        self.assertEqual(self.cmp_times(Time.timetostring(time.time()),
+                                        Time.curtimestr), 1)
 
     def testConversion_separator(self):
         """Same as testConversion, but change time Separator"""
@@ -41,88 +43,95 @@ class TimeTest(unittest.TestCase):
 
     def testCmp(self):
         """Test time comparisons"""
-        assert cmp_times(1, 2) == -1
-        assert cmp_times(2, 2) == 0
-        assert cmp_times(5, 1) == 1
-        assert cmp_times("2001-09-01T21:49:04Z", "2001-08-01T21:49:04Z") == 1
-        assert cmp_times("2001-09-01T04:49:04+03:23", "2001-09-01T21:49:04Z") == -1
-        assert cmp_times("2001-09-01T12:00:00Z", "2001-09-01T04:00:00-08:00") == 0
-        assert cmp_times("2001-09-01T12:00:00-08:00", "2001-09-01T12:00:00-07:00") == 1
+        self.assertEqual(self.cmp_times(1, 2), -1)
+        self.assertEqual(self.cmp_times(2, 2), 0)
+        self.assertEqual(self.cmp_times(5, 1), 1)
+        self.assertEqual(self.cmp_times("2001-09-01T21:49:04Z",
+                                        "2001-08-01T21:49:04Z"), 1)
+        self.assertEqual(self.cmp_times("2001-09-01T04:49:04+03:23",
+                                        "2001-09-01T21:49:04Z"), -1)
+        self.assertEqual(self.cmp_times("2001-09-01T12:00:00Z",
+                                        "2001-09-01T04:00:00-08:00"), 0)
+        self.assertEqual(self.cmp_times("2001-09-01T12:00:00-08:00",
+                                        "2001-09-01T12:00:00-07:00"), 1)
 
     def testBytestotime(self):
         """Test converting byte string to time"""
         timesec = int(time.time())
-        assert timesec == int(Time.bytestotime(Time.timetostring(timesec).encode('ascii')))
+        self.assertEqual(
+            timesec,
+            int(Time.bytestotime(Time.timetostring(timesec).encode('ascii'))))
 
         # assure that non-ascii byte strings return None and that they don't
         # throw an exception (issue #295)
-        assert Time.bytestotime(b'\xff') is None
+        self.assertIsNone(Time.bytestotime(b'\xff'))
 
     def testStringtotime(self):
         """Test converting string to time"""
         timesec = int(time.time())
-        assert timesec == int(Time.stringtotime(Time.timetostring(timesec)))
-        assert not Time.stringtotime("2001-18-83T03:03:03Z")
-        assert not Time.stringtotime("2001-01-23L03:03:03L")
-        assert not Time.stringtotime("2001_01_23T03:03:03Z")
+        self.assertEqual(timesec,
+                         int(Time.stringtotime(Time.timetostring(timesec))))
+        self.assertFalse(Time.stringtotime("2001-18-83T03:03:03Z"))
+        self.assertFalse(Time.stringtotime("2001-01-23L03:03:03L"))
+        self.assertFalse(Time.stringtotime("2001_01_23T03:03:03Z"))
 
     def testIntervals(self):
         """Test converting strings to intervals"""
         i2s = Time._intervalstr_to_seconds
         for s in ["32", "", "d", "231I", "MM", "s", "-2h"]:
-            try:
+            with self.assertRaises(Time.TimeException):
                 i2s(s)
-            except Time.TimeException:
-                pass
-            else:
-                assert 0, s
-        assert i2s("7D") == 7 * 86400
-        assert i2s("232s") == 232
-        assert i2s("2M") == 2 * 30 * 86400
-        assert i2s("400m") == 400 * 60
-        assert i2s("1Y") == 365 * 86400
-        assert i2s("30h") == 30 * 60 * 60
-        assert i2s("3W") == 3 * 7 * 86400
+        self.assertEqual(i2s("7D"), 7 * 86400)
+        self.assertEqual(i2s("232s"), 232)
+        self.assertEqual(i2s("2M"), 2 * 30 * 86400)
+        self.assertEqual(i2s("400m"), 400 * 60)
+        self.assertEqual(i2s("1Y"), 365 * 86400)
+        self.assertEqual(i2s("30h"), 30 * 60 * 60)
+        self.assertEqual(i2s("3W"), 3 * 7 * 86400)
 
     def testIntervalsComposite(self):
         """Like above, but allow composite intervals"""
         i2s = Time._intervalstr_to_seconds
-        assert i2s("7D2h") == 7 * 86400 + 2 * 3600
-        assert i2s("2Y3s") == 2 * 365 * 86400 + 3
-        assert i2s("1M2W4D2h5m20s") == \
-            (30 * 86400 + 2 * 7 * 86400 + 4 * 86400 + 2 * 3600 + 5 * 60 + 20)
+        self.assertEqual(i2s("7D2h"), 7 * 86400 + 2 * 3600)
+        self.assertEqual(i2s("2Y3s"), 2 * 365 * 86400 + 3)
+        self.assertEqual(
+            i2s("1M2W4D2h5m20s"),
+            (30 * 86400 + 2 * 7 * 86400 + 4 * 86400 + 2 * 3600 + 5 * 60 + 20))
 
     def testPrettyIntervals(self):
         """Test printable interval conversion"""
-        assert Time.inttopretty(3600) == "1 hour"
-        assert Time.inttopretty(7220) == "2 hours 20 seconds"
-        assert Time.inttopretty(0) == "0 seconds"
-        assert Time.inttopretty(353) == "5 minutes 53 seconds"
-        assert Time.inttopretty(3661) == "1 hour 1 minute 1 second"
-        assert Time.inttopretty(353.234234) == "5 minutes 53.23 seconds"
+        self.assertEqual(Time.inttopretty(3600), "1 hour")
+        self.assertEqual(Time.inttopretty(7220), "2 hours 20 seconds")
+        self.assertEqual(Time.inttopretty(0), "0 seconds")
+        self.assertEqual(Time.inttopretty(353), "5 minutes 53 seconds")
+        self.assertEqual(Time.inttopretty(3661), "1 hour 1 minute 1 second")
+        self.assertEqual(Time.inttopretty(353.234234),
+                         "5 minutes 53.23 seconds")
 
     def testPrettyTimes(self):
         """Convert seconds to pretty and back"""
         now = int(time.time())
         for i in [1, 200000, now]:
-            assert Time.prettytotime(Time.timetopretty(i)) == i, i
-        assert Time.prettytotime("now") is None
-        assert Time.prettytotime("12314") is None
+            self.assertEqual(Time.prettytotime(Time.timetopretty(i)), i)
+        self.assertIsNone(Time.prettytotime("now"))
+        self.assertIsNone(Time.prettytotime("12314"))
 
     def testGenericString(self):
         """Test genstrtotime, conversion of arbitrary string to time"""
         g2t = Time.genstrtotime
-        assert g2t('now', 1000) == 1000
-        assert g2t('2h3s', 10000) == 10000 - 2 * 3600 - 3
-        assert g2t('2001-09-01T21:49:04Z') == \
-            Time.stringtotime('2001-09-01T21:49:04Z')
-        assert g2t('2002-04-26T04:22:01') == \
-            Time.stringtotime('2002-04-26T04:22:01' + Time._get_tzd())
+        self.assertEqual(g2t('now', 1000), 1000)
+        self.assertEqual(g2t('2h3s', 10000), 10000 - 2 * 3600 - 3)
+        self.assertEqual(
+            g2t('2001-09-01T21:49:04Z'),
+            Time.stringtotime('2001-09-01T21:49:04Z'))
+        self.assertEqual(
+            g2t('2002-04-26T04:22:01'),
+            Time.stringtotime('2002-04-26T04:22:01' + Time._get_tzd()))
         t = Time.stringtotime('2001-05-12T00:00:00' + Time._get_tzd())
-        assert g2t('2001-05-12') == t
-        assert g2t('2001/05/12') == t
-        assert g2t('5/12/2001') == t
-        assert g2t('123456') == 123456
+        self.assertEqual(g2t('2001-05-12'), t)
+        self.assertEqual(g2t('2001/05/12'), t)
+        self.assertEqual(g2t('5/12/2001'), t)
+        self.assertEqual(g2t('123456'), 123456)
 
     def testGenericStringErrors(self):
         """Test genstrtotime on some bad strings"""
@@ -138,11 +147,10 @@ class TimeTest(unittest.TestCase):
         s1 = "2005-04-03T03:45:03-03:00"
         s2 = "2005-04-03T02:45:03-03:00"
         diff = f(s1) - f(s2)
-        assert diff == 3600, diff
+        self.assertEqual(diff, 3600)
 
-        assert f(invf(f(s1))) == f(s1), (s1, invf(f(s1)), f(invf(f(s1))),
-                                         f(s1))
-        assert f(invf(f(s2))) == f(s2), (s2, f(invf(f(s2))), f(s2))
+        self.assertEqual(f(invf(f(s1))), f(s1))
+        self.assertEqual(f(invf(f(s2))), f(s2))
 
 
 if __name__ == '__main__':

--- a/testing/user_grouptest.py
+++ b/testing/user_grouptest.py
@@ -11,24 +11,24 @@ class UserGroupTest(unittest.TestCase):
         """Test basic id2name.  May need to modify for different systems"""
         user_group._uid2uname_dict = {}
         user_group._gid2gname_dict = {}
-        assert user_group.uid2uname(0) == "root"
-        assert user_group.uid2uname(0) == "root"
-        assert user_group.gid2gname(0) == "root"
-        assert user_group.gid2gname(0) == "root"
+        self.assertEqual(user_group.uid2uname(0), "root")
+        self.assertEqual(user_group.uid2uname(0), "root")
+        self.assertEqual(user_group.gid2gname(0), "root")
+        self.assertEqual(user_group.gid2gname(0), "root")
         # Assume no user has uid 29378
-        assert user_group.gid2gname(29378) is None
-        assert user_group.gid2gname(29378) is None
+        self.assertIsNone(user_group.gid2gname(29378))
+        self.assertIsNone(user_group.gid2gname(29378))
 
     def test_basic_reverse(self):
         """Test basic name2id.  Depends on systems users/groups"""
         user_group._uname2uid_dict = {}
         user_group._gname2gid_dict = {}
-        assert user_group._uname2uid("root") == 0
-        assert user_group._uname2uid("root") == 0
-        assert user_group._gname2gid("root") == 0
-        assert user_group._gname2gid("root") == 0
-        assert user_group._uname2uid("aoeuth3t2ug89") is None
-        assert user_group._uname2uid("aoeuth3t2ug89") is None
+        self.assertEqual(user_group._uname2uid("root"), 0)
+        self.assertEqual(user_group._uname2uid("root"), 0)
+        self.assertEqual(user_group._gname2gid("root"), 0)
+        self.assertEqual(user_group._gname2gid("root"), 0)
+        self.assertIsNone(user_group._uname2uid("aoeuth3t2ug89"))
+        self.assertIsNone(user_group._uname2uid("aoeuth3t2ug89"))
 
     def test_default_mapping(self):
         """Test the default user mapping"""
@@ -37,10 +37,10 @@ class UserGroupTest(unittest.TestCase):
         binid = pwd.getpwnam('bin')[2]
         syncid = pwd.getpwnam('sync')[2]
         user_group.init_user_mapping()
-        assert user_group._user_map(0) == rootid
-        assert user_group._user_map(0, 'bin') == binid
-        assert user_group._user_map(0, 'sync') == syncid
-        assert user_group._user_map.map_acl(0, 'aoeuth3t2ug89') is None
+        self.assertEqual(user_group._user_map(0), rootid)
+        self.assertEqual(user_group._user_map(0, 'bin'), binid)
+        self.assertEqual(user_group._user_map(0, 'sync'), syncid)
+        self.assertIsNone(user_group._user_map.map_acl(0, 'aoeuth3t2ug89'))
 
     def test_user_mapping(self):
         """Test the user mapping file through the _DefinedMap class"""
@@ -57,17 +57,17 @@ sync:0"""
         daemonid = pwd.getpwnam('daemon')[2]
         user_group.init_user_mapping(mapping_string)
 
-        assert user_group._user_map(rootid, 'root') == binid
-        assert user_group._user_map(binid, 'bin') == rootid
-        assert user_group._user_map(0) == syncid
-        assert user_group._user_map(syncid, 'sync') == 0
-        assert user_group._user_map(500) == 501
+        self.assertEqual(user_group._user_map(rootid, 'root'), binid)
+        self.assertEqual(user_group._user_map(binid, 'bin'), rootid)
+        self.assertEqual(user_group._user_map(0), syncid)
+        self.assertEqual(user_group._user_map(syncid, 'sync'), 0)
+        self.assertEqual(user_group._user_map(500), 501)
 
-        assert user_group._user_map(501) == 501
-        assert user_group._user_map(123, 'daemon') == daemonid
+        self.assertEqual(user_group._user_map(501), 501)
+        self.assertEqual(user_group._user_map(123, 'daemon'), daemonid)
 
-        assert user_group._user_map.map_acl(29378, 'aoeuth3t2ug89') is None
-        assert user_group._user_map.map_acl(0, 'aoeuth3t2ug89') is syncid
+        self.assertIsNone(user_group._user_map.map_acl(29378, 'aoeuth3t2ug89'))
+        self.assertIs(user_group._user_map.map_acl(0, 'aoeuth3t2ug89'), syncid)
 
         if 0:
             code.InteractiveConsole(globals()).interact()
@@ -75,8 +75,8 @@ sync:0"""
     def test_overflow(self):
         """Make sure querying large uids/gids doesn't raise exception"""
         large_num = 4000000000
-        assert user_group.uid2uname(large_num) is None
-        assert user_group.gid2gname(large_num) is None
+        self.assertIsNone(user_group.uid2uname(large_num))
+        self.assertIsNone(user_group.gid2gname(large_num))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The assertXXX functions fit better in the unittest framework, give by default more information in case something goes wrong.

Because the os.system calls didn't so well in the concept, I introduced also the xcopytree to make it easier to copy trees independently from the operating system.

