### PR TITLE
Add PyYAML to Windows build(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ jobs:
         - pyenv local $pyver
         - python --version
       install:
-        - pip install --upgrade tox pywin32 setuptools-scm PyInstaller wheel
+        - pip install --upgrade tox pywin32 setuptools-scm PyInstaller wheel PyYAML
         - pyenv rehash
         - git clone -b v2.2.1 https://github.com/librsync/librsync.git $HOME/.librsync
         - export LIBRSYNC_DIR=$HOME/librsync

--- a/tools/windows/playbook-provision.yml
+++ b/tools/windows/playbook-provision.yml
@@ -50,7 +50,7 @@
 # TODO remove importlib-metadata once we've moved to Python 3.8
 
   - name: install necessary python libraries
-    win_command: pip.exe install py2exe pywin32 pyinstaller wheel certifi setuptools-scm tox importlib-metadata
+    win_command: pip.exe install py2exe pywin32 pyinstaller wheel certifi setuptools-scm tox importlib-metadata PyYAML
     register: pipcmd
     changed_when: "'Successfully installed ' in pipcmd.stdout"
     # pylibacl and pyxattr aren't supported under Windows


### PR DESCRIPTION
Small fix as I've forgotten to add PyYAML to the pip-installed dependencies under Windows (required for PyInstaller to pick it properly).