### PR TITLE
[DOC] Clarify slashes in selection patterns and fix recursion

### DIFF
--- a/docs/rdiff-backup-old.1
+++ b/docs/rdiff-backup-old.1
@@ -749,8 +749,13 @@ web at
 .BR rdiff-backup 's
 selection system was originally inspired by
 .BR rsync (1),
-but there are many differences.  (For instance, trailing backslashes
-have no special significance.)
+but there are many differences. For instance, trailing backslashes
+have no special significance.
+
+.BR IMPORTANT:
+include and exclude patterns under Windows solely support
+slashes "/" as file separators, given that backslashes "\\" have a special
+meaning in regex/glob patterns.
 
 The file selection system comprises a number of file
 selection conditions, which are set using one of the following command

--- a/docs/rdiff-backup.1.md
+++ b/docs/rdiff-backup.1.md
@@ -736,8 +736,12 @@ file included in the package, or on the web at
 <https://rdiff-backup.net/docs/examples.html>.
 
 rdiff-backup's selection system was originally inspired by
-**rsync**(1), but there are many differences. (For instance, trailing
-backslashes have no special significance.)
+**rsync**(1), but there are many differences. For instance, trailing
+backslashes have no special significance.
+
+**IMPORTANT:** include and exclude patterns under Windows solely support
+slashes '`/`' as file separators, given that backslashes '`\`' have a
+special meaning in regex/glob patterns.
 
 All the available file selection conditions are listed under
 [SELECTION OPTIONS](#selection-options).

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -481,7 +481,7 @@ def _action_backup(rpin, rpout):
     _init_user_group_mapping(rpout.conn)
     _backup_final_init(rpout)
     _backup_set_select(rpin)
-    _backup_warn_if_infinite_regress(rpin, rpout)
+    _backup_warn_if_infinite_recursion(rpin, rpout)
     if _prevtime:
         Time.setprevtime(_prevtime)
         rpout.conn.Main.backup_touch_curmirror_local(rpin, rpout)
@@ -628,7 +628,7 @@ destination directory: %s""" % (Globals.rbdir.get_safepath(), exc,
     SetConnections.UpdateGlobal('rbdir', Globals.rbdir)
 
 
-def _backup_warn_if_infinite_regress(rpin, rpout):
+def _backup_warn_if_infinite_recursion(rpin, rpout):
     """Warn user if destination area contained in source area"""
     # Just a few heuristics, we don't have to get every case
     if rpout.conn is not rpin.conn:
@@ -648,7 +648,7 @@ def _backup_warn_if_infinite_regress(rpin, rpout):
 
     Log(
         """Warning: The destination directory '%s' may be contained in the
-source directory '%s'.  This could cause an infinite regress.  You
+source directory '%s'.  This could cause an infinite recursion.  You
 may need to use the --exclude option (which you might already have done)."""
         % (rpout.get_safepath(), rpin.get_safepath()), 2)
 


### PR DESCRIPTION
DOC: clarify in the man page(s) that only slashes are allowed in selection patterns under Windows, closes #531

Also rename infinite regress to infinite recursion.