### PR TITLE
Fix build issue with PyInstaller in Win64

### DIFF
--- a/tools/win_build_rdiffbackup.sh
+++ b/tools/win_build_rdiffbackup.sh
@@ -34,7 +34,7 @@ py_ver_brief=${PYTHON_VERSION%.[0-9]}
 
 ${PYEXE} setup.py bdist_wheel
 ${PYINST} --onefile --distpath build/${ver_name}-${bits} \
-	--paths=build/lib.win32-${py_ver_brief} \
+	--paths=build/lib.${py_win_bits}-${py_ver_brief} \
 	--additional-hooks-dir=tools \
 	--console build/scripts-${py_ver_brief}/rdiff-backup \
 	--add-data=src/rdiff_backup.egg-info/PKG-INFO\;rdiff_backup.egg-info


### PR DESCRIPTION
FIX: 64 bits version compiled with PyInstaller for Windows couldn't find its module rdiff_backup, closes #555

This time, I tried both Windows builds and they both work.