### PR TITLE
fix action plugins and long path under Windows

### DIFF
--- a/docs/Windows-README.md
+++ b/docs/Windows-README.md
@@ -25,6 +25,8 @@ and copy the four enclosed files to the same directory as *rdiff-backup.exe*.
 
 You will need to follow either method only once.
 
+> **NOTE:** you might want to [enable long paths support in Windows 10 v1607 or later](https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later)
+
 ## Additional Issues
 
 Currently, *rdiff-backup*'s `--include` and `--exclude` options do not support

--- a/tools/hook-rdiffbackup.actions_mgr.py
+++ b/tools/hook-rdiffbackup.actions_mgr.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import collect_submodules
+hiddenimports = collect_submodules('rdiffbackup.actions')

--- a/tools/win_build_rdiffbackup.sh
+++ b/tools/win_build_rdiffbackup.sh
@@ -35,5 +35,6 @@ py_ver_brief=${PYTHON_VERSION%.[0-9]}
 ${PYEXE} setup.py bdist_wheel
 ${PYINST} --onefile --distpath build/${ver_name}-${bits} \
 	--paths=build/lib.win32-${py_ver_brief} \
+	--additional-hooks-dir=tools
 	--console build/scripts-${py_ver_brief}/rdiff-backup \
 	--add-data=src/rdiff_backup.egg-info/PKG-INFO\;rdiff_backup.egg-info

--- a/tools/windows/playbook-build-rdiff-backup.yml
+++ b/tools/windows/playbook-build-rdiff-backup.yml
@@ -28,8 +28,10 @@
     - name: compile rdiff-backup into an executable using pyinstaller
       win_command: >
         pyinstaller --onefile
-        --paths=build/lib.{{ python_win_bits }}-{{ python_version }} --paths={{ librsync_install_dir }}/lib
+        --paths=build/lib.{{ python_win_bits }}-{{ python_version }}
+        --paths={{ librsync_install_dir }}/lib
         --paths={{ librsync_install_dir }}/bin
+        --additional-hooks-dir=tools
         --console build/scripts-{{ python_version }}/rdiff-backup
         --add-data src/rdiff_backup.egg-info/PKG-INFO;rdiff_backup.egg-info
       environment:


### PR DESCRIPTION
PyInstaller doesn't support pkgutil.iter_modules out of the box
but there is a workaround:
https://github.com/pyinstaller/pyinstaller/issues/1905

FIX: support long paths under Windows 10 v1607 or later, once enabled in
registry/GPO (see Windows README for details), closes #236