### PR TITLE
Improve benchmark (aka slow) test

### DIFF
--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -22,7 +22,5 @@ commands_pre =
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =
-    python testing/benchmark.py many_files
-    python testing/benchmark.py many_files_no_fsync
-    python testing/benchmark.py many_files_rsync
-    python testing/benchmark.py nested_files
+    python testing/benchmark.py many
+    python testing/benchmark.py nested


### PR DESCRIPTION
I'm a bit concerned that code changes might impact the performance without
us noticing. Absolute benchmark times are too much dependent on the sizing
of the testing platform to be relevant, but I'm hoping that the relative
numbers, compared to rsync, are more relevant.
