### PR TITLE
Define fully action plugins interface and implement most of it

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -55,12 +55,12 @@ rdiff-backup FAQ
       1   Fatal Errors displayed
       2   Warnings
       3   Important messages, and maybe later some global statistics (default)
-      4   Some global settings, miscellaneous messages
+      4   Some global settings, miscellaneous messages (obsolete)
       5   Mentions which files were changed
-      6   More information on each file processed
-      7   More information on various things
-      8   All logging is dated
-      9   Details on which objects are moving across the connection
+      6   More information on each file processed (obsolete)
+      7   More information on various things (obsolete)
+      8   (not used)
+      9   Details on which objects are moving across the connection, debug (with timestamp)
       --- ----------------------------------------------------------------------
 
 2.  **[Is rdiff-backup backwards compatible?]{#compatible}**

--- a/docs/arch/plugins_actions.md
+++ b/docs/arch/plugins_actions.md
@@ -31,28 +31,51 @@ this single class.
 
 The Action class has the following interface:
 
-* the class method `cls.get_name()` returns the name of the plug-in, only this name
-  will be used in the code, and it doesn't need to be aligned with the name of
-  the module or of the class (but it should). Only requirement is that it is
+* the class method `cls.get_name()` returns the name of the plug-in, only this
+  name will be used in the code, and it doesn't need to be aligned with the name
+  of the module or of the class (but it should). Only requirement is that it is
   unique or plug-ins will overwrite each other.
-* the class method `cls.get_version()` returns the version of the plug-in as a string.
-* the class method `cls.add_action_subparser(sub_handler)` returns a subparser as
-  returned by argparse's `sub_handler.add_parser` function, so that the sub-options
-  of the action can be parsed by the `rdiffbackup.arguments.parse` function.
-* the method `self.__init__(args, log, errlog)` initializes the class as object, based
-  on the namespace returned by argparse, a Log and an ErrorLog object.
-* the method `self.pre_check()` just validates that the arguments passed were correct,
-  beyond what argparse could do, and shouldn't try to connect yet to any remote
-  location. A return value unequal 0 means an error, which can be used as exit code.
+* the class method `cls.get_security_class()` returns the security class of
+  the action plug-in, one of `backup`, `restore` or `validate`.
+* the class method `cls.get_version()` returns the version of the plug-in as a
+  string.
+* the class method `cls.add_action_subparser(sub_handler)` returns a subparser
+  as returned by argparse's `sub_handler.add_parser` function, so that the
+  sub-options of the action can be parsed by the `rdiffbackup.arguments.parse`
+  function.
+* the method `self.__init__(args, log, errlog)` initializes the class as object,
+  based on the namespace returned by argparse, a Log and an ErrorLog object.
+* the method `self.pre_check()` just validates that the arguments passed were
+  correct, beyond what argparse could do, and shouldn't try to connect yet to
+  any remote location. A return value unequal 0 means an error, which can be
+  used as exit code.
+* the method `self.connect()` returns a
+  [context manager object](https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers)
+  which can be used in a `with action.connect() as conn_act:` construct.
+  It is expected that the action object itself is the context manager, but it
+  isn't absolutely necessary (but the default implementation offered by the
+  BaseAction). The returned class must hence have two methods `self.__enter__()`
+  and `self.__exit__(self, exc_type, exc_value, traceback)` (closing the
+  connections). Again, it is expected that the runtime context object returned
+  by `__enter__` is the same action object (aka `return self`), but it isn't
+  an obligation.
 
-> **TODO:** further interface aspects haven't yet been defined but will definitely be
-  added step by step as the code progress. The current direction is to have the class
-  being instantiated from the Namespace resulting of the parsing of the CLI arguments,
-  and then object methods representing a workflow through the action be called one after
-  the other, something like:
-  `pre_check` → `connect` → `execute` → `clean_up`.
+  This context object has the following interface, usable through the
+  connection(s) started by `connect()`:
+    * `self.check()` to validate the environment before doing changes.
+      It returns 0 in case of success, else an integer to be used as exit code.
+    * `self.setup()` still doesn't do changes but prepares the environment.
+      It returns 0 in case of success, else an integer to be used as exit code.
+    * `self.run()` finally does whatever the action is supposed to do.
+      It might return 0 in case of success, else an integer to be used as exit
+      code. It is the only function that might exit directly instead, even
+      though it isn't the recommended approach (but a matter of fact for most
+      existing actions).
 
-Of course, action classes inheriting from the BaseAction class don't need to define all
-aspects themselves, making the life of plug-in developers easier.
+> **NOTE:** the context object doesn't need a "cleanup" action as clean-up is to
+  be done as part of the `__exit__` method provided by the context manager.
+
+Of course, action classes inheriting from the BaseAction class don't need to
+define all aspects themselves, making the life of plug-in developers easier.
 
 > **NOTE:** more information is provided with `pydoc rdiffbackup.actions`.

