### PR TITLE
Apply str to arguments of a security violations

### DIFF
--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -241,7 +241,8 @@ def _raise_violation(reason, request, arglist):
     raise Violation(
         "\nWARNING: Security Violation!\n"
         "%s for function: %s\n"
-        "with arguments: %s\n" % (reason, request.function_string, arglist))
+        "with arguments: %s\n" % (reason, request.function_string,
+                                  list(map(str, arglist))))
 
 
 def vet_request(request, arglist):


### PR DESCRIPTION
Especially if the arguments are rpath, it makes the message much more informative. Very small improvement through