### PR TITLE
Make flake8 check python scripts and simplify rdiff-backup-statistics

### DIFF
--- a/src/rdiff-backup-delete
+++ b/src/rdiff-backup-delete
@@ -106,7 +106,7 @@ def _parse_options():
         _print_usage('fatal: too many arguments')
     # NOTE: we can't check for actual existence of path because it might only
     #       exist in past increments
-    #elif not os.path.lexists(args[0]):
+    # elif not os.path.lexists(args[0]):
     #    # we use lexists so that we can delete a dangling link (?)
     #    _print_usage('fatal: path must refer to an existing file or directory')
 

--- a/src/rdiff-backup-statistics
+++ b/src/rdiff-backup-statistics
@@ -48,7 +48,7 @@ def parse_args():
             "hV",
             ["begin-time=", "end-time=", "help", "minimum-ratio=", "null-separator", "quiet", "version"],
         )
-    except getopt.GetoptError as e:
+    except getopt.GetoptError:
         usage(1)
 
     for opt, arg in optlist:
@@ -355,7 +355,7 @@ def _accumulate_fs(fs_iter):
     """
     root = next(fs_iter)
     if root.nametuple != ():
-        raise RuntimeException(
+        raise RuntimeError(
             "Name tuple of root should be empty but is {name}.".format(
                 name=root.nametuple))
     stack = [root]

--- a/src/rdiff-backup-statistics
+++ b/src/rdiff-backup-statistics
@@ -239,148 +239,153 @@ def make_fst(session_rp, filestat_rp):
     files/directories with some stat exceeding the min ratio.
 
     """
-
-    def get_ss_dict():
-        """Parse session statistics file and return dictionary with ss data"""
-        fileobj = session_rp.open("rb", session_rp.isinccompressed())
-        return_val = {}
-        for line in fileobj:
-            if line.startswith(b"#"):
-                continue
-            comps = line.split()
-            if len(comps) < 2:
-                sys.stderr.write("Unable to parse session statistics line: " + line)
-                continue
-            return_val[comps[0]] = float(comps[1])
-        return return_val
-
-    def get_cutoff_fs(session_dict):
-        """Return FileStat object set with absolute cutoffs
-
-        Any FileStat object that is bigger than the result in any
-        aspect will be considered "important".
-
-        """
-
-        def get_min(attrib):
-            return min_ratio * session_dict[attrib]
-
-        min_changed = min_ratio * (
-            session_dict[b"NewFiles"]
-            + session_dict[b"ChangedFiles"]
-            + session_dict[b"NewFiles"]
-        )
-        return FileStat(
-            (), min_changed, get_min(b"SourceFileSize"), get_min(b"IncrementFileSize")
-        )
-
-    def yield_fs_objs(filestatsobj):
-        """Iterate FileStats by processing file_statistics fileobj"""
-        r = re.compile(
-            b"^(.*) ([0-9]+) ([0-9]+|NA) ([0-9]+|NA) " b"([0-9]+|NA)%b?$" % (separator,)
-        )
-        for line in filestatsobj:
-            if line.startswith(b"#"):
-                continue
-            match = r.match(line)
-            if not match:
-                sys.stderr.write("Error parsing line: %s\n" % _safe_str(line))
-                continue
-
-            filename = match.group(1)
-            if filename == b".":
-                nametuple = ()
-            else:
-                nametuple = tuple(filename.split(b"/"))
-
-            sourcesize_str = match.group(3)
-            if sourcesize_str == b"NA":
-                sourcesize = 0
-            else:
-                sourcesize = int(sourcesize_str)
-
-            incsize_str = match.group(5)
-            if incsize_str == b"NA":
-                incsize = 0
-            else:
-                incsize = int(incsize_str)
-
-            yield FileStat(nametuple, int(match.group(2)), sourcesize, incsize)
-
-    def accumulate_fs(fs_iter):
-        """Yield the FileStat objects in fs_iter, but with total statistics
-
-        In fs_iter, the statistics of directories FileStats only apply
-        to themselves.  This will iterate the same FileStats, but
-        directories will include all the files under them.  As a
-        result, the directories will come after the files in them
-        (e.g. '.' will be last.).
-
-        Naturally this would be written recursively, but profiler said
-        it was too slow in python.
-
-        """
-        root = next(fs_iter)
-        assert root.nametuple == (), root
-        stack = [root]
-        try:
-            fs = next(fs_iter)
-        except StopIteration:
-            yield root
-            return
-
-        while 1:
-            if fs and fs.is_child(stack[-1]):
-                stack.append(fs)
-                try:
-                    fs = next(fs_iter)
-                except StopIteration:
-                    fs = None
-            else:
-                expired = stack.pop()
-                yield expired
-                if not stack:
-                    return
-                else:
-                    stack[-1].add_child(expired)
-
-    def make_tree_one_level(fs_iter, first_fs):
-        """Populate a tree of FileStat objects from fs_iter
-
-        This function wants the fs_iter in the reverse direction as
-        usual, with the parent coming directly after all the children.
-        It will return the parent of first_fs.
-
-        """
-        children = [first_fs]
-        fs = next(fs_iter)
-        while 1:
-            if first_fs.is_child(fs):
-                fs.children = children
-                return fs
-            elif first_fs.is_brother(fs):
-                children.append(fs)
-                fs = next(fs_iter)
-            else:
-                fs = make_tree_one_level(fs_iter, fs)
-
-    def make_root_tree(fs_iter):
-        """Like make_tree, but assume fs_iter starts at the root"""
-        try:
-            fs = next(fs_iter)
-        except StopIteration:
-            sys.exit("No files in iterator")
-
-        while fs.nametuple != ():
-            fs = make_tree_one_level(fs_iter, fs)
-        return fs
-
-    cutoff_fs = get_cutoff_fs(get_ss_dict())
+    cutoff_fs = _get_cutoff_fs(_get_ss_dict(session_rp))
     filestat_fileobj = ReadlineBuffer(filestat_rp)