--- a/docs/arch/plugins_actions.md
+++ b/docs/arch/plugins_actions.md
@@ -39,6 +39,11 @@ The Action class has the following interface:
 * the class method `cls.add_action_subparser(sub_handler)` returns a subparser as
   returned by argparse's `sub_handler.add_parser` function, so that the sub-options
   of the action can be parsed by the `rdiffbackup.arguments.parse` function.
+* the method `self.__init__(args, log, errlog)` initializes the class as object, based
+  on the namespace returned by argparse, a Log and an ErrorLog object.
+* the method `self.pre_check()` just validates that the arguments passed were correct,
+  beyond what argparse could do, and shouldn't try to connect yet to any remote
+  location. A return value unequal 0 means an error, which can be used as exit code.
 
 > **TODO:** further interface aspects haven't yet been defined but will definitely be
   added step by step as the code progress. The current direction is to have the class

--- a/src/rdiff-backup
+++ b/src/rdiff-backup
@@ -29,4 +29,4 @@ except ImportError:
 
 # the __no_execute__ flag is used for tests
 if __name__ == "__main__" and "__no_execute__" not in globals():
-    rdiff_backup.Main.error_check_Main(sys.argv[1:])
+    rdiff_backup.Main.main_run(sys.argv[1:])

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -232,9 +232,6 @@ no_compression_regexp = None
 # nulls instead of newlines.
 null_separator = None
 
-# Determines whether or not ssh will be run with the -C switch
-ssh_compression = 1
-
 # If true, print statistics after successful backup
 print_statistics = None
 

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -116,7 +116,7 @@ def _set_security_level(security_class, cmdpairs):
     def getpath(cmdpair):
         return cmdpair[1]
 
-    if Globals.server:
+    if security_class == "server":
         return
     cp1 = cmdpairs[0]
     if len(cmdpairs) > 1:

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -62,10 +62,10 @@ _file_requests = {
 }
 
 
-def initialize(action, cmdpairs):
+def initialize(security_class, cmdpairs):
     """Initialize allowable request list and chroot"""
     global _allowed_requests
-    _set_security_level(action, cmdpairs)
+    _set_security_level(security_class, cmdpairs)
     _set_allowed_requests(Globals.security_level)
 
 
@@ -95,13 +95,13 @@ def vet_request(request, arglist):
     _raise_violation("Invalid request", request, arglist)
 
 
-def _set_security_level(action, cmdpairs):
-    """If running client, set security level and restrict_path
+def _set_security_level(security_class, cmdpairs):
+    """
+    If running client, set security level and restrict_path
 
