### PR TITLE
Refactor Main.py into the actions' run() methods

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -54,13 +54,13 @@ rdiff-backup FAQ
       0   No information given
       1   Fatal Errors displayed
       2   Warnings
-      3   Important messages, and maybe later some global statistics (default)
+      3   Important notes, and maybe later some global statistics (default)
       4   Some global settings, miscellaneous messages (obsolete)
-      5   Mentions which files were changed
+      5   Mentions which files were changed, and other info
       6   More information on each file processed (obsolete)
       7   More information on various things (obsolete)
-      8   (not used)
-      9   Details on which objects are moving across the connection, debug (with timestamp)
+      8   Debug, without timestamp
+      9   Also debug, but with timestamp
       --- ----------------------------------------------------------------------
 
 2.  **[Is rdiff-backup backwards compatible?]{#compatible}**

--- a/docs/arch/plugins_actions.md
+++ b/docs/arch/plugins_actions.md
@@ -67,9 +67,11 @@ The Action class has the following interface:
 
   This context object has the following interface, usable through the
   connection(s) started by `connect()`:
-    * `self.check()` to validate the environment before doing changes.
+    * `self.check()` to validate the environment before doing _any_ changes.
+      The check method continues to verify the environment and report as many issues as it can, as to help the user to fix them at once.
       It returns 0 in case of success, else an integer to be used as exit code.
-    * `self.setup()` still doesn't do changes but prepares the environment.
+    * `self.setup()` prepares the environment (define variables, etc), it might create empty directories and logfiles, but it can't lead under any circumstances to a broken repository requiring a regression.
+      The setup method returns as soon as it finds an issue and doesn't try to continue.
       It returns 0 in case of success, else an integer to be used as exit code.
     * `self.run()` finally does whatever the action is supposed to do.
       It might return 0 in case of success, else an integer to be used as exit
@@ -80,8 +82,7 @@ The Action class has the following interface:
 > **NOTE:** the context object doesn't need a "cleanup" action as clean-up is to
   be done as part of the `__exit__` method provided by the context manager.
 
-Of course, action classes inheriting from the BaseAction class don't need to
-define all aspects themselves, making the life of plug-in developers easier.
+Of course, action classes inheriting from the BaseAction class don't need to define all aspects themselves, making the life of plug-in developers easier.
 
 > **NOTE:** more information is provided with `pydoc rdiffbackup.actions`.
 
@@ -107,4 +108,4 @@ with action.connect() as conn_act:
 # implicit context_manager.__exit__(exc_type, exc_val, exc_tb)
 ```
 
-> **TIP:** the actual code can be found in `rdiff_backup.Main.main_run()`.
+> **TIP:** the actual code can be found in `rdiff_backup.Main._main_run()`.

--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,7 @@ setup(
     download_url="https://github.com/rdiff-backup/rdiff-backup/releases",
     python_requires='~=3.6',
     platforms=['linux', 'win32'],
-    packages=["rdiff_backup", "rdiffbackup", "rdiffbackup.actions", "rdiffbackup.utils"],
+    packages=["rdiff_backup", "rdiffbackup", "rdiffbackup.actions", "rdiffbackup.utils", "rdiffbackup.locations"],
     package_dir={"": "src"},  # tell distutils packages are under src
     ext_modules=[
         Extension("rdiff_backup.C", ["src/cmodule.c"]),

--- a/src/rdiff-backup
+++ b/src/rdiff-backup
@@ -29,4 +29,4 @@ except ImportError:
 
 # the __no_execute__ flag is used for tests
 if __name__ == "__main__" and "__no_execute__" not in globals():
-    rdiff_backup.Main.main_run(sys.argv[1:])
+    rdiff_backup.Main.main_run_and_exit(sys.argv[1:])

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -206,10 +206,6 @@ use_compatible_timestamps = 0
 
 allow_duplicate_timestamps = False
 
-# If true, emit output intended to be easily readable by a
-# computer.  False means output is intended for humans.
-parsable_output = None
-
 # If true, then hardlinks will be preserved to mirror and recorded
 # in the increments directory.  There is also a difference here
 # between None and 0.  When restoring, None or 1 means to preserve

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -299,9 +299,7 @@ def _parse_cmdlineoptions_compat200(arglist):  # noqa: C901
 
 def _take_action(rps):
     """Do whatever action says"""
-    if _action.startswith("compare"):
-        action_result = _action_compare(_action, rps[0], rps[1])
-    elif _action == "list-at-time":
+    if _action == "list-at-time":
         action_result = _action_list_at_time(rps[0])
     elif _action == "list-changed-since":
         action_result = _action_list_changed_since(rps[0])
@@ -440,39 +438,6 @@ def _action_list_at_time(rp):
     inc_rp = mirror_rp.append_path(b"increments", _restore_index)
     for rorp in rp.conn.restore.ListAtTime(mirror_rp, inc_rp, rest_time):
         print(rorp.get_safeindexpath())
-
-
-def _action_compare(compare_type, src_rp, dest_rp, compare_time=None):
-    """Compare metadata in src_rp with metadata of backup session
-
-    Prints to stdout whenever a file in the src_rp directory has
-    different metadata than what is recorded in the metadata for the
-    appropriate session.
-
-    Session time is read from _restore_timestr if compare_time is None.
-
-    """
-    dest_rp = _require_root_set(dest_rp, 1)
-    if not compare_time:
-        try:
-            compare_time = Time.genstrtotime(_restore_timestr)
-        except Time.TimeException as exc:
-            Log.FatalError(str(exc))
-
-    mirror_rp = restore_root.new_index(_restore_index)
-    inc_rp = Globals.rbdir.append_path(b"increments", _restore_index)
-    _backup_set_select(src_rp)  # Sets source rorp iterator
-    if compare_type == "compare":
-        compare_func = compare.Compare
-    elif compare_type == "compare-hash":
-        compare_func = compare.Compare_hash
-    elif compare_type == "compare-full":
-        compare_func = compare.Compare_full
-    else:
-        raise ValueError(
-            "Comparaison type '{comp}' must be one of compare, "
-            "compare-hash or compare-full.".format(comp=compare_type))
-    return compare_func(src_rp, mirror_rp, inc_rp, compare_time)
 
 
 def _action_verify(dest_rp, verify_time=None):

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -195,6 +195,9 @@ def _parse_cmdlineoptions_compat200(arglist):  # noqa: C901
     if arglist.action in ('backup'):
         Globals.set("file_statistics", arglist.file_statistics)
         Globals.set("print_statistics", arglist.print_statistics)
+    if arglist.action in ('regress'):
+        Globals.set("allow_duplicate_timestamps",
+                    arglist.allow_duplicate_timestamps)
     Globals.set("null_separator", arglist.null_separator)
     Globals.set("use_compatible_timestamps", arglist.use_compatible_timestamps)
     Globals.set("do_fsync", arglist.fsync)

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -300,8 +300,6 @@ def _take_action(rps):
     """Do whatever action says"""
     if _action == "remove-older-than":
         action_result = _action_remove_older_than(rps[0])
-    elif _action == "verify":
-        action_result = _action_verify(rps[0])
     else:
         raise ValueError("Unknown action " + _action)
     return action_result
@@ -357,17 +355,3 @@ def _rot_require_rbdir_base(rootrp):
         Log.FatalError("Increments for directory %s cannot be removed "
                        "separately.\nInstead run on entire directory %s." %
                        (rootrp.get_safepath(), restore_root.get_safepath()))
-
-
-def _action_verify(dest_rp, verify_time=None):
-    """Check the hashes of the regular files against mirror_metadata"""
-    dest_rp = _require_root_set(dest_rp, 1)
-    if not verify_time:
-        try:
-            verify_time = Time.genstrtotime(_restore_timestr)
-        except Time.TimeException as exc:
-            Log.FatalError(str(exc))
-
-    mirror_rp = restore_root.new_index(_restore_index)
-    inc_rp = Globals.rbdir.append_path(b"increments", _restore_index)
-    return dest_rp.conn.compare.Verify(mirror_rp, inc_rp, verify_time)

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -299,9 +299,7 @@ def _parse_cmdlineoptions_compat200(arglist):  # noqa: C901
 
 def _take_action(rps):
     """Do whatever action says"""
-    if _action == "check-destination-dir":
-        action_result = _action_check_dest(rps[0])
-    elif _action.startswith("compare"):
+    if _action.startswith("compare"):
         action_result = _action_compare(_action, rps[0], rps[1])
     elif _action == "list-at-time":
         action_result = _action_list_at_time(rps[0])
@@ -489,22 +487,6 @@ def _action_verify(dest_rp, verify_time=None):
     mirror_rp = restore_root.new_index(_restore_index)
     inc_rp = Globals.rbdir.append_path(b"increments", _restore_index)
     return dest_rp.conn.compare.Verify(mirror_rp, inc_rp, verify_time)
-
-
-def _action_check_dest(dest_rp):
-    """Check the destination directory, """
-    dest_rp = _require_root_set(dest_rp, 0)
-    need_check = _checkdest_need_check(dest_rp)
-    if need_check is None:
-        Log("No destination dir found at {ddir}.".format(
-            ddir=dest_rp.get_safepath()), 1)
-        return 1
-    elif need_check == 0:
-        Log("Destination dir {ddir} does not need checking.".format(
-            ddir=dest_rp.get_safepath()), 2)
-        return 0
-    _init_user_group_mapping(dest_rp.conn)
-    dest_rp.conn.regress.Regress(dest_rp)
 
 
 def _checkdest_need_check(dest_rp):

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -299,9 +299,7 @@ def _parse_cmdlineoptions_compat200(arglist):  # noqa: C901
 
 def _take_action(rps):
     """Do whatever action says"""
-    if _action == "calculate-average":
-        action_result = _action_calculate_average(rps)
-    elif _action == "check-destination-dir":
+    if _action == "check-destination-dir":
         action_result = _action_check_dest(rps[0])
     elif _action.startswith("compare"):
         action_result = _action_compare(_action, rps[0], rps[1])
@@ -365,14 +363,6 @@ def _action_list_increment_sizes(rp):
     """Print out a summary of the increments """
     rp = _require_root_set(rp, 1)
     print(manage.list_increment_sizes(restore_root, _restore_index))
-
-
-def _action_calculate_average(rps):
-    """Print out the average of the given statistics files"""
-    statobjs = [statistics.StatsObj().read_stats_from_rp(rp) for rp in rps]
-    average_stats = statistics.StatsObj().set_to_average(statobjs)
-    print(average_stats.get_stats_logstring(
-        "Average of %d stat files" % len(rps)))
 
 
 def _action_remove_older_than(rootrp):

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -190,6 +190,8 @@ def _parse_cmdlineoptions_compat200(arglist):  # noqa: C901
     else:
         Globals.set("no_compression_regexp_string",
                     os.fsencode(actions.DEFAULT_NOT_COMPRESSED_REGEXP))
+    if arglist.action in ('server'):
+        Globals.server = True
     if arglist.action in ('backup'):
         Globals.set("file_statistics", arglist.file_statistics)
         Globals.set("print_statistics", arglist.print_statistics)

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -140,13 +140,14 @@ def _set_security_level(security_class, cmdpairs):
             rdir = tempfile.gettempdirb()
         elif islocal(cp1):
             sec_level = "read-only"
-            # FIXME it shouldn't be necessary to call back Main's function.
-            Main.restore_set_root(
-                rpath.RPath(Globals.local_connection, getpath(cp1)))
-            if Main.restore_root:
-                rdir = Main.restore_root.path
-            else:
-                log.Log.FatalError("Invalid restore directory")
+            rp1 = rpath.RPath(Globals.local_connection,  getpath(cp1))
+            (base_dir, restore_index, restore_type) = rp1.get_repository_dirs()
+            if restore_type is None:
+                # the error will be catched later more cleanly, so that the
+                # connections can be properly closed
+                log.Log("Invalid restore directory '{path}'".format(
+                    path=getpath(cp1)), log.Log.ERROR)
+            rdir = base_dir.path
         else:  # cp2 is local but not cp1
             sec_level = "all"
             rdir = getpath(cp2)

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -19,7 +19,7 @@
 """Functions to make sure remote requests are kosher"""
 
 import tempfile
-from . import Globals, Main, rpath, log
+from . import Globals, log, rpath
 
 
 class Violation(Exception):
@@ -140,7 +140,7 @@ def _set_security_level(security_class, cmdpairs):
             rdir = tempfile.gettempdirb()
         elif islocal(cp1):
             sec_level = "read-only"
-            rp1 = rpath.RPath(Globals.local_connection,  getpath(cp1))
+            rp1 = rpath.RPath(Globals.local_connection, getpath(cp1))
             (base_dir, restore_index, restore_type) = rp1.get_repository_dirs()
             if restore_type is None:
                 # the error will be catched later more cleanly, so that the

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -387,6 +387,7 @@ class PipeConnection(LowLevelPipeConnection):
         Globals.connections.append(self)
         log.Log("Starting server", 6)
         self._get_response(-1)
+        return 0  # all is well...
 
     # @API(reval, 200)
     def reval(self, function_string, *args):

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -37,9 +37,9 @@ class Logger:
     """All functions which deal with logging"""
     ERROR = 1
     WARNING = 2
-    DEFAULT = 3
+    NOTE = 3
     INFO = 5
-    DEBUG = 9
+    DEBUG = 8  # we reserve 9 for adding the timestamp
 
     def __init__(self):
         self.log_file_open = None

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -123,7 +123,8 @@ class MirrorStruct:
     @classmethod
     def set_mirror_select(cls, target_rp, select_opts, *filelists):
         """Initialize the mirror selection object"""
-        assert select_opts, "If no selection options, don't use selector"
+        if not select_opts:
+            return  # nothing to do...
         cls._select = selection.Select(target_rp)
         cls._select.parse_selection_args(select_opts, filelists)
 
@@ -235,6 +236,8 @@ class TargetStruct:
     @classmethod
     def set_target_select(cls, target, select_opts, *filelists):
         """Return a selection object iterating the rorpaths in target"""
+        if not select_opts:
+            return  # nothing to do...
         cls._select = selection.Select(target)
         cls._select.parse_selection_args(select_opts, filelists)
 

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -996,8 +996,7 @@ class RPath(RORPath):
                     return (self, [], None)
                 else:
                     # base_dir is the directory above the data directory
-                    base_dir = rpath.RPath(self.conn,
-                                           b"/".join(path_list[:data_idx]))
+                    base_dir = RPath(self.conn, b"/".join(path_list[:data_idx]))
                     # base_index is the path within the increments directory,
                     # replacing the name of the increment with the name of the
                     # file it represents

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1016,8 +1016,8 @@ class RPath(RORPath):
                 if (parent_rp.lstat() and parent_rp.isdir()
                         and b"rdiff-backup-data" in parent_rp.listdir()):
                     return (parent_rp, path_list[-element:], "subdir")
-            log.Log("Path '{rp}' couldn't be identified as fitting "
-                    "for a restore action".format(
+            log.Log("Path '{rp}' couldn't be identified as being within "
+                    "an existing backup repository".format(
                         rp=self.get_safepath()), log.Log.ERROR)
             return (self, [], None)
 

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -400,8 +400,8 @@ class BaseAction:
         beyond what argparse can do.
         Return 0 if everything looked good, else an error code.
 
-        Try to check everything before returning and not force the user to fix their
-        entries step by step.
+        Try to check everything before returning and not force the user to fix
+        their entries step by step.
         """
         if self.values.action == self.name:
             return 0

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -379,9 +379,9 @@ class BaseAction:
         Returns False to propagate potential exception, else True.
         """
         self.log("Cleaning up", self.log.INFO)
-        self.errlog.close()
-        self.log.close_logfile()
         if self.security != "server":
+            self.errlog.close()
+            self.log.close_logfile()
             SetConnections.CloseConnections()
 
         return False

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -27,8 +27,10 @@ import argparse
 import os
 import sys
 import yaml
+from rdiff_backup import (
+    Globals, rpath, Security, SetConnections, Time
+)
 from rdiffbackup.utils.argopts import BooleanOptionalAction, SelectAction
-from rdiff_backup import Globals, rpath, Security, SetConnections, Time
 
 # The default regexp for not compressing those files
 # compat200: it is also used by Main.py to avoid having a 2nd default
@@ -513,6 +515,23 @@ class BaseAction:
             self.values.group_mapping_file)
         dest_conn.user_group.init_group_mapping(
             group_mapping_string, self.values.preserve_numerical_ids)
+
+    def _get_parsed_time(self, timestr, ref_rp=None):
+        """
+        Parse time string, potentially using the given remote path as reference
+
+        Returns None if the time string couldn't be parsed, else the time in
+        seconds.
+        The reference remote path is used when the time string consists in a
+        number of past backups.
+        """
+        try:
+            return Time.genstrtotime(timestr, rp=ref_rp)
+        except Time.TimeException as exc:
+            self.log("Time string '{tstr}' couldn't be parsed "
+                     "due to '{exc}'".format(tstr=timestr, exc=exc),
+                     self.log.ERROR)
+            return None
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -100,6 +100,11 @@ class BackupAction(actions.BaseAction):
             self.source.base_dir, self.values.force)
         self.target.init_quoting(self.values.chars_to_quote)
         self._init_user_group_mapping(self.target.base_dir.conn)
+        previous_time = self.target.get_mirror_time()
+        if previous_time >= Time.curtime:
+            self.log("The last backup is not in the past. Aborting.",
+                     self.log.ERROR)
+            return 1
         if self.log.verbosity > 0:
             try:  # the target repository must be writable
                 self.log.open_logfile(

--- a/src/rdiffbackup/actions/calculate.py
+++ b/src/rdiffbackup/actions/calculate.py
@@ -18,9 +18,11 @@
 # 02110-1301, USA
 
 """
-A built-in rdiff-backup action plug-in to calculate average across multiple statistics files.
+A built-in rdiff-backup action plug-in to calculate average across multiple
+statistics files.
 """
 
+from rdiff_backup import statistics
 from rdiffbackup import actions
 
 
@@ -36,11 +38,26 @@ class CalculateAction(actions.BaseAction):
         subparser = super().add_action_subparser(sub_handler)
         subparser.add_argument(
             "--method", choices=["average"], default="average",
-            help="what to calculate from the different statistics")
+            help="what to calculate from the different session statistics")
         subparser.add_argument(
             "locations", metavar="STATISTIC_FILE", nargs="+",
-            help="locations of the statistic files to calculate from")
+            help="locations of the session statistic files to calculate from")
         return subparser
+
+    def run(self):
+        """
+        Print out the calculation of the given statistics files, according
+        to calculation method.
+        """
+        statobjs = [
+            statistics.StatsObj().read_stats_from_rp(loc)
+            for loc in self.connected_locations
+        ]
+        if self.values.method == "average":
+            calc_stats = statistics.StatsObj().set_to_average(statobjs)
+        print(calc_stats.get_stats_logstring(
+            "Average of %d stat files" % len(self.connected_locations)))
+        return 0
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -88,6 +88,11 @@ class CompareAction(actions.BaseAction):
         if return_code != 0:
             return return_code
 
+        # set the filesystem properties of the repository
+        self.target.base_dir.conn.fs_abilities.single_set_globals(
+            self.target.base_dir, 1)  # read_only=True
+        self.target.init_quoting(self.values.chars_to_quote)
+
         (select_opts, select_data) = selection.get_prepared_selections(
             self.values.selections)
         self.source.set_select(select_opts, select_data)

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -97,9 +97,9 @@ class CompareAction(actions.BaseAction):
         self.inc_rpath = self.target.data_dir.append_path(
             b'increments', self.target.restore_index)
 
-        self.compare_time = self._get_parsed_time(self.values.at,
-                                                  ref_rp=self.inc_rpath)
-        if self.compare_time is None:
+        self.action_time = self._get_parsed_time(self.values.at,
+                                                 ref_rp=self.inc_rpath)
+        if self.action_time is None:
             return 1
 
         return 0  # all is good
@@ -114,7 +114,7 @@ class CompareAction(actions.BaseAction):
         ret_code = compare_funcs[self.values.method](self.source.base_dir,
                                                      self.mirror_rpath,
                                                      self.inc_rpath,
-                                                     self.compare_time)
+                                                     self.action_time)
         return ret_code
 
 

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -23,7 +23,7 @@ a back-up repository with the current state of a directory.
 Comparaison can be done using metadata, file content or hashes.
 """
 
-from rdiff_backup import (compare, selection, Time)
+from rdiff_backup import (compare, selection)
 from rdiffbackup import actions
 from rdiffbackup.locations import (directory, repository)
 

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -97,13 +97,9 @@ class CompareAction(actions.BaseAction):
         self.inc_rpath = self.target.data_dir.append_path(
             b'increments', self.target.restore_index)
 
-        try:
-            self.compare_time = Time.genstrtotime(self.values.at,
-                                                  rp=self.inc_rpath)
-        except Time.TimeException as exc:
-            self.log("Time string '{tstr}' couldn't be parsed "
-                     "due to '{exc}'".format(tstr=self.values.at, exc=exc),
-                     self.log.ERROR)
+        self.compare_time = self._get_parsed_time(self.values.at,
+                                                  ref_rp=self.inc_rpath)
+        if self.compare_time is None:
             return 1
 
         return 0  # all is good

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -23,7 +23,9 @@ a back-up repository with the current state of a directory.
 Comparaison can be done using metadata, file content or hashes.
 """
 
+from rdiff_backup import (compare, selection, Time)
 from rdiffbackup import actions
+from rdiffbackup.locations import (directory, repository)
 
 
 class CompareAction(actions.BaseAction):
@@ -49,6 +51,75 @@ class CompareAction(actions.BaseAction):
             help="locations of SOURCE_DIR and backup REPOSITORY to compare"
                  " (same order as for a backup)")
         return subparser
+
+    def connect(self):
+        conn_value = super().connect()
+        if conn_value:
+            self.source = directory.ReadDir(self.connected_locations[0],
+                                            self.log, self.values.force)
+            self.target = repository.ReadRepo(self.connected_locations[1],
+                                              self.log, self.values.force)
+        return conn_value
+
+    def check(self):
+        # we try to identify as many potential errors as possible before we
+        # return, so we gather all potential issues and return only the final
+        # result
+        return_code = super().check()
+
+        # we verify that source directory and target repository are correct
+        return_code |= self.source.check()
+        return_code |= self.target.check()
+
+        return return_code
+
+    def setup(self):
+        # in setup we return as soon as we detect an issue to avoid changing
+        # too much
+        return_code = super().setup()
+        if return_code != 0:
+            return return_code
+
+        return_code = self.source.setup()
+        if return_code != 0:
+            return return_code
+
+        return_code = self.target.setup()
+        if return_code != 0:
+            return return_code
+
+        (select_opts, select_data) = selection.get_prepared_selections(
+            self.values.selections)
+        self.source.set_select(select_opts, select_data)
+
+        self.mirror_rpath = self.target.base_dir.new_index(
+            self.target.restore_index)
+        self.inc_rpath = self.target.data_dir.append_path(
+            b'increments', self.target.restore_index)
+
+        try:
+            self.compare_time = Time.genstrtotime(self.values.at,
+                                                  rp=self.inc_rpath)
+        except Time.TimeException as exc:
+            self.log("Time string '{tstr}' couldn't be parsed "
+                     "due to '{exc}'".format(tstr=self.values.at, exc=exc),
+                     self.log.ERROR)
+            return 1
+
+        return 0  # all is good
+
+    def run(self):
+        # call the right comparaison function for the chosen method
+        compare_funcs = {
+            "meta": compare.Compare,
+            "hash": compare.Compare_hash,
+            "full": compare.Compare_full
+        }
+        ret_code = compare_funcs[self.values.method](self.source.base_dir,
+                                                     self.mirror_rpath,
+                                                     self.inc_rpath,
+                                                     self.compare_time)
+        return ret_code
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -22,7 +22,10 @@ A built-in rdiff-backup action plug-in to output info, especially useful
 for documenting an issue.
 """
 
+import yaml
+
 from rdiffbackup import actions
+from rdiff_backup import Globals
 
 
 class InfoAction(actions.BaseAction):
@@ -36,8 +39,13 @@ class InfoAction(actions.BaseAction):
 
     def setup(self):
         # there is nothing to setup for the info action
-        pass
+        return 0
 
+    def run(self):
+        runtime_info = Globals.get_runtime_info()
+        print(yaml.safe_dump(runtime_info,
+                             explicit_start=True, explicit_end=True))
+        return 0
 
 def get_action_class():
     return InfoAction

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -47,5 +47,6 @@ class InfoAction(actions.BaseAction):
                              explicit_start=True, explicit_end=True))
         return 0
 
+
 def get_action_class():
     return InfoAction

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -98,12 +98,12 @@ class ListAction(actions.BaseAction):
 
         if self.values.entity == "files":
             if self.values.changed_since:
-                self.list_time = self._get_parsed_time(
+                self.action_time = self._get_parsed_time(
                     self.values.changed_since, ref_rp=self.inc_rpath)
             elif self.values.at:
-                self.list_time = self._get_parsed_time(
+                self.action_time = self._get_parsed_time(
                     self.values.at, ref_rp=self.inc_rpath)
-            if self.list_time is None:
+            if self.action_time is None:
                 return 1
 
         return 0  # all is good
@@ -142,14 +142,14 @@ class ListAction(actions.BaseAction):
     def _list_files_changed_since(self):
         """List all the files under rp that have changed since restoretime"""
         for rorp in self.source.base_dir.conn.restore.ListChangedSince(
-                self.mirror_rpath, self.inc_rpath, self.list_time):
+                self.mirror_rpath, self.inc_rpath, self.action_time):
             # This is a hack, see restore.ListChangedSince for rationale
             print(rorp.get_safeindexpath())
 
     def _list_files_at_time(self):
         """List files in archive under rp that are present at restoretime"""
         for rorp in self.source.base_dir.conn.restore.ListAtTime(
-                self.mirror_rpath, self.inc_rpath, self.list_time):
+                self.mirror_rpath, self.inc_rpath, self.action_time):
             print(rorp.get_safeindexpath())
 
 def get_action_class():

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -25,7 +25,7 @@ The module is named with an underscore at the end to avoid overwriting the
 builtin 'list' class.
 """
 
-from rdiff_backup import (Globals, manage, restore)
+from rdiff_backup import (manage, restore)
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
 from rdiffbackup.utils.argopts import BooleanOptionalAction
@@ -151,6 +151,7 @@ class ListAction(actions.BaseAction):
         for rorp in self.source.base_dir.conn.restore.ListAtTime(
                 self.mirror_rpath, self.inc_rpath, self.action_time):
             print(rorp.get_safeindexpath())
+
 
 def get_action_class():
     return ListAction

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -91,6 +91,11 @@ class ListAction(actions.BaseAction):
         if return_code != 0:
             return return_code
 
+        # set the filesystem properties of the repository
+        self.source.base_dir.conn.fs_abilities.single_set_globals(
+            self.source.base_dir, 1)  # read_only=True
+        self.source.init_quoting(self.values.chars_to_quote)
+
         self.mirror_rpath = self.source.base_dir.new_index(
             self.source.restore_index)
         self.inc_rpath = self.source.data_dir.append_path(

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -22,7 +22,7 @@ A built-in rdiff-backup action plug-in to regress a failed back-up from a
 back-up repository.
 """
 
-from rdiff_backup import (log, regress, Security)
+from rdiff_backup import (log, Security)
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
 
@@ -98,6 +98,7 @@ class RegressAction(actions.BaseAction):
             self.log("Given repository doesn't need to be regressed",
                      self.log.NOTE)
             return 0  # all is good
+
 
 def get_action_class():
     return RegressAction

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -95,8 +95,8 @@ class RegressAction(actions.BaseAction):
         if self.source.needs_regress():
             return self.source.regress()
         else:
-            self.log("Given repository doesn't need to be regressed.",
-                     self.log.DEFAULT)
+            self.log("Given repository doesn't need to be regressed",
+                     self.log.NOTE)
             return 0  # all is good
 
 def get_action_class():

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -74,6 +74,11 @@ class RegressAction(actions.BaseAction):
         if return_code != 0:
             return return_code
 
+        # set the filesystem properties of the repository
+        self.source.base_dir.conn.fs_abilities.single_set_globals(
+            self.source.base_dir, 0)  # read_only=False
+        self.source.init_quoting(self.values.chars_to_quote)
+
         # TODO validate how much of the following lines and methods
         # should go into the directory/repository modules
         self._init_user_group_mapping(self.source.base_dir.conn)

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -87,6 +87,11 @@ class RemoveAction(actions.BaseAction):
         if return_code != 0:
             return return_code
 
+        # set the filesystem properties of the repository
+        self.source.base_dir.conn.fs_abilities.single_set_globals(
+            self.source.base_dir, 0)  # read_only=False
+        self.source.init_quoting(self.values.chars_to_quote)
+
         # TODO validate how much of the following lines and methods
         # should go into the directory/repository modules
         if self.log.verbosity > 0:
@@ -150,7 +155,7 @@ class RemoveAction(actions.BaseAction):
                     ptim=pretty_times), self.log.NOTE)
         else:
             self.log("Deleting increment at time:\n{ptim}".format(
-                ptim=pretty_times), self.log.INFO)
+                ptim=pretty_times), self.log.NOTE)
         # make sure we don't delete current increment
         return times_in_secs[-1] + 1
 

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -138,12 +138,12 @@ class RestoreAction(actions.BaseAction):
         self.inc_rpath = self.source.data_dir.append_path(
             b'increments', self.source.restore_index)
         if self.values.at:
-            self.restore_time = self._get_parsed_time(self.values.at,
-                                                      ref_rp=self.inc_rpath)
-            if self.restore_time is None:
+            self.action_time = self._get_parsed_time(self.values.at,
+                                                     ref_rp=self.inc_rpath)
+            if self.action_time is None:
                 return 1
         elif self.values.increment:
-            self.restore_time = self.source.orig_path.getinctime()
+            self.action_time = self.source.orig_path.getinctime()
         else:  # this should have been catched in the check method
             self.log("This shouldn't happen but neither restore time nor "
                      "an increment have been identified so far", self.log.ERROR)
@@ -173,7 +173,7 @@ class RestoreAction(actions.BaseAction):
         try:
             restore.Restore(
                 self.source.base_dir.new_index(self.source.restore_index),
-                self.inc_rpath, self.target.base_dir, self.restore_time)
+                self.inc_rpath, self.target.base_dir, self.action_time)
         except IOError as exc:
             self.log("Could not complete restore due to\n{exc}".format(exc=exc),
                      self.log.ERROR)

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -22,7 +22,15 @@ A built-in rdiff-backup action plug-in to restore a certain state of a back-up
 repository to a directory.
 """
 
+from rdiff_backup import (
+    log,
+    restore,
+    selection,
+    Security,
+    Time,
+)
 from rdiffbackup import actions
+from rdiffbackup.locations import (directory, repository)
 
 
 class RestoreAction(actions.BaseAction):
@@ -33,8 +41,9 @@ class RestoreAction(actions.BaseAction):
     name = "restore"
     security = "restore"
     parent_parsers = [
-        actions.CREATION_PARSER, actions.COMPRESSION_PARSER, actions.SELECTION_PARSER,
-        actions.FILESYSTEM_PARSER, actions.USER_GROUP_PARSER,
+        actions.CREATION_PARSER, actions.COMPRESSION_PARSER,
+        actions.SELECTION_PARSER, actions.FILESYSTEM_PARSER,
+        actions.USER_GROUP_PARSER,
     ]
 
     @classmethod
@@ -51,6 +60,129 @@ class RestoreAction(actions.BaseAction):
             "locations", metavar="[[USER@]SERVER::]PATH", nargs=2,
             help="locations of backup REPOSITORY/INCREMENT and to which TARGET_DIR to restore")
         return subparser
+
+    def connect(self):
+        conn_value = super().connect()
+        if conn_value:
+            self.source = repository.ReadRepo(self.connected_locations[0],
+                                              self.log, self.values.force)
+            self.target = directory.WriteDir(self.connected_locations[1],
+                                             self.log, self.values.force,
+                                             self.values.create_full_path)
+        return conn_value
+
+    def check(self):
+        # we try to identify as many potential errors as possible before we
+        # return, so we gather all potential issues and return only the final
+        # result
+        return_code = super().check()
+
+        # we validate that the discovered restore type and the given options
+        # fit together
+        if self.source.restore_type == "inc":
+            if self.values.at:
+                self.log("You can't give an increment file and a time to restore "
+                         "at the same time.", self.log.ERROR)
+                return_code |= 1
+            elif not self.values.increment:
+                self.values.increment = True
+        elif self.source.restore_type in ("base", "subdir"):
+            if self.values.increment:
+                self.log("You can't use the --increment option and _not_ "
+                         "give an increment file", self.log.ERROR)
+                return_code |= 1
+            elif not self.values.at:
+                self.values.at = "now"
+
+        # we verify that source directory and target repository are correct
+        return_code |= self.source.check()
+        return_code |= self.target.check()
+
+        return return_code
+
+    def setup(self):
+        # in setup we return as soon as we detect an issue to avoid changing
+        # too much
+        return_code = super().setup()
+        if return_code != 0:
+            return return_code
+
+        return_code = self.source.setup()
+        if return_code != 0:
+            return return_code
+
+        return_code = self.target.setup()
+        if return_code != 0:
+            return return_code
+
+        # TODO validate how much of the following lines and methods
+        # should go into the directory/repository modules
+        try:
+            self.target.base_dir.conn.fs_abilities.restore_set_globals(
+                self.target.base_dir)
+        except IOError as exc:
+            self.log("Could not begin restore due to\n{exc}".format(exc=exc),
+                     self.log.ERROR)
+            return 1
+        self.source.init_quoting(self.values.chars_to_quote)
+        self._init_user_group_mapping(self.target.base_dir.conn)
+        if self.log.verbosity > 0:
+            try:  # the source repository could be read-only
+                self.log.open_logfile(
+                    self.source.data_dir.append("restore.log"))
+            except (log.LoggerError, Security.Violation) as exc:
+                self.log("Unable to open logfile due to '{exc}'".format(
+                    exc=exc), self.log.WARNING)
+
+        # we need now to identify the actual time of restore
+        self.inc_rpath = self.source.data_dir.append_path(
+            b'increments', self.source.restore_index)
+        if self.values.at:
+            try:
+                self.restore_time = Time.genstrtotime(self.values.at,
+                                                      rp=self.inc_rpath)
+            except Time.TimeException as exc:
+                self.log(str(exc), self.log.ERROR)
+                return 1
+        elif self.values.increment:
+            self.restore_time = self.source.orig_path.getinctime()
+        else:  # this should have been catched in the check method
+            self.log("This shouldn't happen but neither restore time nor "
+                     "an increment have been identified so far", self.log.ERROR)
+            return 1
+        (select_opts, select_data) = selection.get_prepared_selections(
+            self.values.selections)
+        # We must set both sides because restore filtering is different from
+        # select filtering.  For instance, if a file is excluded it should
+        # not be deleted from the target directory.
+        self.source.set_select(select_opts, select_data)
+        self.target.set_select(select_opts, select_data)
+
+        return 0  # all is good
+
+    def run(self):
+
+        # This is more a check than a part of run, but because backup does
+        # the regress in the run section, we also do the check here...
+        if self.source.needs_regress():
+            # source could be read-only, so we don't try to regress it
+            self.log("Previous backup to {rp} seems to have failed. "
+                     "Use rdiff-backup to 'regress' first the failed backup, "
+                     "then try again to restore.".format(
+                         rp=self.source.base_dir.get_safepath()),
+                     self.log.ERROR)
+            return 1
+        try:
+            restore.Restore(
+                self.source.base_dir.new_index(self.source.restore_index),
+                self.inc_rpath, self.target.base_dir, self.restore_time)
+        except IOError as exc:
+            self.log("Could not complete restore due to\n{exc}".format(exc=exc),
+                     self.log.ERROR)
+            return 1
+        else:
+            self.log("Restore successfully finished", self.log.INFO)
+            return 0
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -138,11 +138,9 @@ class RestoreAction(actions.BaseAction):
         self.inc_rpath = self.source.data_dir.append_path(
             b'increments', self.source.restore_index)
         if self.values.at:
-            try:
-                self.restore_time = Time.genstrtotime(self.values.at,
-                                                      rp=self.inc_rpath)
-            except Time.TimeException as exc:
-                self.log(str(exc), self.log.ERROR)
+            self.restore_time = self._get_parsed_time(self.values.at,
+                                                      ref_rp=self.inc_rpath)
+            if self.restore_time is None:
                 return 1
         elif self.values.increment:
             self.restore_time = self.source.orig_path.getinctime()

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -147,7 +147,7 @@ class RestoreAction(actions.BaseAction):
         # We must set both sides because restore filtering is different from
         # select filtering.  For instance, if a file is excluded it should
         # not be deleted from the target directory.
-        self.source.set_select(select_opts, select_data)
+        self.source.set_select(select_opts, select_data, self.target.base_dir)
         self.target.set_select(select_opts, select_data)
 
         return 0  # all is good

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -22,13 +22,7 @@ A built-in rdiff-backup action plug-in to restore a certain state of a back-up
 repository to a directory.
 """
 
-from rdiff_backup import (
-    log,
-    restore,
-    selection,
-    Security,
-    Time,
-)
+from rdiff_backup import (log, restore, selection, Security)
 from rdiffbackup import actions
 from rdiffbackup.locations import (directory, repository)
 

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -21,7 +21,10 @@
 A built-in rdiff-backup action plug-in to start a remote server process.
 """
 
+import sys
+
 from rdiffbackup import actions
+from rdiff_backup import connection
 
 
 class ServerAction(actions.BaseAction):
@@ -31,6 +34,10 @@ class ServerAction(actions.BaseAction):
     name = "server"
     security = "server"
     # server has no specific sub-options
+
+    def run(self):
+        return connection.PipeConnection(sys.stdin.buffer,
+                                         sys.stdout.buffer).Server()
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/test.py
+++ b/src/rdiffbackup/actions/test.py
@@ -71,6 +71,9 @@ class TestAction(actions.BaseAction):
         else:
             return return_code
 
+    def run(self):
+        result = SetConnections.TestConnections(self.connected_locations)
+        return result
 
 def get_action_class():
     return TestAction

--- a/src/rdiffbackup/actions/test.py
+++ b/src/rdiffbackup/actions/test.py
@@ -75,5 +75,6 @@ class TestAction(actions.BaseAction):
         result = SetConnections.TestConnections(self.connected_locations)
         return result
 
+
 def get_action_class():
     return TestAction

--- a/src/rdiffbackup/actions/verify.py
+++ b/src/rdiffbackup/actions/verify.py
@@ -76,6 +76,11 @@ class VerifyAction(actions.BaseAction):
         if return_code != 0:
             return return_code
 
+        # set the filesystem properties of the repository
+        self.source.base_dir.conn.fs_abilities.single_set_globals(
+            self.source.base_dir, 1)  # read_only=True
+        self.source.init_quoting(self.values.chars_to_quote)
+
         self.mirror_rpath = self.source.base_dir.new_index(
             self.source.restore_index)
         self.inc_rpath = self.source.data_dir.append_path(

--- a/src/rdiffbackup/arguments.py
+++ b/src/rdiffbackup/arguments.py
@@ -47,14 +47,14 @@ def parse(args, version_string, generic_parsers, parent_parsers, actions_dict=No
     """
     # we try to recognize if the user wants the old or the new parameters
     # it's the case if --new is explicitly given, or if any parameter starts
-    # with an @ (meaning read from file), or if api-version is used, or if
-    # any of the action names is found in the parameters, without `--no-new`
-    # being found.
+    # with an @ (meaning read from file), or if api-version or help is used,
+    # or if any of the action names is found in the parameters,
+    # without `--no-new` being found.
     # note: `set1 & set2` is the intersection of two sets
     if ('--new' in args
             or (any(map(lambda x: x.startswith('@'), args)))
             or ('--no-new' not in args
-                and ('--api-version' in args
+                and ('--api-version' in args or '--help' in args
                      or (set(actions_dict.keys()) & set(args))))):
         return _parse_new(args, version_string, generic_parsers, actions_dict)
     else:

--- a/src/rdiffbackup/arguments.py
+++ b/src/rdiffbackup/arguments.py
@@ -109,7 +109,7 @@ def _parse_compat200(args, version_string, parent_parsers=[]):
     """
 
     DEPRECATION_MESSAGE = (
-        "CAUTION: this command line interface is deprecated and will "
+        "WARNING: this command line interface is deprecated and will "
         "disappear, start using the new one as described with '--new --help'."
     )
 

--- a/src/rdiffbackup/arguments.py
+++ b/src/rdiffbackup/arguments.py
@@ -201,7 +201,8 @@ def _parse_compat200(args, version_string, parent_parsers=[]):
     _make_values_like_new_compat200(values)
     _validate_number_locations_compat200(values, parser)
 
-    sys.stderr.write(DEPRECATION_MESSAGE + "\n")
+    if "--no-new" not in args:
+        sys.stderr.write(DEPRECATION_MESSAGE + "\n")
 
     return values
 

--- a/src/rdiffbackup/locations/__init__.py
+++ b/src/rdiffbackup/locations/__init__.py
@@ -21,6 +21,9 @@
 Generic classes for locations
 """
 
+import os
+
+
 class Location():
 
     def __init__(self, base_dir, log, force):
@@ -30,7 +33,22 @@ class Location():
 
 
 class ReadLocation(Location):
-    pass
+
+    def check(self):
+        return_code = 0
+        # check that the source exists and is a directory
+        if not self.base_dir.lstat():
+            self.log("Source path {rp} does not exist".format(
+                rp=self.base_dir.get_safepath()), self.log.ERROR)
+            return_code |= 1
+        elif not self.base_dir.isdir():
+            self.log("Source path {rp} is not a directory".format(
+                rp=self.base_dir.get_safepath()), self.log.ERROR)
+            return_code |= 1
+        return return_code
+
+    def setup(self):
+        return 0
 
 
 class WriteLocation(Location):
@@ -38,3 +56,46 @@ class WriteLocation(Location):
     def __init__(self, base_dir, log, force, create_full_path):
         super().__init__(base_dir, log, force)
         self.create_full_path = create_full_path
+
+    def check(self):
+        ret_code = 0
+
+        # check that target is a directory or doesn't exist
+        if (self.base_dir.lstat() and not self.base_dir.isdir()):
+            if self.force:
+                self.log(
+                    "Target {rp} exists but isn't a directory, "
+                    "and will be force deleted".format(
+                        rp=self.base_dir.get_safepath()),
+                    self.log.WARNING)
+            else:
+                self.log(
+                    "Target {rp} exists and is not a directory, "
+                    "call with '--force' to overwrite".format(
+                        rp=self.base_dir.get_safepath()),
+                    self.log.ERROR)
+                ret_code |= 1
+
+        return ret_code
+
+    def setup(self):
+        # make sure the target directory is present
+        try:
+            # if the target exists and isn't a directory, force delete it
+            if (self.base_dir.lstat() and not self.base_dir.isdir()
+                    and self.force):
+                self.base_dir.delete()
+
+            # if the target doesn't exist, create it
+            if not self.base_dir.lstat():
+                if self.create_full_path:
+                    self.base_dir.makedirs()
+                else:
+                    self.base_dir.mkdir()
+                self.base_dir.chmod(0o700)  # only read-writable by its owner
+        except os.error:
+            self.log("Unable to delete and/or create directory {rp}".format(
+                rp=self.base_dir.get_safepath()), self.log.ERROR)
+            return 1
+
+        return 0  # all is good

--- a/src/rdiffbackup/locations/__init__.py
+++ b/src/rdiffbackup/locations/__init__.py
@@ -1,0 +1,40 @@
+# Copyright 2021 the rdiff-backup project
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+
+"""
+Generic classes for locations
+"""
+
+class Location():
+
+    def __init__(self, base_dir, log, force):
+        self.base_dir = base_dir
+        self.log = log
+        self.force = force
+
+
+class ReadLocation(Location):
+    pass
+
+
+class WriteLocation(Location):
+
+    def __init__(self, base_dir, log, force, create_full_path):
+        super().__init__(base_dir, log, force)
+        self.create_full_path = create_full_path

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -24,7 +24,7 @@ This plug-in tests that all remote locations are properly reachable and
 usable for a back-up.
 """
 
-import sys
+import io
 from rdiffbackup import locations
 
 
@@ -36,58 +36,66 @@ class ReadDir(Dir, locations.ReadLocation):
     selections = []
     select_files = []
 
-    def check(self):
-        return_code = 0
-        # check that the source exists and is a directory
-        if not self.base_dir.lstat():
-            self.log("Source path {rp} does not exist".format(
-                rp=self.base_dir.get_safepath()), self.log.ERROR)
-            return_code |= 1
-        elif not self.base_dir.isdir():
-            self.log("Source path {rp} is not a directory".format(
-                rp=self.base_dir.get_safepath()), self.log.ERROR)
-            return_code |= 1
-        return return_code
-
-    def set_select(self, selections):
+    def set_select(self, select_opts, select_data):
         """
-        Accepts a list of selection tuple made of (selection method, parameter)
+        Set the selection and selection data on the directory
+
+        Accepts a tuple of two lists:
+        * one of selection tuple made of (selection method, parameter)
+        * and one of the content of the selection files
 
         Saves the selections list and makes it ready for usage on the source
         side over its connection.
         """
-        def sel_fl(filename):
-            """
-            Helper function for including/excluding filelists below
-            """
-            if filename is True:  # we really mean the boolean True
-                return sys.stdin.buffer
-            try:
-                return open(filename, "rb")  # files match paths hence bytes/bin
-            except IOError:
-                self.log.FatalError("Error opening file %s" % filename)
-
-        if selections:
-            # the following loop is a compatibility measure # compat200
-            for selection in selections:
-                if 'filelist' in selection[0]:
-                    if selection[0].endswith("-stdin"):
-                        self.selections.append((
-                            "--" + selection[0][:-6],  # remove '-stdin'
-                            "standard input"))
-                    else:
-                        self.selections.append(("--" + selection[0],
-                                                selection[1]))
-                    self.select_files.append(sel_fl(selection[1]))
-                else:
-                    self.selections.append(("--" + selection[0], selection[1]))
-        else:
-            self.selections = []
 
         # FIXME not sure we couldn't support symbolic links nowadays on Windows
         if self.base_dir.conn.os.name == 'nt':
             self.log("Symbolic links excluded by default on Windows",
-                     self.log.INFO)
-            self.selections.append(("--exclude-symbolic-links", None))
+                     self.log.DEFAULT)
+            select_opts.append(("--exclude-symbolic-links", None))
+        # FIXME we're retransforming bytes into a file pointer
         self.base_dir.conn.backup.SourceStruct.set_source_select(
-            self.base_dir, self.selections, *self.select_files)
+            self.base_dir, select_opts, *list(map(io.BytesIO, select_data)))
+
+
+class WriteDir(Dir, locations.WriteLocation):
+
+    def check(self):
+        ret_code = super().check()
+
+        # if the target is a non-empty existing directory
+        if (self.base_dir.lstat()
+                and self.base_dir.isdir()
+                and self.base_dir.listdir()):
+            if self.force:
+                self.log(
+                    "Target {rp} exists and isn't empty, "
+                    "content might be force overwritten by restore".format(
+                        rp=self.base_dir.get_safepath()),
+                    self.log.WARNING)
+            else:
+                self.log(
+                    "Target {rp} exists and isn't empty, "
+                    "call with '--force' to overwrite".format(
+                        rp=self.base_dir.get_safepath()),
+                    self.log.ERROR)
+                ret_code |= 1
+
+        return ret_code
+
+    def set_select(self, select_opts, select_data):
+        """
+        Set the selection and selection data on the directory
+
+        Accepts a tuple of two lists:
+        * one of selection tuple made of (selection method, parameter)
+        * and one of the content of the selection files
+
+        Saves the selections list and makes it ready for usage on the source
+        side over its connection.
+        """
+
+        # FIXME we're retransforming bytes into a file pointer
+        if select_opts:
+            self.base_dir.conn.restore.TargetStruct.set_target_select(
+                self.base_dir, select_opts, *list(map(io.BytesIO, select_data)))

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -51,7 +51,7 @@ class ReadDir(Dir, locations.ReadLocation):
         # FIXME not sure we couldn't support symbolic links nowadays on Windows
         if self.base_dir.conn.os.name == 'nt':
             self.log("Symbolic links excluded by default on Windows",
-                     self.log.DEFAULT)
+                     self.log.NOTE)
             select_opts.append(("--exclude-symbolic-links", None))
         # FIXME we're retransforming bytes into a file pointer
         self.base_dir.conn.backup.SourceStruct.set_source_select(

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -1,0 +1,93 @@
+# Copyright 2021 the rdiff-backup project
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+
+"""
+A built-in rdiff-backup action plug-in to test servers.
+
+This plug-in tests that all remote locations are properly reachable and
+usable for a back-up.
+"""
+
+import sys
+from rdiffbackup import locations
+
+
+class Dir():
+    pass
+
+
+class ReadDir(Dir, locations.ReadLocation):
+    selections = []
+    select_files = []
+
+    def check(self):
+        return_code = 0
+        # check that the source exists and is a directory
+        if not self.base_dir.lstat():
+            self.log("Source path {rp} does not exist".format(
+                rp=self.base_dir.get_safepath()), self.log.ERROR)
+            return_code |= 1
+        elif not self.base_dir.isdir():
+            self.log("Source path {rp} is not a directory".format(
+                rp=self.base_dir.get_safepath()), self.log.ERROR)
+            return_code |= 1
+        return return_code
+
+    def set_select(self, selections):
+        """
+        Accepts a list of selection tuple made of (selection method, parameter)
+
+        Saves the selections list and makes it ready for usage on the source
+        side over its connection.
+        """
+        def sel_fl(filename):
+            """
+            Helper function for including/excluding filelists below
+            """
+            if filename is True:  # we really mean the boolean True
+                return sys.stdin.buffer
+            try:
+                return open(filename, "rb")  # files match paths hence bytes/bin
+            except IOError:
+                self.log.FatalError("Error opening file %s" % filename)
+
+        if selections:
+            # the following loop is a compatibility measure # compat200
+            for selection in selections:
+                if 'filelist' in selection[0]:
+                    if selection[0].endswith("-stdin"):
+                        self.selections.append((
+                            "--" + selection[0][:-6],  # remove '-stdin'
+                            "standard input"))
+                    else:
+                        self.selections.append(("--" + selection[0],
+                                                selection[1]))
+                    self.select_files.append(sel_fl(selection[1]))
+                else:
+                    self.selections.append(("--" + selection[0], selection[1]))
+        else:
+            self.selections = []
+
+        # FIXME not sure we couldn't support symbolic links nowadays on Windows
+        if self.base_dir.conn.os.name == 'nt':
+            self.log("Symbolic links excluded by default on Windows",
+                     self.log.INFO)
+            self.selections.append(("--exclude-symbolic-links", None))
+        self.base_dir.conn.backup.SourceStruct.set_source_select(
+            self.base_dir, self.selections, *self.select_files)

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -32,7 +32,6 @@ from rdiff_backup import (
     rpath,
     Security,
     SetConnections,
-    Time,
 )
 
 

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -1,0 +1,316 @@
+# Copyright 2021 the rdiff-backup project
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+
+"""
+A location module to define repository classes as created by rdiff-backup
+"""
+
+import os
+
+from rdiffbackup import locations
+
+from rdiff_backup import (
+    FilenameMapping,
+    Globals,
+    restore,  # FIXME shouldn't be necessary!
+    rpath,
+    Security,
+    SetConnections,
+    Time,
+)
+
+
+class Repo():
+    """
+    Represent a Backup Repository as created by rdiff-backup
+    """
+
+    def get_mirror_time(self):
+        """
+        Return time in seconds of previous mirror if possible
+
+        Return -1 if there is more than one mirror,
+        or 0 if there is no backup yet.
+        """
+        incbase = self.data_dir.append_path(b"current_mirror")
+        mirror_rps = restore.get_inclist(incbase)  # FIXME is probably better here
+        if mirror_rps:
+            if len(mirror_rps) == 1:
+                return mirror_rps[0].getinctime()
+            else:  # there is a failed backup and 2+ current_mirror files
+                return -1
+        else:  # it's the first backup
+            return 0  # is always in the past
+
+
+class ReadRepo(Repo, locations.ReadLocation):
+    """
+    A writable/updatable Repository as target for a backup
+    """
+
+    def __init__(self, base_dir, log, force):
+        super().__init__(base_dir, log, force)
+        self.data_dir = self.base_dir.append_path(b"rdiff-backup-data")
+        self.incs_dir = self.data_dir.append_path(b"increments")
+
+
+class WriteRepo(Repo, locations.WriteLocation):
+    """
+    A writable/updatable Repository as target for a backup
+    """
+
+    def __init__(self, base_dir, log, force, create_full_path):
+        super().__init__(base_dir, log, force, create_full_path)
+        self.data_dir = self.base_dir.append_path(b"rdiff-backup-data")
+        self.incs_dir = self.data_dir.append_path(b"increments")
+
+    def check(self):
+        return_code = 0
+        # check that target is a directory or doesn't exist
+        if (self.base_dir.lstat() and not self.base_dir.isdir()):
+            if self.force:
+                self.log(
+                    "Destination {rp} exists but isn't a directory, "
+                    "and will be force deleted".format(
+                        rp=self.base_dir.get_safepath()),
+                    self.log.WARNING)
+            else:
+                self.log(
+                    "Destination {rp} exists and is not a directory, "
+                    "call with '--force' to overwrite".format(
+                        rp=self.base_dir.get_safepath()),
+                    self.log.ERROR)
+                return_code |= 1
+        # if the target is a non-empty existing directory
+        # without rdiff-backup-data sub-directory
+        elif (self.base_dir.lstat()
+              and self.base_dir.isdir()
+              and self.base_dir.listdir()):
+            if self.data_dir.lstat():
+                previous_time = self.get_mirror_time()
+                if previous_time >= Time.curtime:
+                    self.log("Time of last backup is not in the past. "
+                             "This is probably caused by running two backups "
+                             "in less than a second. "
+                             "Wait a second and try again.",
+                             self.log.ERROR)
+                    return_code |= 1
+            else:
+                if self.force:
+                    self.log(
+                        "Target '{repo}' does not look like a rdiff-backup "
+                        "repository but will be force overwritten".format(
+                            repo=self.base_dir.get_safepath()),
+                        self.log.WARNING)
+                else:
+                    self.log(
+                        "Target '{repo}' does not look like a rdiff-backup "
+                        "repository, "
+                        "call with '--force' to overwrite".format(
+                            repo=self.base_dir.get_safepath()),
+                        self.log.ERROR)
+                    return_code |= 1
+        return return_code
+
+    def setup(self):
+        # make sure the target directory is present
+        try:
+            # if the target exists and isn't a directory, force delete it
+            if (self.base_dir.lstat() and not self.base_dir.isdir()
+                    and self.force):
+                self.base_dir.delete()
+
+            # if the target doesn't exist, create it
+            if not self.base_dir.lstat():
+                if self.create_full_path:
+                    self.base_dir.makedirs()
+                else:
+                    self.base_dir.mkdir()
+                self.base_dir.chmod(0o700)  # only read-writable by its owner
+        except os.error:
+            self.log("Unable to delete and/or create directory {rp}".format(
+                rp=self.base_dir.get_safepath()), self.log.ERROR)
+            return 1
+
+        Globals.rbdir = self.data_dir  # compat200
+
+        # define a few essential subdirectories
+        if not self.data_dir.lstat():
+            try:
+                self.data_dir.mkdir()
+            except (OSError, IOError) as exc:
+                self.log("Could not create 'rdiff-backup-data' sub-directory "
+                         "in '{rp}' due to '{exc}'. "
+                         "Please fix the access rights and retry.".format(
+                             rp=self.base_dir, exc=exc), self.log.ERROR)
+                return 1
+        elif self._is_failed_initial_backup():
+            self._fix_failed_initial_backup()
+        if not self.incs_dir.lstat():
+            try:
+                self.incs_dir.mkdir()
+            except (OSError, IOError) as exc:
+                self.log("Could not create 'increments' sub-directory "
+                         "in '{rp}' due to '{exc}'. "
+                         "Please fix the access rights and retry.".format(
+                             rp=self.data_dir, exc=exc), self.log.ERROR)
+                return 1
+
+        SetConnections.UpdateGlobal('rbdir', self.data_dir)  # compat200
+
+        return 0
+
+    def init_quoting(self, chars_to_quote):
+        """
+        Set QuotedRPath versions of important RPaths if chars_to_quote is set.
+
+        Return True if quoting needed to be done, False else.
+        """
+        if not chars_to_quote:
+            return False
+
+        SetConnections.UpdateGlobal(  # compat200
+            'rbdir', FilenameMapping.get_quotedrpath(self.data_dir))
+        self.incs_dir = FilenameMapping.get_quotedrpath(self.incs_dir)
+        self.base_dir = FilenameMapping.get_quotedrpath(self.base_dir)
+
+        return True
+
+    def needs_regress(self):
+        """
+        Checks if the repository contains a previously failed backup and needs
+        to be regressed
+
+        Return None if the repository can't be found,
+        True if it needs regressing, False otherwise.
+        """
+        if not self.base_dir.isdir() or not self.data_dir.isdir():
+            return None
+        for filename in self.data_dir.listdir():
+            # check if we can find any file of importance
+            if filename not in [
+                    b'chars_to_quote', b'special_escapes',
+                    b'backup.log', b'increments'
+            ]:
+                break
+        else:  # This may happen the first backup just after we test for quoting
+            if not self.incs_dir.isdir() or not self.incs_dir.listdir():
+                return None
+        curmirroot = self.data_dir.append(b"current_mirror")
+        curmir_incs = restore.get_inclist(curmirroot)  # FIXME belongs here
+        if not curmir_incs:
+            self.log.FatalError(
+                """Bad rdiff-backup-data dir on destination side
+
+The rdiff-backup data directory
+{data}
+exists, but we cannot find a valid current_mirror marker.  You can
+avoid this message by removing the rdiff-backup-data directory;
+however any data in it will be lost.
+
+Probably this error was caused because the first rdiff-backup session
+into a new directory failed.  If this is the case it is safe to delete
+the rdiff-backup-data directory because there is no important
+information in it.
+
+""".format(data=self.data_dir.get_safepath()))
+        elif len(curmir_incs) == 1:
+            return False
+        else:
+            if not self.force:
+                try:
+                    curmir_incs[0].conn.regress.check_pids(curmir_incs)
+                except (OSError, IOError) as exc:
+                    self.log.FatalError(
+                        "Could not check if rdiff-backup is currently"
+                        "running due to\n{exc}".format(exc=exc))
+            assert len(curmir_incs) == 2, (
+                "Found more than 2 current_mirror incs in '{rp!s}'.".format(
+                    rp=self.data_dir))
+            return True
+
+    def regress(self):
+        """
+        Regress the backup repository in case the last backup failed
+
+        This can/should be run before any action on the repository to start
+        with a clean state.
+        """
+        self.log(
+            "Previous backup seems to have failed, regressing "
+            "destination now.", self.log.WARNING)
+        try:
+            self.base_dir.conn.regress.Regress(self.base_dir)
+        except Security.Violation:
+            self.log.FatalError(
+                "Security violation while attempting to regress destination, "
+                "perhaps due to --restrict-read-only or "
+                "--restrict-update-only.")
+
+    def _is_failed_initial_backup(self):
+        """
+        Returns True if it looks like the rdiff-backup-data directory contains
+        a failed initial backup, else False.
+        """
+        if self.data_dir.lstat():
+            rbdir_files = self.data_dir.listdir()
+            mirror_markers = [
+                x for x in rbdir_files if x.startswith(b"current_mirror")
+            ]
+            error_logs = [x for x in rbdir_files if x.startswith(b"error_log")]
+            metadata_mirrors = [
+                x for x in rbdir_files if x.startswith(b"mirror_metadata")
+            ]
+            # If we have no current_mirror marker, and the increments directory
+            # is empty, we most likely have a failed backup.
+            return not mirror_markers and len(error_logs) <= 1 and \
+                len(metadata_mirrors) <= 1
+        return False
+
+    def _fix_failed_initial_backup(self):
+        """
+        Clear the given rdiff-backup-data if possible, it's faster than
+        trying to do a regression, which would probably anyway fail.
+        """
+        self.log("Found interrupted initial backup in {rp}. "
+                 "Removing...".format(rp=self.data_dir.get_safepath()),
+                 self.log.DEFAULT)
+        rbdir_files = self.data_dir.listdir()
+
+        # Try to delete the increments dir first
+        if b'increments' in rbdir_files:
+            rbdir_files.remove(b'increments')
+            rp = self.data_dir.append(b'increments')
+            # FIXME I don't really understand the logic here: either it's
+            # a failed initial backup and we can remove everything, or we
+            # should fail and not continue.
+            try:
+                rp.conn.rpath.delete_dir_no_files(rp)
+            except rpath.RPathException:
+                self.log("Increments dir contains files.", self.log.INFO)
+                return
+            except Security.Violation:
+                self.log("Server doesn't support resuming.", self.log.WARNING)
+                return
+
+        # then delete all remaining files
+        for file_name in rbdir_files:
+            rp = self.data_dir.append_path(file_name)
+            if not rp.isdir():  # Only remove files, not folders
+                rp.delete()

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -234,31 +234,23 @@ class WriteRepo(Repo, locations.WriteLocation):
         # without rdiff-backup-data sub-directory
         if (self.base_dir.lstat()
                 and self.base_dir.isdir()
-                and self.base_dir.listdir()):
-            if self.data_dir.lstat():
-                previous_time = self.get_mirror_time()
-                if previous_time >= Time.curtime:
-                    self.log("Time of last backup is not in the past. "
-                             "This is probably caused by running two backups "
-                             "in less than a second. "
-                             "Wait a second and try again.",
-                             self.log.ERROR)
-                    ret_code |= 1
+                and self.base_dir.listdir()
+                and not self.data_dir.lstat()):
+            if self.force:
+                self.log(
+                    "Target '{repo}' does not look like a rdiff-backup "
+                    "repository but will be force overwritten".format(
+                        repo=self.base_dir.get_safepath()),
+                    self.log.WARNING)
             else:
-                if self.force:
-                    self.log(
-                        "Target '{repo}' does not look like a rdiff-backup "
-                        "repository but will be force overwritten".format(
-                            repo=self.base_dir.get_safepath()),
-                        self.log.WARNING)
-                else:
-                    self.log(
-                        "Target '{repo}' does not look like a rdiff-backup "
-                        "repository, "
-                        "call with '--force' to overwrite".format(
-                            repo=self.base_dir.get_safepath()),
-                        self.log.ERROR)
-                    ret_code |= 1
+                self.log(
+                    "Target '{repo}' does not look like a rdiff-backup "
+                    "repository, "
+                    "call with '--force' to overwrite".format(
+                        repo=self.base_dir.get_safepath()),
+                    self.log.ERROR)
+                ret_code |= 1
+
         return ret_code
 
     def setup(self):

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -321,7 +321,7 @@ class WriteRepo(Repo, locations.WriteLocation):
         """
         self.log("Found interrupted initial backup in {rp}. "
                  "Removing...".format(rp=self.data_dir.get_safepath()),
-                 self.log.DEFAULT)
+                 self.log.NOTE)
         rbdir_files = self.data_dir.listdir()
 
         # Try to delete the increments dir first

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -64,7 +64,10 @@ class Repo():
 
         Return True if quoting needed to be done, False else.
         """
-        if not chars_to_quote:
+        # FIXME the problem is that the chars_to_quote can come from the command
+        # line but can also be a value coming from the repository itself,
+        # set globally by the fs_abilities.xxx_set_globals functions.
+        if not Globals.chars_to_quote:
             return False
 
         FilenameMapping.set_init_quote_vals()  # compat200
@@ -199,13 +202,14 @@ class ReadRepo(Repo, locations.ReadLocation):
 
         return 0  # all is good
 
-    def set_select(self, select_opts, select_data):
+    def set_select(self, select_opts, select_data, target_rp):
         """
         Set the selection and selection data on the repository
 
         Accepts a tuple of two lists:
         * one of selection tuple made of (selection method, parameter)
         * and one of the content of the selection files
+        And an rpath of the target directory to map the selection criteria.
 
         Saves the selections list and makes it ready for usage on the source
         side over its connection.
@@ -214,7 +218,7 @@ class ReadRepo(Repo, locations.ReadLocation):
         # FIXME we're retransforming bytes into a file pointer
         if select_opts:
             self.base_dir.conn.restore.MirrorStruct.set_mirror_select(
-                self.base_dir, select_opts, *list(map(io.BytesIO, select_data)))
+                target_rp, select_opts, *list(map(io.BytesIO, select_data)))
 
 
 class WriteRepo(Repo, locations.WriteLocation):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -216,7 +216,7 @@ def InternalBackup(source_local,
 
     args.extend(_get_locations(source_local, dest_local, src_dir, dest_dir))
 
-    Main.main_run(args, security_override=True, do_exit=False)
+    Main._main_run(args, security_override=True)
 
 
 def InternalMirror(source_local, dest_local, src_dir, dest_dir, force=False):
@@ -273,7 +273,7 @@ def InternalRestore(mirror_local,
 
     args.extend(_get_locations(mirror_local, dest_local, mirror_dir, dest_dir))
 
-    Main.main_run(args, security_override=True, do_exit=False)
+    Main._main_run(args, security_override=True)
 
 
 def get_increment_rp(mirror_rp, time):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -540,8 +540,6 @@ def MirrorTest(source_local,
     Globals.set("no_compression_regexp_string",
                 os.fsencode(actions.DEFAULT_NOT_COMPRESSED_REGEXP))
     dest_rp = rpath.RPath(Globals.local_connection, dest_dirname)
-    old_force_val = Main._force
-    Main._force = 1
 
     Myrm(dest_dirname)
     for dirname in list_of_dirnames:
@@ -553,7 +551,6 @@ def MirrorTest(source_local,
                        force=True)
         _reset_connections(src_rp, dest_rp)
         assert compare_recursive(src_rp, dest_rp, compare_hardlinks)
-    Main.force = old_force_val
 
 
 def raise_interpreter(use_locals=None):


### PR DESCRIPTION
It's a rather huge PR but as all the actions were entangled into the Main.py module, it was more or less impossible to split them one by one, so I had to split them all at once, refactoring them into the run() method of the new actions. There is still potential for improvement but at least, it's clear now which action belongs where.

At the same time, I had to create a new "locations" kind of object, which represent either a directory or a (backup) repository. It wasn't the main purpose of the PR but a first logical step.

This aspect will need to be revisited later on though, as it's kind of duplicate with the *Struct classes present in `rdiff_backup/backup.py` and `rdiff_backup/restore.py`, and of course, those action-looking-modules should also be merged with the new action plug-ins. Where it gets messy, is that those aspects are more often used in client/server mode, hence will impact the API. But this is for one or more follow-up PR(s)...