### PR TITLE
When using the --remove-older-than option with --tempdir, the --tempdir flag is not honored

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -993,6 +993,7 @@ class RPath(RORPath):
 
         # we have to create our own "uniqueness" as tempfile.mktemp is
         # obsolete and we just want a name agnostic regarding file vs. dir
+        import tempfile
         while True:
             if self.__class__._temp_file_index > 100000000:
                 log.Log("Warning: Resetting tempfile index", 2)

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1001,9 +1001,9 @@ class RPath(RORPath):
 
             # here to catch the bytes string passed via cli opts
             if type(tempfile.tempdir) == bytes:
-              tempdir = tempfile.tempdir.decode()
+                tempdir = tempfile.tempdir.decode()
             else:
-              tempdir = tempfile.tempdir
+                tempdir = tempfile.tempdir
 
             tf = self.append(os.path.join(tempdir, 'rdiff-backup.tmp.{index:d}'.format(
                              index=self.__class__._temp_file_index)))

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1001,7 +1001,7 @@ class RPath(RORPath):
                 log.Log("Warning: Resetting tempfile index", 2)
                 self.__class__._temp_file_index = 0
 
-            if tempfile.tempdir and (shutil.disk_usage(self).free == 0):
+            if tempfile.tempdir and (shutil.disk_usage(self.path).free == 0):
                 # here to catch the bytes string passed via cli opts
                 if type(tempfile.tempdir) == bytes:
                     tempdir = tempfile.tempdir.decode()

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -997,8 +997,15 @@ class RPath(RORPath):
             if self.__class__._temp_file_index > 100000000:
                 log.Log("Warning: Resetting tempfile index", 2)
                 self.__class__._temp_file_index = 0
-            tf = self.append('rdiff-backup.tmp.{index:d}'.format(
-                             index=self.__class__._temp_file_index))
+
+            # here to catch the bytes string passed via cli opts
+            if type(tempfile.tempdir) == bytes:
+              tempdir = tempfile.tempdir.decode()
+            else:
+              tempdir = tempfile.tempdir
+
+            tf = self.append(os.path.join(tempdir, 'rdiff-backup.tmp.{index:d}'.format(
+                             index=self.__class__._temp_file_index)))
             self.__class__._temp_file_index += 1
             if not tf.lstat():
                 return tf

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1000,21 +1000,25 @@ class RPath(RORPath):
                 log.Log("Warning: Resetting tempfile index", 2)
                 self.__class__._temp_file_index = 0
 
+            # When the file system hosting the rdiff-backup-data directory
+            # is full and when the --tempdir flag is defined, attempt to save
+            # temporary files on a different path / file system.
             if tempfile.tempdir and (shutil.disk_usage(self.path).free == 0):
-                # here to catch the bytes string passed via cli opts
+                # If tempfile.tempdir is manually passed in via the --tempdir
+                # cli flag, it defaults being a bytes string, as such we need to
+                # convert the target path to a string first
                 if type(tempfile.tempdir) == bytes:
-                    tempdir = tempfile.tempdir.decode()
+                    tempdir = os.fsdecode(tempfile.tempdir)
                 else:
                     tempdir = tempfile.tempdir
             else:
                 tempdir = None
 
+            _tf = 'rdiff-backup.tmp.{index:d}'.format(index=self.__class__._temp_file_index)
             if not tempdir:
-                tf = self.append('rdiff-backup.tmp.{index:d}'.format(
-                                 index=self.__class__._temp_file_index))
+                tf = self.append(_tf)
             else:
-                tf = self.append(os.path.join(tempdir, 'rdiff-backup.tmp.{index:d}'.format(
-                                 index=self.__class__._temp_file_index)))
+                tf = os.path.join(tempdir, _tf)
             self.__class__._temp_file_index += 1
             if not tf.lstat():
                 return tf

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1001,7 +1001,7 @@ class RPath(RORPath):
                 log.Log("Warning: Resetting tempfile index", 2)
                 self.__class__._temp_file_index = 0
 
-            if tempfile.tempdir and (shutil.disk_usage.free == 0):
+            if tempfile.tempdir and (shutil.disk_usage(self).free == 0):
                 # here to catch the bytes string passed via cli opts
                 if type(tempfile.tempdir) == bytes:
                     tempdir = tempfile.tempdir.decode()

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -34,12 +34,14 @@ are dealing with are local or remote.
 
 """
 
-import os
-import stat
-import re
-import gzip
-import time
 import errno
+import gzip
+import os
+import re
+import shutil
+import stat
+import tempfile
+import time
 from . import Globals, Time, log, user_group, C
 
 try:
@@ -982,9 +984,6 @@ class RPath(RORPath):
         return self.__class__(self.conn, self.base, index, {'type': None})
 
     def get_temp_rpath(self, sibling=False):
-        import tempfile
-        import shutil
-
         """Return new temp rpath in given or parent directory"""
         assert self.conn is Globals.local_connection, (
             "Function must be called locally not over {conn}.".format(

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1007,10 +1007,7 @@ class RPath(RORPath):
                 # If tempfile.tempdir is manually passed in via the --tempdir
                 # cli flag, it defaults being a bytes string, as such we need to
                 # convert the target path to a string first
-                if type(tempfile.tempdir) == bytes:
-                    tempdir = os.fsdecode(tempfile.tempdir)
-                else:
-                    tempdir = tempfile.tempdir
+                tempdir = os.fsdecode(tempfile.tempdir)
             else:
                 tempdir = None
 


### PR DESCRIPTION
When using the --remove-older-than option with --tempdir, the --tempdir flag is not honored causing it to default to $BACKUPS_PATH. That's fine until the disk hosting the backups goes out of space, make sure the --tempdir flag is really taken into account when used.