-    To find these settings, we must look at the action to see what is
-    supposed to happen, and then look at the cmdpairs to see what end
-    the client is on.
-
+    To find these settings, we must look at the action's security class
+    to see what is supposed to happen, and then look at the cmdpairs to
+    see what end the client is on.
     """
 
     def islocal(cmdpair):
@@ -124,7 +124,7 @@ def _set_security_level(action, cmdpairs):
     else:
         cp2 = cp1
 
-    if action == "backup" or action == "check-destination-dir":
+    if security_class == "backup":
         if bothlocal(cp1, cp2) or bothremote(cp1, cp2):
             sec_level = "minimal"
             rdir = tempfile.gettempdir()
@@ -134,12 +134,13 @@ def _set_security_level(action, cmdpairs):
         else:  # cp2 is local but not cp1
             sec_level = "update-only"
             rdir = getpath(cp2)
-    elif action == "restore" or action == "restore-as-of":
+    elif security_class == "restore":
         if len(cmdpairs) == 1 or bothlocal(cp1, cp2) or bothremote(cp1, cp2):
             sec_level = "minimal"
             rdir = tempfile.gettempdir()
         elif islocal(cp1):
             sec_level = "read-only"
+            # FIXME it shouldn't be necessary to call back Main's function.
             Main.restore_set_root(
                 rpath.RPath(Globals.local_connection, getpath(cp1)))
             if Main.restore_root:
@@ -149,7 +150,7 @@ def _set_security_level(action, cmdpairs):
         else:  # cp2 is local but not cp1
             sec_level = "all"
             rdir = getpath(cp2)
-    elif action == "mirror":
+    elif security_class == "mirror":  # compat200 not sure what this was?!?
         if bothlocal(cp1, cp2) or bothremote(cp1, cp2):
             sec_level = "minimal"
             rdir = tempfile.gettempdir()
@@ -159,16 +160,12 @@ def _set_security_level(action, cmdpairs):
         else:  # cp2 is local but not cp1
             sec_level = "all"
             rdir = getpath(cp2)
-    elif action in [
-            "test-server", "list-increments", 'list-increment-sizes',
-            "list-at-time", "list-changed-since", "calculate-average",
-            "remove-older-than", "compare", "compare-hash", "compare-full",
-            "verify"
-    ]:
+    elif security_class == "validate":
         sec_level = "minimal"
         rdir = tempfile.gettempdir()
     else:
-        raise RuntimeError("Unknown action '{act}'.".format(act=action))
+        raise RuntimeError("Unknown action security class '{sec}'.".format(
+            sec=security_class))
 
     Globals.security_level = sec_level
     Globals.restrict_path = rpath.RPath(Globals.local_connection,
@@ -178,7 +175,7 @@ def _set_security_level(action, cmdpairs):
 def _set_allowed_requests(sec_level):
     """Set the allowed requests list using the security level"""
     global _allowed_requests
-    requests = [
+    requests = [  # minimal set of requests
         "VirtualFile.readfromid", "VirtualFile.closebyid", "Globals.get",
         "Globals.is_not_None", "Globals.get_dict_val",
         "log.Log.open_logfile_allconn", "log.Log.close_logfile_allconn",

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -35,6 +35,11 @@ class LoggerError(Exception):
 
 class Logger:
     """All functions which deal with logging"""
+    ERROR = 1
+    WARNING = 2
+    DEFAULT = 3
+    INFO = 5
+    DEBUG = 9
 
     def __init__(self):
         self.log_file_open = None

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -325,10 +325,11 @@ class ErrorLog:
     @classmethod
     def close(cls):
         """Close the error log file"""
-        if not Globals.isbackup_writer:
-            return Globals.backup_writer.log.ErrorLog.close()
-        cls._log_fileobj.close()
-        cls._log_fileobj = None
+        if cls.isopen():
+            if not Globals.isbackup_writer:
+                return Globals.backup_writer.log.ErrorLog.close()
+            cls._log_fileobj.close()
+            cls._log_fileobj = None
 
     @classmethod
     def _get_log_string(cls, error_type, rp, exc):

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -286,7 +286,7 @@ class BaseAction:
         Return the security class of the Action class.
 
         Children classes only need to define the class member 'security',
-        with one of the values 'backup', 'restore' or 'validate'.
+        with one of the values 'backup', 'restore', 'server' or 'validate'.
         """
         return cls.security
 

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -24,9 +24,11 @@ plugins can inheritate default behaviors.
 """
 
 import argparse
+import os
 import sys
 import yaml
 from rdiffbackup.utils.argopts import BooleanOptionalAction, SelectAction
+from rdiff_backup import SetConnections, Security
 
 # The default regexp for not compressing those files
 # compat200: it is also used by Main.py to avoid having a 2nd default
@@ -259,6 +261,9 @@ class BaseAction:
     # name of the action as a string
     name = None
 
+    # type of action for security purposes, one of backup, restore, validate
+    security = None
+
     # version of the action
     __version__ = "0.0.0"
 
@@ -273,6 +278,16 @@ class BaseAction:
         Children classes only need to define the class member 'name'.
         """
         return cls.name
+
+    @classmethod
+    def get_security_class(cls):
+        """
+        Return the security class of the Action class.
+
+        Children classes only need to define the class member 'security',
+        with one of the values 'backup', 'restore' or 'validate'.
+        """
+        return cls.security
 
     @classmethod
     def get_version(cls):
@@ -331,15 +346,39 @@ class BaseAction:
             subparsers[sub_name].set_defaults(**{sub_dest: sub_name})
         return subparsers
 
-    def __init__(self, values, log, errlog):
+    def __init__(self, values, log=None, errlog=None):
         """
-        Instantiate an action class.
+        Instantiate an action plug-in class.
+
         values is a Namespace as returned by argparse.
         log is a log.Log object and errlog a log.ErrorLog object.
         """
         self.values = values
+        if self.values.remote_schema:
+            self.remote_schema = os.fsencode(self.values.remote_schema)
+        else:
+            self.remote_schema = None
         self.log = log
         self.errlog = errlog
+
+    def __enter__(self):
+        """
+        Context manager interface to enter with-as context.
+
+        Returns self to be used 'as' value.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Context manager interface to exit with-as context.
+
+        Returns False to propagate potential exception, else True.
+        """
+        for location in self.connected_locations:
+            pass  # TODO disconnect
+
+        return False
 
     def print_values(self, explicit=True):
         """
@@ -350,19 +389,68 @@ class BaseAction:
 
     def pre_check(self):
         """
