### PR TITLE
Fix issue with temporary bytes path under Windows

### DIFF
--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -344,7 +344,10 @@ def _parse_cmdlineoptions_compat200(arglist):  # noqa: C901
             Log.FatalError(
                 "Temporary directory '{dir}' doesn't exist.".format(
                     dir=arglist.tempdir))
-        tempfile.tempdir = os.fsencode(arglist.tempdir)
+        # At least until Python 3.10, the module tempfile doesn't work properly,
+        # especially under Windows, if tempdir is stored as bytes.
+        # See https://github.com/python/cpython/pull/20442
+        tempfile.tempdir = arglist.tempdir
 
     # handle selection options
     if (arglist.action in ('backup', 'compare', 'restore')

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -127,7 +127,7 @@ def _set_security_level(action, cmdpairs):
     if action == "backup" or action == "check-destination-dir":
         if bothlocal(cp1, cp2) or bothremote(cp1, cp2):
             sec_level = "minimal"
-            rdir = tempfile.gettempdir()
+            rdir = tempfile.gettempdirb()
         elif islocal(cp1):
             sec_level = "read-only"
             rdir = getpath(cp1)
@@ -137,7 +137,7 @@ def _set_security_level(action, cmdpairs):
     elif action == "restore" or action == "restore-as-of":
         if len(cmdpairs) == 1 or bothlocal(cp1, cp2) or bothremote(cp1, cp2):
             sec_level = "minimal"
-            rdir = tempfile.gettempdir()
+            rdir = tempfile.gettempdirb()
         elif islocal(cp1):
             sec_level = "read-only"
             Main.restore_set_root(
@@ -152,7 +152,7 @@ def _set_security_level(action, cmdpairs):
     elif action == "mirror":
         if bothlocal(cp1, cp2) or bothremote(cp1, cp2):
             sec_level = "minimal"
-            rdir = tempfile.gettempdir()
+            rdir = tempfile.gettempdirb()
         elif islocal(cp1):
             sec_level = "read-only"
             rdir = getpath(cp1)
@@ -166,7 +166,7 @@ def _set_security_level(action, cmdpairs):
             "verify"
     ]:
         sec_level = "minimal"
-        rdir = tempfile.gettempdir()
+        rdir = tempfile.gettempdirb()
     else:
         raise RuntimeError("Unknown action '{act}'.".format(act=action))
 


### PR DESCRIPTION
FIX: setting tempdir under Windows might fail with error about mix of bytes and str, closes #540

The error was due to tempfile module not properly supporting bytes
paths.

@rstarkov you can apply the diff more or less one-to-one to your code. Actually, removing the fsencode in Main.py should be sufficient, because the RPath instantiation using rdir in the Security.py module "swallows" str, but `gettempdirb` makes it more explicit that we want bytes, even if str is acceptable.