### PR TITLE
Add version to schema and use format

### DIFF
--- a/docs/CODING.md
+++ b/docs/CODING.md
@@ -4,6 +4,15 @@ We follow the latest flake8 enforced guidelines, but certain aspects of coding
 can't be enforced through automated checks, hence to be followed by humans
 and reviewers. This document lists such coding conventions.
 
+## QUOTING
+
+* the [style guide for Python code (PEP 8)](https://www.python.org/dev/peps/pep-0008/#string-quotes)
+  doesn't recommend single vs. double quotes but states that triple-quoted
+  strings should use double quotes "to be consistent with the docstring
+  convention in [PEP 257](https://www.python.org/dev/peps/pep-0257)".
+* for this reason, we use double quotes everywhere, unless the text contains
+  itself a double quote, in which case single quotes are obviously preferred.
+
 ## PRIVATE AND PUBLIC ITEMS
 
 * we call items any definition of class, function, member, variable, etc...
@@ -53,3 +62,14 @@ and reviewers. This document lists such coding conventions.
 
 > **NOTE:** one of the main driver for the above recommendations is the
 	possibility to translate those strings in the future.
+
+## BYTES VS. STR
+
+* Paths and commands are expressed in bytes to avoid issues with cross-platform
+  encoding conversion, any function manipulating such things must return bytes.
+* Only methods creating a Path/Command object (`__init__` and similar) might
+  accept strings as input and convert them internally to bytes. Other functions
+  must make sure that they don't accept strings as input (this is one of the
+  few reasons to use asserts).
+* Any conversion between strings and bytes happens with `os.fsencode/fsdecode`.
+* Messages are to be expressed in strings (log, errors, etc).

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -213,6 +213,9 @@ def _fill_schema(host_info):
     """
     Fills host_info and optionally the version into the schema and returns remote command.
     """
+    assert isinstance(host_info, bytes), (
+        "host_info parameter must be bytes not {thi}.".format(
+            thi=type(host_info)))
     try:
         # for security reasons, we accept only specific format placeholders
         # h for host_info, vx,vy,vz for version x.y.z

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -34,8 +34,8 @@ from . import Globals, connection, rpath
 # This is the schema that determines how rdiff-backup will open a
 # pipe to the remote system.  If the file is given as A::B, %s will
 # be substituted with A in the schema.
-__cmd_schema = b'ssh -C %s rdiff-backup --server'
-__cmd_schema_no_compress = b'ssh %s rdiff-backup --server'
+__cmd_schema = b"ssh -C {h} rdiff-backup --server"
+__cmd_schema_no_compress = b"ssh {h} rdiff-backup --server"
 
 # This is a list of remote commands used to start the connections.
 # The first is None because it is the local connection.
@@ -210,11 +210,29 @@ def _parse_file_desc(file_desc):
 
 
 def _fill_schema(host_info):
-    """Fills host_info into the schema and returns remote command"""
+    """
+    Fills host_info and optionally the version into the schema and returns remote command.
+    """
     try:
-        return __cmd_schema % host_info
-    except TypeError:
-        Log.FatalError("Invalid remote schema:\n\n%s\n" % _safe_str(__cmd_schema))
+        # for security reasons, we accept only specific format placeholders
+        # h for host_info, vx,vy,vz for version x.y.z
+        # and the host placeholder is mandatory
+        if ((re.findall(b"{[^}]*}", __cmd_schema)
+             != re.findall(b"{h}|{v[xyz]}", __cmd_schema))
+                or (b"{h}" not in __cmd_schema
+                    and b"%s" not in __cmd_schema)):  # compat200
+            raise KeyError
+        if b"{h}" in __cmd_schema:
+            ver_split = Globals.version.split(".")
+            # bytes doesn't have a format method, hence the conversions
+            return os.fsencode(os.fsdecode(__cmd_schema).format(
+                h=os.fsdecode(host_info),
+                vx=ver_split[0], vy=ver_split[1], vz=ver_split[2]))
+        else:  # compat200: accepts "%s" as host place-holder
+            return __cmd_schema % host_info
+    except (TypeError, KeyError):
+        Log.FatalError("Invalid remote schema:\n\n{schema}\n".format(
+            schema=_safe_str(__cmd_schema)))
 
 
 def _init_connection(remote_cmd):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -113,7 +113,7 @@ def rdiff_backup(source_local,
 
     cmdargs = [RBBin, extra_options]
     if not (source_local and dest_local):
-        cmdargs.append(b"--remote-schema %s")
+        cmdargs.append(b"--remote-schema {h}")
 
     if current_time:
         cmdargs.append(b"--current-time %i" % current_time)
@@ -142,7 +142,7 @@ def _internal_get_cmd_pairs(src_local, dest_local, src_dir, dest_dir):
     Note that the function relies on the global variables
     abs_remote1_dir, abs_remote2_dir and abs_testing_dir."""
 
-    remote_schema = b'%s'
+    remote_schema = b'{h}'
     remote_format = b"cd %s; %s/server.py::%s"
 
     if not src_local:

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -142,7 +142,7 @@ def _internal_get_cmd_pairs(src_local, dest_local, src_dir, dest_dir):
     Note that the function relies on the global variables
     abs_remote1_dir, abs_remote2_dir and abs_testing_dir."""
 
-    remote_schema = b'{h}'
+    remote_schema = b'%s'  # compat200: replace with {h}
     remote_format = b"cd %s; %s/server.py::%s"
 
     if not src_local:

--- a/testing/roottest.py
+++ b/testing/roottest.py
@@ -283,7 +283,7 @@ class HalfRoot(BaseRootTest):
         outrp = rpath.RPath(Globals.local_connection, abs_output_dir)
         re_init_rpath_dir(outrp, userid)
         remote_schema = b'su -c "%s --server" %s' % (RBBin, user.encode())
-        cmd_schema = (RBBin + b" --current-time %i --remote-schema '%%s' %b '%b'::%b")
+        cmd_schema = (RBBin + b" --current-time %i --remote-schema '{h}' %b '%b'::%b")
 
         cmd1 = cmd_schema % (10000, in_rp1.path, remote_schema, outrp.path)
         self._run_cmd(cmd1)
@@ -296,7 +296,7 @@ class HalfRoot(BaseRootTest):
         outrp.setdata()
 
         rout_rp = rpath.RPath(Globals.local_connection, abs_restore_dir)
-        restore_schema = (RBBin + b" -r %b --remote-schema '%%s' '%b'::%b %b")
+        restore_schema = (RBBin + b" -r %b --remote-schema '{h}' '%b'::%b %b")
         Myrm(rout_rp.path)
         cmd3 = restore_schema % (b'10000', remote_schema, outrp.path,
                                  rout_rp.path)

--- a/testing/securitytest.py
+++ b/testing/securitytest.py
@@ -71,7 +71,7 @@ class SecurityTest(unittest.TestCase):
         if not current_time:
             current_time = int(time.time())
         # escape the %s of the remote schema with double %
-        prefix = (b'%b --current-time %i --remote-schema %%s ' %
+        prefix = (b'%b --current-time %i --remote-schema {h} ' %
                   (RBBin, current_time))
 
         if in_local:


### PR DESCRIPTION
As discussed in the previous PR #517, there is a now a placeholder for the version with `{vx}`, `{vy}` and `{vz}`, so that the user can point at a specific version of rdiff-backup corresponding to the current version (e.g. using virtualenvs), and the host placeholder has become `{h}` for consistency.