-        Validate that the values given look correct. This method isn't meant to
-        try to access any file system and even less a remote location, it is
-        really only meant to validate the values beyond what argparse can do.
+        Validate that the values given look correct.
+
+        This method isn't meant to try to access any file system and even less
+        a remote location, it is really only meant to validate the values
+        beyond what argparse can do.
         Return 0 if everything looked good, else an error code.
+
         Try to check everything before returning and not force the user to fix their
         entries step by step.
         """
         if self.values.action == self.name:
             return 0
         else:
-            self.log("Action '{act}' doesn't fit name of action class '{name}'.".format(
-                act=self.values.action, name=self.name), self.log.ERROR)
+            self.log("Action '{act}' doesn't fit name of action class "
+                     "'{name}'.".format(act=self.values.action, name=self.name),
+                     self.log.ERROR)
             return 1
+
+    def connect(self):
+        """
+        Connect to potentially provided locations arguments, remote or local.
+
+        Returns self, to be used as context manager.
+        """
+
+        if 'locations' in self.values:
+            # TODO encapsulate the following lines into one
+            # connections/connections_mgr construct, so that the action doesn't
+            # need to care about cmdpairs and Security (which would become a
+            # feature of the connection).
+            cmdpairs = SetConnections.get_cmd_pairs(
+                self.values.locations,
+                remote_schema=self.remote_schema,
+                ssh_compression=self.values.ssh_compression)
+            Security.initialize(self.get_security_class(), cmdpairs)
+            self.connected_locations = list(
+                    map(SetConnections.get_connected_rpath, cmdpairs))
+        else:
+            self.connected_locations = []
+
+        return self
+
+    def check(self):
+        """
+        Checks that all connections are looking fine.
+
+        Whatever can be checked without changing anything to the environment.
+        Return 0 if everything looked good, else an error code.
+        """
+        return_code = 0
+
+        if 'locations' not in self.values:
+            return return_code
+
+        # if a connection is None, it's an error
+        for conn, loc in zip(self.connected_locations, self.values.locations):
+            if conn is None:
+                self.log("Location '{loc}' couldn't be connected.".format(
+                    loc=loc), self.log.ERROR)
+                return_code |= 1
+
+        return return_code
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -262,6 +262,7 @@ class BaseAction:
     name = None
 
     # type of action for security purposes, one of backup, restore, validate
+    # or server
     security = None
 
     # version of the action

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -331,18 +331,38 @@ class BaseAction:
             subparsers[sub_name].set_defaults(**{sub_dest: sub_name})
         return subparsers
 
-    def __init__(self, values):
+    def __init__(self, values, log, errlog):
         """
-        Dummy initialization method
+        Instantiate an action class.
+        values is a Namespace as returned by argparse.
+        log is a log.Log object and errlog a log.ErrorLog object.
         """
         self.values = values
+        self.log = log
+        self.errlog = errlog
 
     def print_values(self, explicit=True):
         """
-        Dummy output method
+        Debug output method
         """
         print(yaml.safe_dump(self.values.__dict__,
                              explicit_start=explicit, explicit_end=explicit))
+
+    def pre_check(self):
+        """
+        Validate that the values given look correct. This method isn't meant to
+        try to access any file system and even less a remote location, it is
+        really only meant to validate the values beyond what argparse can do.
+        Return 0 if everything looked good, else an error code.
+        Try to check everything before returning and not force the user to fix their
+        entries step by step.
+        """
+        if self.values.action == self.name:
+            return 0
+        else:
+            self.log("Action '{act}' doesn't fit name of action class '{name}'.".format(
+                act=self.values.action, name=self.name), self.log.ERROR)
+            return 1
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -29,6 +29,7 @@ class BackupAction(actions.BaseAction):
     Backup a source directory to a target backup repository.
     """
     name = "backup"
