### PR TITLE
Get rid of spurious resource warnings

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -41,6 +41,10 @@ __cmd_schema_no_compress = b"ssh {h} rdiff-backup --server"
 # The first is None because it is the local connection.
 __conn_remote_cmds = [None]
 
+# keep a list of sub-processes running; we don't use it, it's only to avoid
+# "ResourceWarning: subprocess N is still running" from subprocess library
+_processes = []
+
 
 class SetConnectionsException(Exception):
     pass
@@ -259,6 +263,7 @@ def _init_connection(remote_cmd):
     like global settings, its connection number, and verbosity.
 
     """
+    global _processes
     if not remote_cmd:
         return Globals.local_connection
 
@@ -280,6 +285,8 @@ def _init_connection(remote_cmd):
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE)
         (stdin, stdout) = (process.stdin, process.stdout)
+        # only to avoid resource warnings about subprocess still running
+        _processes.append(process)
     except OSError:
         (stdin, stdout) = (None, None)
     conn_number = len(Globals.connections)

--- a/testing/connectiontest.py
+++ b/testing/connectiontest.py
@@ -1,8 +1,9 @@
-import unittest
-import tempfile
 import os
 import sys
 import subprocess
+import tempfile
+import time
+import unittest
 from commontest import old_test_dir, abs_test_dir
 from rdiff_backup.connection import LowLevelPipeConnection, PipeConnection, \
     VirtualFile, SetConnections
@@ -184,6 +185,7 @@ class PipeConnectionTest(unittest.TestCase):
     def tearDown(self):
         """Bring down connection"""
         self.conn.quit()
+        time.sleep(0.1)  # give the process time to quit
         if (self.p.poll() is None):
             self.p.terminate()
 

--- a/testing/server.py
+++ b/testing/server.py
@@ -34,4 +34,4 @@ except (OSError, IOError, ImportError):
     raise
 
 rdiff_backup.Globals.security_level = "override"
-PipeConnection(sys.stdin.buffer, sys.stdout.buffer).Server()
+sys.exit(PipeConnection(sys.stdin.buffer, sys.stdout.buffer).Server())


### PR DESCRIPTION
FIX: get rid of spurious resource warnings due to subprocess still running, closes #165