-    accumulated_iter = accumulate_fs(yield_fs_objs(filestat_fileobj))
+    accumulated_iter = _accumulate_fs(_yield_fs_objs(filestat_fileobj))
     important_iter = filter(lambda fs: fs >= cutoff_fs, accumulated_iter)
-    trimmed_tree = make_root_tree(important_iter)
+    trimmed_tree = _make_root_tree(important_iter)
     return FileStatisticsTree(cutoff_fs, trimmed_tree)
+
+
+def _get_ss_dict(session_rp):
+    """Parse session statistics file and return dictionary with ss data"""
+    fileobj = session_rp.open("rb", session_rp.isinccompressed())
+    return_val = {}
+    for line in fileobj:
+        if line.startswith(b"#"):
+            continue
+        comps = line.split()
+        if len(comps) < 2:
+            sys.stderr.write("Unable to parse session statistics line: " + line)
+            continue
+        return_val[comps[0]] = float(comps[1])
+    return return_val
+
+
+def _get_cutoff_fs(session_dict):
+    """Return FileStat object set with absolute cutoffs
+
+    Any FileStat object that is bigger than the result in any
+    aspect will be considered "important".
+
+    """
+
+    def get_min(attrib):
+        return min_ratio * session_dict[attrib]
+
+    min_changed = min_ratio * (
+        session_dict[b"NewFiles"]
+        + session_dict[b"ChangedFiles"]
+        + session_dict[b"NewFiles"]
+    )
+    return FileStat(
+        (), min_changed, get_min(b"SourceFileSize"), get_min(b"IncrementFileSize")
+    )
+
+
+def _yield_fs_objs(filestatsobj):
+    """Iterate FileStats by processing file_statistics fileobj"""
+    r = re.compile(
+        b"^(.*) ([0-9]+) ([0-9]+|NA) ([0-9]+|NA) " b"([0-9]+|NA)%b?$" % (separator,)
+    )
+    for line in filestatsobj:
+        if line.startswith(b"#"):
+            continue
+        match = r.match(line)
+        if not match:
+            sys.stderr.write("Error parsing line: %s\n" % _safe_str(line))
+            continue
+
+        filename = match.group(1)
+        if filename == b".":
+            nametuple = ()
+        else:
+            nametuple = tuple(filename.split(b"/"))
+
+        sourcesize_str = match.group(3)
+        if sourcesize_str == b"NA":
+            sourcesize = 0
+        else:
+            sourcesize = int(sourcesize_str)
+
+        incsize_str = match.group(5)
+        if incsize_str == b"NA":
+            incsize = 0
+        else:
+            incsize = int(incsize_str)
+
+        yield FileStat(nametuple, int(match.group(2)), sourcesize, incsize)
+
+
+def _accumulate_fs(fs_iter):
+    """Yield the FileStat objects in fs_iter, but with total statistics
+
+    In fs_iter, the statistics of directories FileStats only apply
+    to themselves.  This will iterate the same FileStats, but
+    directories will include all the files under them.  As a
+    result, the directories will come after the files in them
+    (e.g. '.' will be last.).
+
+    Naturally this would be written recursively, but profiler said
+    it was too slow in python.
+
+    """
+    root = next(fs_iter)
+    assert root.nametuple == (), root
+    stack = [root]
+    try:
+        fs = next(fs_iter)
+    except StopIteration:
+        yield root
+        return
+
+    while 1:
+        if fs and fs.is_child(stack[-1]):
+            stack.append(fs)
+            try:
+                fs = next(fs_iter)
+            except StopIteration:
+                fs = None
+        else:
+            expired = stack.pop()
+            yield expired
+            if not stack:
+                return
+            else:
+                stack[-1].add_child(expired)
+
+
+def _make_root_tree(fs_iter):
+    """Like make_tree, but assume fs_iter starts at the root"""
+    try:
+        fs = next(fs_iter)
+    except StopIteration:
+        sys.exit("No files in iterator")
+
+    while fs.nametuple != ():
+        fs = _make_tree_one_level(fs_iter, fs)
+    return fs
+
+
+def _make_tree_one_level(fs_iter, first_fs):
+    """Populate a tree of FileStat objects from fs_iter
+
+    This function wants the fs_iter in the reverse direction as
+    usual, with the parent coming directly after all the children.
+    It will return the parent of first_fs.
+
+    """
+    children = [first_fs]
+    fs = next(fs_iter)
+    while 1:
+        if first_fs.is_child(fs):
+            fs.children = children
+            return fs
+        elif first_fs.is_brother(fs):
+            children.append(fs)
+            fs = next(fs_iter)
+        else:
+            fs = _make_tree_one_level(fs_iter, fs)
 
 
 class FileStat:

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,9 @@ commands =
 ignore =
 	E501 # line too long (86 > 79 characters)
 	W503 # line break before binary operator
+filename =
+	*.py,
+	src/rdiff-backup*
 exclude =
     .git
     .tox


### PR DESCRIPTION
flake8 was ignoring the src/rdiff-backup* scripts because they don't have the .py ending. This made the complexity of rdiff-backup-statistics apparent and needed to be fixed.

It is normal that the tests fail, their success depends on the changes done to rdiff-backup-delete in PR #474 