+    security = "backup"
     parent_parsers = [
         actions.CREATION_PARSER, actions.COMPRESSION_PARSER, actions.SELECTION_PARSER,
         actions.FILESYSTEM_PARSER, actions.USER_GROUP_PARSER, actions.STATISTICS_PARSER,

--- a/src/rdiffbackup/actions/calculate.py
+++ b/src/rdiffbackup/actions/calculate.py
@@ -29,6 +29,7 @@ class CalculateAction(actions.BaseAction):
     Calculate values (average by default) across multiple statistics files.
     """
     name = "calculate"
+    security = "validate"
 
     @classmethod
     def add_action_subparser(cls, sub_handler):

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -32,6 +32,7 @@ class CompareAction(actions.BaseAction):
     at a given time, using multiple methods.
     """
     name = "compare"
+    security = "validate"
     parent_parsers = [actions.SELECTION_PARSER]
 
     @classmethod

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -34,6 +34,10 @@ class InfoAction(actions.BaseAction):
     security = "validate"  # FIXME introduce a "none" security level?
     # information has no specific sub-options
 
+    def setup(self):
+        # there is nothing to setup for the info action
+        pass
+
 
 def get_action_class():
     return InfoAction

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -31,6 +31,7 @@ class InfoAction(actions.BaseAction):
     in a bug report, and exits.
     """
     name = "info"
+    security = "validate"  # FIXME introduce a "none" security level?
     # information has no specific sub-options
 
 

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -20,6 +20,9 @@
 """
 A built-in rdiff-backup action plug-in to list increments and files in a
 back-up repository.
+
+The module is named with an underscore at the end to avoid overwriting the
+builtin 'list' class.
 """
 
 from rdiffbackup import actions
@@ -32,6 +35,7 @@ class ListAction(actions.BaseAction):
     increments, with or without size, in a given backup repository.
     """
     name = "list"
+    security = "validate"
 
     @classmethod
     def add_action_subparser(cls, sub_handler):

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -31,6 +31,7 @@ class RegressAction(actions.BaseAction):
     backup and reverse to the last known good mirror.
     """
     name = "regress"
+    security = "backup"
     parent_parsers = [actions.COMPRESSION_PARSER, actions.TIMESTAMP_PARSER,
                       actions.USER_GROUP_PARSER]
 

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -30,6 +30,7 @@ class RemoveAction(actions.BaseAction):
     Remove the oldest increments from a backup repository.
     """
     name = "remove"
+    security = "validate"  # FIXME doesn't sound right, rather backup
 
     @classmethod
     def add_action_subparser(cls, sub_handler):

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -31,6 +31,7 @@ class RestoreAction(actions.BaseAction):
     to a target directory.
     """
     name = "restore"
+    security = "restore"
     parent_parsers = [
         actions.CREATION_PARSER, actions.COMPRESSION_PARSER, actions.SELECTION_PARSER,
         actions.FILESYSTEM_PARSER, actions.USER_GROUP_PARSER,

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -29,7 +29,7 @@ class ServerAction(actions.BaseAction):
     Start rdiff-backup in server mode (only meant for internal use).
     """
     name = "server"
-    # server's security is given by the client
+    security = "server"
     # server has no specific sub-options
 
 

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -29,6 +29,7 @@ class ServerAction(actions.BaseAction):
     Start rdiff-backup in server mode (only meant for internal use).
     """
     name = "server"
+    # server's security is given by the client
     # server has no specific sub-options
 
 

--- a/src/rdiffbackup/actions/test.py
+++ b/src/rdiffbackup/actions/test.py
@@ -33,6 +33,7 @@ class TestAction(actions.BaseAction):
     Test that servers are properly reachable and usable for back-ups.
     """
     name = "test"
+    security = "validate"
 
     @classmethod
     def add_action_subparser(cls, sub_handler):
@@ -56,6 +57,19 @@ class TestAction(actions.BaseAction):
                 return_code |= 1  # binary 'or' to always get 1
 
         return return_code
+
+    def check(self):
+        # we call the parent check only to output the failed connections
+        return_code = super().check()
+
+        # even if some connections are bad, we want to validate the remaining
+        # ones later on. The 'None' filter keeps only trueish values.
+        self.connected_locations = list(filter(None, self.connected_locations))
+        if self.connected_locations:
+            # at least one location is apparently valid
+            return 0
+        else:
+            return return_code
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/verify.py
+++ b/src/rdiffbackup/actions/verify.py
@@ -33,6 +33,7 @@ class VerifyAction(actions.BaseAction):
     or that servers are properly reachable.
     """
     name = "verify"
+    security = "validate"
 
     @classmethod
     def add_action_subparser(cls, sub_handler):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -8,7 +8,7 @@ import subprocess
 # Avoid circularities
 from rdiff_backup.log import Log
 from rdiff_backup import Globals, Hardlink, SetConnections, Main, \
-    selection, rpath, eas_acls, rorpiter, Security, hash
+    selection, rpath, eas_acls, rorpiter, hash
 from rdiffbackup import actions
 
 RBBin = os.fsencode(shutil.which("rdiff-backup") or "rdiff-backup")
@@ -135,6 +135,29 @@ def rdiff_backup(source_local,
     return ret_val
 
 
+def _get_locations(src_local, dest_local, src_dir, dest_dir):
+    """
+    Return a tuple of remote or local source and destination locations
+    """
+    remote_location = "cd {rdir}; {tdir}/server.py::{dir}"
+
+    if not src_local:
+        src_dir = remote_location.format(
+            rdir=os.fsdecode(abs_remote1_dir),
+            tdir=os.fsdecode(abs_testing_dir),
+            dir=os.fsdecode(src_dir))
+    else:
+        src_dir = os.fsdecode(src_dir)
+    if not dest_local:
+        dest_dir = remote_location.format(
+            rdir=os.fsdecode(abs_remote2_dir),
+            tdir=os.fsdecode(abs_testing_dir),
+            dir=os.fsdecode(dest_dir))
+    else:
+        dest_dir = os.fsdecode(dest_dir)
+    return (src_dir, dest_dir)
+
+
 def _internal_get_cmd_pairs(src_local, dest_local, src_dir, dest_dir):
     """Function returns a tuple of connections based on the given parameters.
     One or both directories are faked for remote connection if not local,
@@ -162,7 +185,8 @@ def InternalBackup(source_local,
                    dest_dir,
                    current_time=None,
                    eas=None,
-                   acls=None):
+                   acls=None,
+                   force=False):
     """Backup src to dest internally
 
     This is like rdiff_backup but instead of running a separate
@@ -171,38 +195,43 @@ def InternalBackup(source_local,
     correct line/file references.
 
     """
