### PR TITLE
Fix format and improve checks of rdiff-backup-delete

### DIFF
--- a/src/rdiff-backup-delete
+++ b/src/rdiff-backup-delete
@@ -43,7 +43,7 @@ SUFFIXES = [b".missing", b".snapshot.gz", b".snapshot",
 
 
 def _bytes(value):
-    if isinstance(value, bytes if PY3 else str):
+    if isinstance(value, bytes if PY3 else str):  # noqa: F821
         return value
     if PY3:
         return value.encode('utf8', errors='surrogateescape')
@@ -52,7 +52,7 @@ def _bytes(value):
 
 
 def _str(value):
-    if isinstance(value, str if PY3 else unicode):
+    if isinstance(value, str if PY3 else unicode):  # noqa: F821
         return value
     if PY26:
         return value.decode('utf-8')
@@ -63,17 +63,19 @@ def _str(value):
 def _print_usage(error_message=None):
     if error_message:
         print(error_message)
-    print("Usage: %s [OPTION]... PATH\n\n"
-        "Delete PATH from a rdiff-backup repository including the current \n"
-        "mirror and all its history.\n\n"
-        "-h, --help\n\n"
-        "        Display this help text and exit\n\n"
-        "-d, --dry-run\n\n"
-        "        Run the script without doing modifications to the repository.\n\n"
-        "PATH\n\n"
-        "        A relative or absolute path to be deleted. This path must be\n"
-        "        inside a rdiff-backup repository.\n"
-        % (sys.argv[0],))
+    print("""
+Usage: %s [OPTION]... PATH
+    Delete PATH from a rdiff-backup repository including the current
+    mirror and all its history.
+Options:
+    h, --help
+            Display this help text and exit
+    d, --dry-run
+            Run the script without doing modifications to the repository.
+    PATH
+            A relative or absolute path to be deleted. This path must be
+            inside a rdiff-backup repository.
+""" % (sys.argv[0],))
     sys.exit(1 if error_message else 0)
 
 
@@ -102,18 +104,31 @@ def _parse_options():
         _print_usage('fatal: missing arguments')
     elif len(args) > 1:
         _print_usage('fatal: too many arguments')
+    # NOTE: we can't check for actual existence of path because it might only
+    #       exist in past increments
+    #elif not os.path.lexists(args[0]):
+    #    # we use lexists so that we can delete a dangling link (?)
+    #    _print_usage('fatal: path must refer to an existing file or directory')
 
-    # Check the repository.
-    dir = path = os.path.abspath(_bytes(args[0]))
-    while dir != b'/':
-        rdiff_backup_data = os.path.join(dir, b'rdiff-backup-data')
+    # Check the repository, root dir must be at least one level up
+    full_path = os.path.abspath(_bytes(args[0]))
+    root_dir = os.path.dirname(full_path)
+
+    # we need to make sure we won't try to remove rdiff-backup-data or a file
+    # within this directory (os.altsep is for Windows)
+    if (b"rdiff-backup-data" in full_path.split(os.fsencode(os.sep))
+            or (os.altsep
+                and (b"rdiff-backup-data"
+                     in full_path.split(os.fsencode(os.altsep))))):
+        sys.exit("fatal: path to delete can't be rdiff-backup-data or within")
+
+    while root_dir != b'/':
+        rdiff_backup_data = os.path.join(root_dir, b'rdiff-backup-data')
         if os.path.isdir(rdiff_backup_data):
-            relpath = os.path.relpath(path, start=dir)
-            if relpath == b'rdiff-backup-data':
-                sys.exit("fatal: can't delete rdiff-backup-data")
-            return dir, relpath, dry_run
+            relpath = os.path.relpath(full_path, start=root_dir)
+            return root_dir, relpath, dry_run
         # Continue with parent directory.
-        dir = os.path.dirname(dir)
+        root_dir = os.path.dirname(root_dir)
 
     sys.exit("fatal: not a rdiff-backup repository (or any parent up to mount point /)")
 
@@ -189,7 +204,7 @@ def _remove_from_metadata(repopath, file, dry_run):
 
 def _remove_increments(path, dry_run):
     """
-    Remove all <path>.*.<suffixes> 
+    Remove all <path>.*.<suffixes>
     """
     # If the increment is a directory, remove it and all it's content.
     _rmtree(path, dry_run)
@@ -230,21 +245,22 @@ def _rmtree(path, dry_run):
 
 
 def _unquote(name):
-        """Remove quote (;000) from the given name."""
-        assert isinstance(name, bytes)
+    """Remove quote (;000) from the given name."""
+    assert isinstance(name, bytes), (
+        "Input %s to function must be bytes not %s." % (name, type(name)))
 
-        # This function just gives back the original text if it can decode it
-        def unquoted_char(match):
-            """For each ;000 return the corresponding byte."""
-            if not len(match.group()) == 4:
-                return match.group
-            try:
-                return bytes([int(match.group()[1:])])
-            except:
-                return match.group
+    # This function just gives back the original text if it can decode it
+    def unquoted_char(match):
+        """For each ;000 return the corresponding byte."""
+        if not len(match.group()) == 4:
+            return match.group
+        try:
+            return bytes([int(match.group()[1:])])
+        except Exception:
+            return match.group
 
-        # Remove quote using regex
-        return re.sub(b";[0-9]{3}", unquoted_char, name, re.S)
+    # Remove quote using regex
+    return re.sub(b";[0-9]{3}", unquoted_char, name, re.S)
 
 
 def _acl_quote(s):
@@ -265,7 +281,7 @@ def _acl_quote(s):
 class Repo():
     """
     Represent the rediff-backup repository.
-    
+
     rdiff_backup_data: <root>/rdiff-backup-data/
     long_filename_data: <root>/rdiff-backup-data/long_filename_data/
     """
@@ -288,7 +304,7 @@ class Repo():
 class RepoPath():
     """
     Object used to provide all the variation of the same path with different escaping.
-    
+
     root: absolute location of the rdiff-backup repository
     relpath: relative path to the file of folder to be deleted
     abspath: absolute path to the file or folder to be delete (may not exists)
@@ -298,6 +314,7 @@ class RepoPath():
     """
 
     def __init__(self, root, relpath):
+        # assert is kind of OK as everything is also checked in _parse_options
         assert root
         assert isinstance(root, bytes if PY3 else str)
         assert os.path.isdir(root)
@@ -305,6 +322,7 @@ class RepoPath():
         assert relpath
         assert isinstance(relpath, bytes if PY3 else str)
         assert relpath != b'rdiff-backup-data'
+
         self.repo = Repo(root)
         self.relpath = relpath
         self.metaquote = _unquote(self.relpath).replace(b'\\', b'\\\\')
@@ -321,8 +339,8 @@ def main():
     root, relpath, dry_run = _parse_options()
     repopath = RepoPath(root, relpath)
     if repopath.repo.is_lock():
-        sys.exit('fail to acquired repository lock. A backup may be running.')
-    
+        sys.exit('failed to acquire repository lock. A backup may be running.')
+
     # Check if the repository is "locked"
     print("start deleting path `%s` from repository %s" % (_str(relpath), _str(root)))
     if dry_run:

--- a/testing/rdiffbackupdeletetest.py
+++ b/testing/rdiffbackupdeletetest.py
@@ -166,7 +166,7 @@ class RdiffBackupDeleteTest(unittest.TestCase):
             f.write(b'PID 1234')
         self._rdiff_backup_delete(
             to_delete=os.path.join(self.repo, b'tmp'), expected_ret_val=1,
-            expected_output=b'fail to acquired repository lock. A backup may be running.')
+            expected_output=b'failed to acquire repository lock. A backup may be running.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There were flake8 issues and one could try to delete a file within rdiff-backup-data (not sure it would have gone but it wasn't checked properly).

@ikus060 I see that you've tried to support python 2 but on the other hand, there are bytes constructs which are not covered, e.g. `b'rdiff-backup-data'` or `bytes(...)` calls in the `_unquote` function. Do you plan to make it really work under Python 2 (or perhaps it does already?) or shall I clean-up and simplify the code?