### PR TITLE
Get rid of spurious remote schema option ignored warning

### DIFF
--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -134,6 +134,27 @@ def rdiff_backup(source_local,
     return ret_val
 
 
+def _internal_get_cmd_pairs(src_local, dest_local, src_dir, dest_dir):
+    """Function returns a tuple of connections based on the given parameters.
+    One or both directories are faked for remote connection if not local,
+    and the connections are set accordingly.
+    Note that the function relies on the global variables
+    abs_remote1_dir, abs_remote2_dir and abs_testing_dir."""
+
+    remote_schema = b'%s'
+    remote_format = b"cd %s; %s/server.py::%s"
+
+    if not src_local:
+        src_dir = remote_format % (abs_remote1_dir, abs_testing_dir, src_dir)
+    if not dest_local:
+        dest_dir = remote_format % (abs_remote2_dir, abs_testing_dir, dest_dir)
+
+    if src_local and dest_local:
+        return SetConnections.get_cmd_pairs([src_dir, dest_dir])
+    else:
+        return SetConnections.get_cmd_pairs([src_dir, dest_dir], remote_schema)
+
+
 def InternalBackup(source_local,
                    dest_local,
                    src_dir,
@@ -151,14 +172,10 @@ def InternalBackup(source_local,
     """
     Globals.current_time = current_time
     Globals.security_level = "override"
-    remote_schema = b'%s'
 
-    if not source_local:
-        src_dir = b"cd %s; %s/server.py::%s" % (abs_remote1_dir, abs_testing_dir, src_dir)
-    if not dest_local:
-        dest_dir = b"cd %s; %s/server.py::%s" % (abs_remote2_dir, abs_testing_dir, dest_dir)
+    cmdpairs = _internal_get_cmd_pairs(source_local, dest_local,
+                                       src_dir, dest_dir)
 
-    cmdpairs = SetConnections.get_cmd_pairs([src_dir, dest_dir], remote_schema)
     Security.initialize("backup", cmdpairs)
     rpin, rpout = list(map(SetConnections.cmdpair2rp, cmdpairs))
     for attr in ('eas_active', 'eas_write', 'eas_conn'):
@@ -205,15 +222,11 @@ def InternalRestore(mirror_local,
     """
     Main._force = 1
     Main._restore_root_set = 0
-    remote_schema = b'%s'
     Globals.security_level = "override"
-    if not mirror_local:
-        mirror_dir = b"cd %s; %s/server.py::%s" % (abs_remote1_dir, abs_testing_dir, mirror_dir)
-    if not dest_local:
-        dest_dir = b"cd %s; %s/server.py::%s" % (abs_remote2_dir, abs_testing_dir, dest_dir)
 
-    cmdpairs = SetConnections.get_cmd_pairs([mirror_dir, dest_dir],
-                                            remote_schema)
+    cmdpairs = _internal_get_cmd_pairs(mirror_local, dest_local,
+                                       mirror_dir, dest_dir)
+
     Security.initialize("restore", cmdpairs)
     mirror_rp, dest_rp = list(map(SetConnections.cmdpair2rp, cmdpairs))
     for attr in ('eas_active', 'eas_write', 'eas_conn'):


### PR DESCRIPTION
The message 'Remote schema option ignored - no remote file descriptions.' was appearing when using the Internal* functions during testing with only local paths. With a bit of refactoring and a check if both paths are local, those useless warnings are now gone.