-    Globals.current_time = current_time
-    Globals.security_level = "override"
-    Globals.set("no_compression_regexp_string",
-                os.fsencode(actions.DEFAULT_NOT_COMPRESSED_REGEXP))
+    args = []
+    if current_time is not None:
+        args.append("--current-time")
+        args.append(str(current_time))
+    if not (source_local and dest_local):
+        args.append("--remote-schema")
+        args.append("{h}")
+    if force:
+        args.append("--force")
+    args.append("backup")
+    if eas:
+        args.append("--eas")
+    else:
+        args.append("--no-eas")
+    if acls:
+        args.append("--acls")
+    else:
+        args.append("--no-acls")
 
-    cmdpairs = _internal_get_cmd_pairs(source_local, dest_local,
-                                       src_dir, dest_dir)
+    args.extend(_get_locations(source_local, dest_local, src_dir, dest_dir))
 
-    Security.initialize("backup", cmdpairs)
-    rpin, rpout = list(map(SetConnections.get_connected_rpath, cmdpairs))
-    for attr in ('eas_active', 'eas_write', 'eas_conn'):
-        SetConnections.UpdateGlobal(attr, eas)
-    for attr in ('acls_active', 'acls_write', 'acls_conn'):
-        SetConnections.UpdateGlobal(attr, acls)
-    Main._misc_setup([rpin, rpout])
-    Main._action_backup(rpin, rpout)
-    Main._cleanup()
+    Main.main_run(args, security_override=True, do_exit=False)
 
 
-def InternalMirror(source_local, dest_local, src_dir, dest_dir):
-    """Mirror src to dest internally
+def InternalMirror(source_local, dest_local, src_dir, dest_dir, force=False):
+    """
+    Mirror src to dest internally
 
     like InternalBackup, but only mirror.  Do this through
     InternalBackup, but then delete rdiff-backup-data directory.
-
     """
     # Save attributes of root to restore later
     src_root = rpath.RPath(Globals.local_connection, src_dir)
     dest_root = rpath.RPath(Globals.local_connection, dest_dir)
     dest_rbdir = dest_root.append("rdiff-backup-data")
 
-    InternalBackup(source_local, dest_local, src_dir, dest_dir)
+    InternalBackup(source_local, dest_local, src_dir, dest_dir, force=force)
     dest_root.setdata()
     Myrm(dest_rbdir.path)
     # Restore old attributes
@@ -223,31 +252,28 @@ def InternalRestore(mirror_local,
     the testing directory and will be modified for remote trials.
 
     """
-    Main._force = 1
-    Main._restore_root_set = 0
-    Globals.security_level = "override"
-    Globals.set("no_compression_regexp_string",
-                os.fsencode(actions.DEFAULT_NOT_COMPRESSED_REGEXP))
+    Main._restore_root_set = 0  # FIXME required?
+    args = []
+    args.append("--force")
+    if not (mirror_local and dest_local):
+        args.append("--remote-schema")
+        args.append("{h}")
+    args.append("restore")
+    if eas:
+        args.append("--eas")
+    else:
+        args.append("--no-eas")
+    if acls:
+        args.append("--acls")
+    else:
+        args.append("--no-acls")
+    if time:
+        args.append("--at")
+        args.append(str(time))
 
-    cmdpairs = _internal_get_cmd_pairs(mirror_local, dest_local,
-                                       mirror_dir, dest_dir)
+    args.extend(_get_locations(mirror_local, dest_local, mirror_dir, dest_dir))
 
-    Security.initialize("restore", cmdpairs)
-    mirror_rp, dest_rp = list(map(
-        SetConnections.get_connected_rpath, cmdpairs))
-    for attr in ('eas_active', 'eas_write', 'eas_conn'):
-        SetConnections.UpdateGlobal(attr, eas)
-    for attr in ('acls_active', 'acls_write', 'acls_conn'):
-        SetConnections.UpdateGlobal(attr, acls)
-    Main._misc_setup([mirror_rp, dest_rp])
-    inc = get_increment_rp(mirror_rp, time)
-    if inc:
-        Main._restore_timestr = None
-        Main._action_restore(get_increment_rp(mirror_rp, time), dest_rp)
-    else:  # use alternate syntax
-        Main._restore_timestr = str(time)
-        Main._action_restore(mirror_rp, dest_rp)
-    Main._cleanup()
+    Main.main_run(args, security_override=True, do_exit=False)
 
 
 def get_increment_rp(mirror_rp, time):
@@ -268,7 +294,6 @@ def _reset_connections(src_rp, dest_rp):
     Globals.security_level = "override"
     Globals.isbackup_reader = Globals.isbackup_writer = None
     SetConnections.UpdateGlobal('rbdir', None)
-    Main._misc_setup([src_rp, dest_rp])
 
 
 def _hardlink_rorp_eq(src_rorp, dest_rorp):
@@ -524,7 +549,8 @@ def MirrorTest(source_local,
         reset_hardlink_dicts()
         _reset_connections(src_rp, dest_rp)
 
-        InternalMirror(source_local, dest_local, dirname, dest_dirname)
+        InternalMirror(source_local, dest_local, dirname, dest_dirname,
+                       force=True)
         _reset_connections(src_rp, dest_rp)
         assert compare_recursive(src_rp, dest_rp, compare_hardlinks)
     Main.force = old_force_val

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -180,7 +180,7 @@ def InternalBackup(source_local,
                                        src_dir, dest_dir)
 
     Security.initialize("backup", cmdpairs)
-    rpin, rpout = list(map(SetConnections.cmdpair2rp, cmdpairs))
+    rpin, rpout = list(map(SetConnections.get_connected_rpath, cmdpairs))
     for attr in ('eas_active', 'eas_write', 'eas_conn'):
         SetConnections.UpdateGlobal(attr, eas)
     for attr in ('acls_active', 'acls_write', 'acls_conn'):
@@ -233,7 +233,8 @@ def InternalRestore(mirror_local,
                                        mirror_dir, dest_dir)
 
     Security.initialize("restore", cmdpairs)
-    mirror_rp, dest_rp = list(map(SetConnections.cmdpair2rp, cmdpairs))
+    mirror_rp, dest_rp = list(map(
+        SetConnections.get_connected_rpath, cmdpairs))
     for attr in ('eas_active', 'eas_write', 'eas_conn'):
         SetConnections.UpdateGlobal(attr, eas)
     for attr in ('acls_active', 'acls_write', 'acls_conn'):

--- a/testing/restoretest.py
+++ b/testing/restoretest.py
@@ -2,7 +2,7 @@ import unittest
 import os
 from commontest import abs_output_dir, old_test_dir, Myrm, MakeOutputDir, \
     InternalRestore, compare_recursive
-from rdiff_backup import restore, Globals, rpath, Time, log, Main
+from rdiff_backup import restore, Globals, rpath, Time, log
 
 lc = Globals.local_connection
 tempdir = rpath.RPath(Globals.local_connection, abs_output_dir)
@@ -196,10 +196,6 @@ class RestoreTest(unittest.TestCase):
             1, 1, os.path.join(old_test_dir, b'restoretest5', b'regular_file'),
             abs_output_dir, 10000)
         self.assertTrue(os.lstat(abs_output_dir))
-
-    def tearDown(self):
-        # especially the logfile might still appear opened if a test was interrupted
-        Main._cleanup()
 
 
 if __name__ == "__main__":

--- a/testing/roottest.py
+++ b/testing/roottest.py
@@ -3,7 +3,7 @@ import os
 from commontest import old_test_dir, abs_test_dir, abs_output_dir, Myrm, \
     abs_restore_dir, re_init_rpath_dir, compare_recursive, \
     BackupRestoreSeries, rdiff_backup, RBBin, xcopytree
-from rdiff_backup import Globals, rpath, Main
+from rdiff_backup import Globals, rpath
 """Root tests - contain tests which need to be run as root.
 
 Some of the quoting here may not work with csh (works on bash).  Also,
@@ -184,10 +184,6 @@ class RootTest(BaseRootTest):
                      out_rp.path,
                      extra_options=(b"--preserve-numerical-ids"))
         self.assertEqual(get_ownership(out_rp), ((0, 0), (userid, 1)))
-
-    def tearDown(self):
-        # especially the logfile might still appear opened if a test was interrupted
-        Main._cleanup()
 
 
 class HalfRoot(BaseRootTest):

--- a/testing/setconnectionstest.py
+++ b/testing/setconnectionstest.py
@@ -7,21 +7,23 @@ class SetConnectionsTest(unittest.TestCase):
 
     def testParsing(self):
         """Test parsing of various file descriptors"""
-        pfd = SetConnections._parse_file_desc
-        self.assertEqual(pfd(b"bescoto@folly.stanford.edu::/usr/bin/ls"),
-                         (b"bescoto@folly.stanford.edu", b"/usr/bin/ls"))
-        self.assertEqual(pfd(b"hello there::/goodbye:euoeu"),
-                         (b"hello there", b"/goodbye:euoeu"))
-        self.assertEqual(pfd(rb"test\\ing\::more::and more\\.."),
-                         (rb"test\ing::more", rb"and more\\.."))
-        self.assertEqual(pfd(b"a:b:c:d::e"), (b"a:b:c:d", b"e"))
-        self.assertEqual(pfd(b"foobar"), (None, b"foobar"))
-        self.assertEqual(pfd(rb"hello\::there"), (None, rb"hello\::there"))
-        self.assertEqual(pfd(rb"foobar\\"), (None, rb"foobar\\"))
+
+        pl = SetConnections.parse_location
+
+        self.assertEqual(pl(b"bescoto@folly.stanford.edu::/usr/bin/ls"),
+                         (b"bescoto@folly.stanford.edu", b"/usr/bin/ls", None))
+        self.assertEqual(pl(b"hello there::/goodbye:euoeu"),
+                         (b"hello there", b"/goodbye:euoeu", None))
+        self.assertEqual(pl(rb"test\\ing\::more::and more\\.."),
+                         (rb"test\ing::more", rb"and more\\..", None))
+        self.assertEqual(pl(b"a:b:c:d::e"), (b"a:b:c:d", b"e", None))
+        self.assertEqual(pl(b"foobar"), (None, b"foobar", None))
+        self.assertEqual(pl(rb"hello\::there"), (None, rb"hello\::there", None))
+        self.assertEqual(pl(rb"foobar\\"), (None, rb"foobar\\", None))
 
         # test missing path and missing host
-        self.assertRaises(SetConnections.SetConnectionsException, pfd, rb"hello\:there::")
-        self.assertRaises(SetConnections.SetConnectionsException, pfd, b"::some/path/without/host")
+        self.assertIsNotNone(pl(rb"hello\:there::")[2])
+        self.assertIsNotNone(pl(b"::some/path/without/host")[2])
 
 
 if __name__ == "__main__":

--- a/testing/statisticstest.py
+++ b/testing/statisticstest.py
@@ -197,7 +197,7 @@ class IncStatTest(unittest.TestCase):
                        abs_output_dir)
         InternalBackup(1, 1, os.path.join(old_test_dir, b"stattest2"),
                        abs_output_dir,
-                       time.time() + 1)
+                       int(time.time()) + 1)
 
         rbdir = rpath.RPath(Globals.local_connection,
                             os.path.join(abs_output_dir, b"rdiff-backup-data"))

--- a/tools/crossversion/Vagrantfile
+++ b/tools/crossversion/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.define "oldrdiffbackup" do |oldrdiffbackup|
-    oldrdiffbackup.vm.box = "centos/6"
+    oldrdiffbackup.vm.box = "centos/7"
   end
 
   # Disable automatic box update checking. If you disable this, then
@@ -46,6 +46,8 @@ Vagrant.configure("2") do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/tools/crossversion/playbook-smoke-test.yml
+++ b/tools/crossversion/playbook-smoke-test.yml
@@ -56,10 +56,8 @@
     command: rdiff-backup --version
     delegate_to: localhost
 
-  - name: call local rdiff-backup --verbosity 9 (with expected failure)
-    command: rdiff-backup --verbosity 9
-    register: rb_res
-    failed_when: rb_res.rc != 1
+  - name: call local rdiff-backup info
+    command: rdiff-backup info
     delegate_to: localhost
 
   - name: check that the remote rdiff-backup works


### PR DESCRIPTION
As the subject says, this PR is a further step towards having proper action plugins.
The architecture documentation has been completed, and the implementation has been progressed.
I still reserve the implementation of `action.run()` for a further PR because it goes quite deeper into the current code, and I have reached a state which passes the tests, so I'd like it committed to master before I continue.

As a side note, I also introduced more understandable log levels, deprecating some of the old ones, which (I think) were too many to keep in mind (I'll formalize this once I'll properly define the log -plugin- interface):
    ERROR = 1
    WARNING = 2
    DEFAULT = 3
    INFO = 5
    DEBUG = 9