### PR TITLE
Make rpath easier to handle as path or str

### DIFF
--- a/src/rdiff-backup-statistics
+++ b/src/rdiff-backup-statistics
@@ -77,7 +77,7 @@ def parse_args():
         os.path.join(os.fsencode(args[0]), b"rdiff-backup-data"),
     )
     if not Globals.rbdir.isdir():
-        sys.exit("Directory %s not found" % (Globals.rbdir.get_safepath(),))
+        sys.exit("Directory {rp} not found".format(rp=Globals.rbdir))
 
 
 def usage(rc):
@@ -141,9 +141,8 @@ class StatisticsRPaths:
             if time in filestat_dict:
                 result.append((session_dict[time], filestat_dict[time]))
             else:
-                sys.stderr.write(
-                    "No file_statistics to match '%s'\n" % session_dict[time].get_safepath()
-                )
+                sys.stderr.write("No file_statistics to match '{rp}'".format(
+                    rp=session_dict[time]))
         return result
 
 

--- a/src/rdiff_backup/FilenameMapping.py
+++ b/src/rdiff_backup/FilenameMapping.py
@@ -101,8 +101,12 @@ class QuotedRPath(rpath.RPath):
             result = rpath.RPath.isincfile(self)
         return result
 
-    def get_path(self):
-        """Just a getter to return the path unquoted"""
+    def __fspath__(self):
+        """
+        Just a getter to return the path unquoted
+
+        Fulfills the os.PathLike interface
+        """
         return unquote(self.path)
 
 
@@ -166,7 +170,7 @@ def unquote(path):
 def get_quotedrpath(rp, separate_basename=0):
     """Return quoted version of rpath rp"""
     assert not rp.index, (
-        "Trying to start quoting '{rp!s}' in the middle.".format(rp=rp))
+        "Trying to start quoting '{rp}' in the middle.".format(rp=rp))
     if separate_basename:
         dirname, basename = rp.dirsplit()
         return QuotedRPath(rp.conn, dirname, (unquote(basename), ), rp.data)
@@ -195,9 +199,8 @@ def update_quoting(rbdir):
                 list.append(new_name)
             name_rp = dirpath_rp.append(name)
             new_rp = dirpath_rp.append(new_name)
-            log.Log(
-                "Re-quoting %s to %s" % (name_rp.get_safepath(),
-                                         new_rp.get_safepath()), 5)
+            log.Log("Re-quoting {orp} to {nrp}".format(
+                orp=name_rp, nrp=new_rp), 5)
             rpath.move(name_rp, new_rp)
 
     assert rbdir.conn is Globals.local_connection, (
@@ -206,7 +209,7 @@ def update_quoting(rbdir):
     mirror_rp = rbdir.get_parent_rp()
     mirror = mirror_rp.path
 
-    log.Log("Re-quoting repository %s" % mirror_rp.get_safepath(), 3)
+    log.Log("Re-quoting repository {rp}".format(rp=mirror_rp), 3)
 
     for dirpath, dirs, files in os.walk(mirror):
         dirpath_rp = mirror_rp.newpath(dirpath)

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -116,7 +116,7 @@ def backup_touch_curmirror_local(rpin, rpout):
     """
     mirrorrp = Globals.rbdir.append(b'.'.join(
         map(os.fsencode, (b"current_mirror", Time.curtimestr, "data"))))
-    log.Log("Writing mirror marker %s" % mirrorrp.get_safepath(), 6)
+    log.Log("Writing mirror marker {rp}".format(rp=mirrorrp), 6)
     try:
         pid = os.getpid()
     except BaseException:

--- a/src/rdiff_backup/Rdiff.py
+++ b/src/rdiff_backup/Rdiff.py
@@ -25,26 +25,23 @@ def get_signature(rp, blocksize=None):
     """Take signature of rpin file and return in file object"""
     if not blocksize:
         blocksize = _find_blocksize(rp.getsize())
-    log.Log(
-        "Getting signature of %s with blocksize %s" % (rp.get_safeindexpath(),
-                                                       blocksize), 7)
+    log.Log("Getting signature of {rp} with blocksize {blks}".format(
+        rp=rp, blks=blocksize), 7)
     return librsync.SigFile(rp.open("rb"), blocksize)
 
 
 def get_delta_sigrp_hash(rp_signature, rp_new):
     """Like above but also calculate hash of new as close() value"""
-    log.Log(
-        "Getting delta (with hash) of %s with signature %s" %
-        (rp_new.get_safepath(), rp_signature.get_safeindexpath()), 7)
+    log.Log("Getting delta (with hash) of {rp} with signature {srp}".format(
+        rp=rp_new, srp=rp_signature), 7)
     return librsync.DeltaFile(
         rp_signature.open("rb"), hash.FileWrapper(rp_new.open("rb")))
 
 
 def write_delta(basis, new, delta, compress=None):
     """Write rdiff delta which brings basis to new"""
-    log.Log(
-        "Writing delta %s from %s -> %s" %
-        (basis.get_safepath(), new.get_safepath(), delta.get_safepath()), 7)
+    log.Log("Writing delta {brp} from {nrp} -> {drp}".format(
+        brp=basis, nrp=new, drp=delta), 7)
     deltafile = librsync.DeltaFile(get_signature(basis), new.open("rb"))
     delta.write_from_fileobj(deltafile, compress)
 

--- a/src/rdiff_backup/backup.py
+++ b/src/rdiff_backup/backup.py
@@ -26,9 +26,8 @@ from . import Globals, metadata, rorpiter, Hardlink, robust, \
 
 def Mirror(src_rpath, dest_rpath):
     """Turn dest_rpath into a copy of src_rpath"""
-    log.Log(
-        "Starting mirror %s to %s" % (src_rpath.get_safepath(),
-                                      dest_rpath.get_safepath()), 4)
+    log.Log("Starting mirror {srp} to {drp}".format(
+        srp=src_rpath, drp=dest_rpath), 4)
     SourceS = src_rpath.conn.backup.SourceStruct
     DestS = dest_rpath.conn.backup.DestinationStruct
 
@@ -41,10 +40,8 @@ def Mirror(src_rpath, dest_rpath):
 
 def Mirror_and_increment(src_rpath, dest_rpath, inc_rpath):
     """Mirror + put increments in tree based at inc_rpath"""
-    log.Log(
-        "Starting increment operation %s to %s" % (src_rpath.get_safepath(),
-                                                   dest_rpath.get_safepath()),
-        4)
+    log.Log("Starting increment operation {drp} to {srp}".format(
+        srp=src_rpath, drp=dest_rpath), 4)
     SourceS = src_rpath.conn.backup.SourceStruct
     DestS = dest_rpath.conn.backup.DestinationStruct
 
@@ -194,7 +191,7 @@ class DestinationStruct:
         """Patch dest_rpath with an rorpiter of diffs"""
         ITR = rorpiter.IterTreeReducer(PatchITRB, [dest_rpath, cls.CCPP])
         for diff in rorpiter.FillInIter(source_diffiter, dest_rpath):
-            log.Log("Processing changed file %s" % diff.get_safeindexpath(), 5)
+            log.Log("Processing changed file {rp}".format(rp=diff), 5)
             ITR(diff.index, diff)
         ITR.finish_processing()
         cls.CCPP.close()
@@ -206,7 +203,7 @@ class DestinationStruct:
         ITR = rorpiter.IterTreeReducer(IncrementITRB,
                                        [dest_rpath, inc_rpath, cls.CCPP])
         for diff in rorpiter.FillInIter(source_diffiter, dest_rpath):
-            log.Log("Processing changed file %s" % diff.get_safeindexpath(), 5)
+            log.Log("Processing changed file {rp}".format(rp=diff), 5)
             ITR(diff.index, diff)
         ITR.finish_processing()
         cls.CCPP.close()
@@ -281,8 +278,8 @@ class DestinationStruct:
                     return Rdiff.get_signature(dest_rp)
                 except (IOError, OSError):
                     log.Log.FatalError(
-                        "Could not open %s for reading. Check "
-                        "permissions on file." % (dest_rp.path, ))
+                        "Could not open {rp} for reading. Check "
+                        "permissions on file.".format(rp=dest_rp))
             else:
                 raise
 
@@ -598,7 +595,7 @@ class PatchITRB(rorpiter.ITRBranch):
         mirror_rp, discard = longname.get_mirror_inc_rps(
             self.CCPP.get_rorps(index), self.basis_root_rp)
         assert not mirror_rp.isdir(), (
-            "Mirror path '{rp!s}' points to a directory.".format(rp=mirror_rp))
+            "Mirror path '{rp}' points to a directory.".format(rp=mirror_rp))
         tf = mirror_rp.get_temp_rpath(sibling=True)
         if self._patch_to_temp(mirror_rp, diff_rorp, tf):
             if tf.lstat():
@@ -631,7 +628,7 @@ class PatchITRB(rorpiter.ITRBranch):
         """Finish processing directory"""
         if self.dir_update:
             assert self.base_rp.isdir(), (
-                "Base directory '{rp!s}' isn't a directory.".format(
+                "Base directory '{rp}' isn't a directory.".format(
                     rp=self.base_rp))
             rpath.copy_attribs(self.dir_update, self.base_rp)
 
@@ -711,7 +708,7 @@ class PatchITRB(rorpiter.ITRBranch):
     def _patch_diff_to_temp(self, basis_rp, diff_rorp, new):
         """Apply diff_rorp to basis_rp, write output in new"""
         assert diff_rorp.get_attached_filetype() == 'diff', (
-            "Type attached to '{rp!s}' isn't '{exp}' but '{att}'.".format(
+            "Type attached to '{rp}' isn't '{exp}' but '{att}'.".format(
                 rp=diff_rorp, exp="diff",
                 att=diff_rorp.get_attached_filetype()))
         report = robust.check_common_error(
@@ -737,7 +734,7 @@ class PatchITRB(rorpiter.ITRBranch):
             return 1
         log.ErrorLog.write_if_open(
             "UpdateError", diff_rorp, "Updated mirror "
-            "temp file '%s' does not match source" % new_rp.get_safepath())
+            "temp file '{rp}' does not match source".format(rp=new_rp))
         return 0
 
     def _write_special(self, diff_rorp, new):
@@ -757,7 +754,7 @@ class PatchITRB(rorpiter.ITRBranch):
 
         """
         assert diff_rorp.get_attached_filetype() == 'snapshot', (
-            "Type attached to '{rp!s}' isn't '{exp}' but '{att}'.".format(
+            "Type attached to '{rp}' isn't '{exp}' but '{att}'.".format(
                 rp=diff_rorp, exp="snapshot",
                 att=diff_rorp.get_attached_filetype()))
         self.dir_replacement = base_rp.get_temp_rpath(sibling=True)
@@ -831,9 +828,8 @@ class IncrementITRB(PatchITRB):
             self.CCPP.get_rorps(index), self.basis_root_rp, self.inc_root_rp)
         self.base_rp.setdata()
         assert diff_rorp.isdir() or self.base_rp.isdir(), (
-            "Either diff '{ipath}' or base '{bpath}' must be a directory".format(
-                ipath=diff_rorp.get_safeindexpath(),
-                bpath=self.base_rp.get_safepath()))
+            "Either diff '{ipath!r}' or base '{bpath!r}' "
+            "must be a directory".format(ipath=diff_rorp, bpath=self.base_rp))
         if diff_rorp.isdir():
             inc = increment.Increment(diff_rorp, self.base_rp, inc_prefix)
             if inc and inc.isreg():

--- a/src/rdiff_backup/compare.py
+++ b/src/rdiff_backup/compare.py
@@ -91,9 +91,8 @@ class DataSide(backup.SourceStruct):
             """Return 0 if their data hashes same, 1 otherwise"""
             verify_sha1 = _get_hash(mir_rorp)
             if not verify_sha1:
-                log.Log(
-                    "Warning: Metadata file has no digest for %s, "
-                    "unable to compare." % (mir_rorp.get_safeindexpath(), ), 2)
+                log.Log("Warning: Metadata file has no digest for {rp}, "
+                        "unable to compare.".format(rp=mir_rorp), 2)
                 return 0
             elif (src_rp.getsize() == mir_rorp.getsize()
                   and hash.compute_sha1(src_rp) == verify_sha1):
@@ -113,7 +112,7 @@ class DataSide(backup.SourceStruct):
         """Given repo iter with full data attached, return report iter"""
 
         def error_handler(exc, src_rp, repo_rorp):
-            log.Log("Error reading file %s" % src_rp.get_safepath(), 2)
+            log.Log("Error reading file {rp}".format(rp=src_rp), 2)
             return 0  # They aren't the same if we get an error
 
         def data_changed(src_rp, repo_rorp):
@@ -212,25 +211,20 @@ def Verify(mirror_rp, inc_rp, verify_time):
             continue
         verify_sha1 = _get_hash(repo_rorp)
         if not verify_sha1:
-            log.Log(
-                "Warning: Cannot find SHA1 digest for file %s,\n"
-                "perhaps because this feature was added in v1.1.1" %
-                (repo_rorp.get_safeindexpath(), ), 2)
+            log.Log("Warning: Cannot find SHA1 digest for file {rp},\n"
+                    "perhaps because this feature was added in v1.1.1".format(
+                        rp=repo_rorp), 2)
             continue
         fp = RepoSide.rf_cache.get_fp(base_index + repo_rorp.index, repo_rorp)
         computed_hash = hash.compute_sha1_fp(fp)
         if computed_hash == verify_sha1:
-            log.Log(
-                "Verified SHA1 digest of %s" % repo_rorp.get_safeindexpath(),
-                5)
+            log.Log("Verified SHA1 digest of {rp}".format(rp=repo_rorp), 5)
         else:
             bad_files += 1
-            log.Log(
-                "Warning: Computed SHA1 digest of %s\n   %s\n"
-                "doesn't match recorded digest of\n   %s\n"
-                "Your backup repository may be corrupted!" %
-                (repo_rorp.get_safeindexpath(), computed_hash,
-                 verify_sha1), 2)
+            log.Log("Warning: Computed SHA1 digest of {rp}\n   {chsh}\n"
+                    "doesn't match recorded digest of\n   {rhsh}\n"
+                    "Your backup repository may be corrupted!".format(
+                        rp=repo_rorp, chsh=computed_hash, rhsh=verify_sha1), 2)
     RepoSide.close_rf_cache()
     if bad_files:
         log.Log("Not all files could be verified.", 3)
@@ -310,6 +304,5 @@ def _get_basic_report(src_rp, repo_rorp, comp_data_func=None):
 
 def _log_success(src_rorp, mir_rorp=None):
     """Log that src_rorp and mir_rorp compare successfully"""
-    path = src_rorp and src_rorp.get_safeindexpath(
-    ) or mir_rorp.get_safeindexpath()
-    log.Log("Successful compare: %s" % (path, ), 5)
+    path = src_rorp and str(src_rorp) or str(mir_rorp)
+    log.Log("Successful compare: {rp}".format(rp=path), 5)

--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -74,8 +74,8 @@ class ExtendedAttributes:
             if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.ETXTBSY):
                 return  # if not supported, consider empty
             if exc.errno in (errno.EACCES, errno.ENOENT, errno.ELOOP):
-                log.Log("Warning: listattr(%s): %s" % (rp.get_safepath(), exc),
-                        4)
+                log.Log("Warning: listattr({rp}): {exc}".format(
+                    rp=rp, exc=exc), 4)
                 return
             raise
         for attr in attr_list:
@@ -111,9 +111,8 @@ class ExtendedAttributes:
                 # fail gracefully if can't call xattr.set
                 if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.EACCES,
                                  errno.ENOENT, errno.EINVAL):
-                    log.Log(
-                        "Warning: unable to write xattr %s to %s" %
-                        (name, rp.get_safepath()), 6)
+                    log.Log("Warning: unable to write xattr "
+                            "{xat} to {rp}".format(xat=name, rp=rp), 6)
                     continue
                 else:
                     raise
@@ -143,9 +142,8 @@ class ExtendedAttributes:
                 except PermissionError:  # errno.EACCES
                     # SELinux attributes cannot be removed, and we don't want
                     # to bail out or be too noisy at low log levels.
-                    log.Log(
-                        "Warning: unable to remove xattr %s from %s" %
-                        (name, rp.get_safepath()), 7)
+                    log.Log("Warning: unable to remove xattr "
+                            "{xat} from {rp}".format(xat=name, rp=rp), 7)
                     continue
                 except OSError as exc:
                     # can happen because trusted.SGI_ACL_FILE is deleted together with
@@ -157,9 +155,8 @@ class ExtendedAttributes:
         except io.UnsupportedOperation:  # errno.EOPNOTSUPP or errno.EPERM
             return  # if not supported, consider empty
         except FileNotFoundError as exc:
-            log.Log(
-                "Warning: unable to clear xattrs on %s: %s" %
-                (rp.get_safepath(), exc), 3)
+            log.Log("Warning: unable to clear xattrs on {rp}: {exc}".format(
+                rp=rp, exc=exc), 3)
             return
 
 
@@ -448,11 +445,11 @@ class AccessControlLists:
         """Returns same as __eq__ but print explanation if not equal.
         TEST: This function is used solely as part of the test suite."""
         if not self.cmp_entry_list(self.entry_list, acl.entry_list):
-            print("ACL entries for %s compare differently" % (self.index, ))
+            print("ACL entries for {rp} compare differently".format(rp=self))
             return 0
         if not self.cmp_entry_list(self.default_entry_list,
                                    acl.default_entry_list):
-            print("Default ACL entries for %s do not compare" % (self.index, ))
+            print("Default ACL entries for {rp} do not compare".format(rp=self))
             return 0
         return 1
 
@@ -508,9 +505,8 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
         acl.applyto(rp.path)
     except IOError as exc:
         if exc.errno == errno.EOPNOTSUPP:
-            log.Log(
-                "Warning: unable to set ACL on %s: %s" % (rp.get_safepath(),
-                                                          exc), 4)
+            log.Log("Warning: unable to set ACL on {rp}: {exc}".format(
+                rp=rp, exc=exc), 4)
             return
         else:
             raise
@@ -532,9 +528,8 @@ def get_acl_lists_from_rp(rp):
     try:
         acl = posix1e.ACL(file=rp.path)
     except (FileNotFoundError, UnicodeEncodeError) as exc:
-        log.Log(
-            "Warning: unable to read ACL from %s: %s" % (rp.get_safepath(),
-                                                         exc), 3)
+        log.Log("Warning: unable to read ACL from {rp}: {exc}".format(
+            rp=rp, exc=exc), 3)
         acl = None
     except IOError as exc:
         if exc.errno == errno.EOPNOTSUPP:
@@ -545,9 +540,8 @@ def get_acl_lists_from_rp(rp):
         try:
             def_acl = posix1e.ACL(filedef=os.fsdecode(rp.path))
         except (FileNotFoundError, UnicodeEncodeError) as exc:
-            log.Log(
-                "Warning: unable to read default ACL from %s: %s" %
-                (rp.get_safepath(), exc), 3)
+            log.Log("Warning: unable to read default ACL from {rp}: "
+                    "{exc}".format(rp=rp, exc=exc), 3)
             def_acl = None
         except IOError as exc:
             if exc.errno == errno.EOPNOTSUPP:

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -150,7 +150,7 @@ class FSAbilities:
         """
         if not self.root_rp.isdir():
             assert not self.root_rp.lstat(), (
-                "Root path '{rp!s}' can't be writable, exist and not be "
+                "Root path '{rp}' can't be writable, exist and not be "
                 "a directory.".format(rp=self.root_rp))
             self.root_rp.mkdir()
         subdir = self.root_rp.get_temp_rpath()
@@ -202,9 +202,8 @@ class FSAbilities:
                 raise IOError(errno.EOPNOTSUPP, "Hard links don't compare")
         except (IOError, OSError, AttributeError):
             if Globals.preserve_hardlinks != 0:
-                log.Log(
-                    "Warning: hard linking not supported by filesystem "
-                    "at %s" % self.root_rp.get_safepath(), 3)
+                log.Log("Warning: hard linking not supported by filesystem "
+                        "at {rp}".format(rp=self.root_rp), 3)
             self.hardlinks = None
         else:
             self.hardlinks = 1
@@ -214,9 +213,8 @@ class FSAbilities:
         try:
             testdir.fsync()
         except (IOError, OSError):
-            log.Log(
-                "Directories on file system at %s are not fsyncable.\n"
-                "Assuming it's unnecessary." % testdir.get_safepath(), 4)
+            log.Log("Directories on file system at {rp} are not fsyncable."
+                    "Assuming it's unnecessary.".format(rp=testdir), 4)
             self.fsync_dirs = 0
         else:
             self.fsync_dirs = 1
@@ -233,9 +231,8 @@ class FSAbilities:
             ord_rp.delete()
         except (IOError, OSError) as exc:
             log.Log.FatalError(
-                "File with normal name '{file}' couldn't be created, "
-                "and failed with '{exc}'.".format(
-                    file=ord_rp.get_safepath(), exc=exc))
+                "File with normal name '{rp}' couldn't be created, "
+                "and failed with '{exc}'.".format(rp=ord_rp, exc=exc))
 
         # Try path with UTF-8 encoded character
         extended_filename = (
@@ -297,19 +294,17 @@ class FSAbilities:
         try:
             import posix1e
         except ImportError:
-            log.Log(
-                "Unable to import module posix1e from pylibacl "
-                "package.\nPOSIX ACLs not supported on filesystem at %s" %
-                rp.get_safepath(), 4)
+            log.Log("Unable to import module posix1e from pylibacl package. "
+                    "POSIX ACLs not supported on filesystem at {rp}".format(
+                        rp=rp), 4)
             self.acls = 0
             return
 
         try:
             posix1e.ACL(file=rp.path)
         except IOError:
-            log.Log(
-                "POSIX ACLs not supported by filesystem at %s" %
-                rp.get_safepath(), 4)
+            log.Log("POSIX ACLs not supported by filesystem at {rp}".format(
+                rp=rp), 4)
             self.acls = 0
         else:
             self.acls = 1
@@ -327,10 +322,10 @@ class FSAbilities:
                 # we know that (fuse-)exFAT 1.3.0 takes 1sec to register the
                 # deletion (July 2020)
                 log.Log.FatalError(
-                    "We're sorry but the target file system at '%s' isn't "
+                    "We're sorry but the target file system at '{rp}' isn't "
                     "deemed reliable enough for a backup. It takes too long "
-                    "or doesn't register case insensitive deletion of files."
-                    % subdir.get_safepath())
+                    "or doesn't register case insensitive deletion of "
+                    "files.".format(rp=subdir))
             self.case_sensitive = 0
         else:
             upper_a.delete()
@@ -374,9 +369,9 @@ class FSAbilities:
         if not triple:
             log.Log(
                 "Warning: could not determine case sensitivity of "
-                "source directory at\n  %s\n"
+                "source directory at\n  {rp}\n"
                 "because we can't find any files with letters in them.\n"
-                "It will be treated as case sensitive." % rp.get_safepath(), 2)
+                "It will be treated as case sensitive.".format(rp=rp), 2)
             self.case_sensitive = 1
             return
 
@@ -387,7 +382,7 @@ class FSAbilities:
         assert rp.conn is Globals.local_connection, (
             "Action only foreseen locally and not over {conn}.".format(
                 conn=rp.conn))
-        assert rp.lstat(), "Path '{rp!s}' must exist to test EAs.".format(rp=rp)
+        assert rp.lstat(), "Path '{rp}' must exist to test EAs.".format(rp=rp)
         if Globals.eas_active == 0:
             log.Log(
                 "Extended attributes test skipped. rdiff-backup run "
@@ -401,8 +396,8 @@ class FSAbilities:
                 import xattr
             except ImportError:
                 log.Log(
-                    "Unable to import module (py)xattr.\nExtended attributes not "
-                    "supported on filesystem at %s" % (rp.get_safepath(), ), 4)
+                    "Unable to import module (py)xattr. Extended attributes "
+                    "not supported on filesystem at {rp}".format(rp=rp), 4)
                 self.eas = 0
                 return
 
@@ -413,18 +408,17 @@ class FSAbilities:
                 xattr.set(rp.path, b"user.test", test_ea)
                 read_ea = xattr.get(rp.path, b"user.test")
         except IOError:
-            log.Log(
-                "Extended attributes not supported by "
-                "filesystem at %s" % (rp.get_safepath(), ), 4)
+            log.Log("Extended attributes not supported by "
+                    "filesystem at {rp}".format(rp=rp), 4)
             self.eas = 0
         else:
             if write and read_ea != test_ea:
                 log.Log(
                     "Extended attributes support is broken on filesystem at "
-                    "%s.\nPlease upgrade the filesystem driver, contact the "
-                    "developers,\nor use the --no-eas option to disable "
-                    "extended attributes\nsupport and suppress this message." %
-                    (rp.get_safepath(), ), 1)
+                    "{rp}. Please upgrade the filesystem driver, contact the "
+                    "developers, or use the --no-eas option to disable "
+                    "extended attributes support and suppress this "
+                    "message.".format(rp=rp), 1)
                 self.eas = 0
             else:
                 self.eas = 1
@@ -434,7 +428,7 @@ class FSAbilities:
         assert dir_rp.conn is Globals.local_connection, (
             "Action only foreseen locally and not over {conn}.".format(
                 conn=dir_rp.conn))
-        assert dir_rp.lstat(), "Path '{rp!s}' must exist to test ACLs.".format(
+        assert dir_rp.lstat(), "Path '{rp}' must exist to test ACLs.".format(
             rp=dir_rp)
         if Globals.win_acls_active == 0:
             log.Log(
@@ -447,9 +441,8 @@ class FSAbilities:
             import win32security
             import pywintypes
         except ImportError:
-            log.Log(
-                "Unable to import win32security module. Windows ACLs\n"
-                "not supported by filesystem at %s" % dir_rp.get_safepath(), 4)
+            log.Log("Unable to import win32security module. Windows ACLs not "
+                    "supported by filesystem at {rp}".format(rp=dir_rp), 4)
             self.win_acls = 0
             return
         try:
@@ -470,18 +463,16 @@ class FSAbilities:
                     sd.GetSecurityDescriptorGroup(),
                     sd.GetSecurityDescriptorDacl(), None)
         except (OSError, AttributeError, pywintypes.error):
-            log.Log(
-                "Unable to load a Windows ACL.\nWindows ACLs not supported "
-                "by filesystem at %s" % dir_rp.get_safepath(), 4)
+            log.Log("Unable to load a Windows ACL. Windows ACLs not supported "
+                    "by filesystem at {rp}".format(rp=dir_rp), 4)
             self.win_acls = 0
             return
 
         try:
             win_acls.init_acls()
         except (OSError, AttributeError, pywintypes.error):
-            log.Log(
-                "Unable to init win_acls.\nWindows ACLs not supported by "
-                "filesystem at %s" % dir_rp.get_safepath(), 4)
+            log.Log("Unable to init win_acls. Windows ACLs not supported by "
+                    "filesystem at {rp}".format(rp=dir_rp), 4)
             self.win_acls = 0
             return
         self.win_acls = 1
@@ -645,14 +636,14 @@ class FSAbilities:
         period_rp = testdir.append("foo.")
         if period_rp.lstat():
             log.Log.FatalError(
-                "File '{rp!s}' already exists where it shouldn't, something "
+                "File '{rp}' already exists where it shouldn't, something "
                 "is very wrong with your file system.".format(rp=period_rp))
 
         tmp_rp = testdir.append("foo")
         tmp_rp.touch()
         if not tmp_rp.lstat():
             log.Log.FatalError(
-                "File '{rp!s}' doesn't exist even though it's been created, "
+                "File '{rp}' doesn't exist even though it's been created, "
                 "something is very wrong with your file system.".format(
                     rp=tmp_rp))
 
@@ -690,12 +681,10 @@ class FSAbilities:
                 return
 
         # no file could be found to do any test
-        log.Log(
-            "Warning: could not determine if source directory at\n"
-            "  %s\npermits trailing spaces or periods in "
-            "filenames because we can't find any files.\n"
-            "It will be treated as permitting such files." %
-            rp.get_safepath(), 2)
+        log.Log("Warning: could not determine if source directory at "
+                "  {rp} permits trailing spaces or periods in "
+                "filenames because we can't find any files. "
+                "It will be treated as permitting such files.".format(rp=rp), 2)
         self.escape_trailing_spaces = 0
 
 
@@ -900,13 +889,12 @@ class BackupSetGlobals(SetGlobals):
                 ctq_rp.write_bytes(suggested_ctq)
                 return (suggested_ctq, 1)
             else:
-                log.Log.FatalError(
-                    """New quoting requirements!
+                log.Log.FatalError("""New quoting requirements!
 
-The quoting chars this session needs %r do not match
-the repository settings %r listed in
+The quoting chars this session needs '{sctq}' do not match
+the repository settings '{actq}' listed in
 
-%s
+{rp}
 
 This may be caused when you copy an rdiff-backup repository from a
 normal file system onto a windows one that cannot support the same
@@ -915,8 +903,8 @@ case-insensitive one that previously only had case-insensitive ones
 backed up onto it.
 
 By specifying the --force option, rdiff-backup will migrate the
-repository from the old quoting chars to the new ones.""" %
-                    (suggested_ctq, actual_ctq, ctq_rp.get_safepath()))
+repository from the old quoting chars to the new ones.""".format(
+                    sctq=suggested_ctq, actq=actual_ctq, rp=ctq_rp))
         return (actual_ctq, None)  # Maintain Globals override
 
 

--- a/src/rdiff_backup/increment.py
+++ b/src/rdiff_backup/increment.py
@@ -33,7 +33,7 @@ def Increment(new, mirror, incpref):
     file to incpref.
 
     """
-    log.Log("Incrementing mirror file %s" % mirror.get_safepath(), 5)
+    log.Log("Incrementing mirror file {rp}".format(rp=mirror), 5)
     if ((new and new.isdir()) or mirror.isdir()) and not incpref.lstat():
         incpref.mkdir()
 
@@ -70,7 +70,7 @@ def get_inc(rp, typestr, time=None):
         incrp = rp.__class__(rp.conn, dirname, (addtostr(basename), ))
     if incrp.lstat():
         log.Log.FatalError(
-            "New increment path '{rp!s}' shouldn't exist, something went "
+            "New increment path '{rp}' shouldn't exist, something went "
             "really wrong.".format(rp=incrp))
     return incrp
 

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -196,7 +196,7 @@ class Logger:
             self.logfp = rpath.open("ab")
         except (OSError, IOError) as e:
             raise LoggerError(
-                "Unable to open logfile %s: %s" % (rpath.path, e))
+                "Unable to open logfile {rp}: {exc}".format(rp=rpath, exc=e))
         self.log_file_local = 1
         self.logrp = rpath
 
@@ -304,14 +304,6 @@ class ErrorLog:
         cls._log_fileobj.write(_to_bytes(logstr))
 
     @classmethod
-    def get_indexpath(cls, obj):
-        """Return filename for logging.  rp is a rpath, string, or tuple"""
-        if getattr(obj, 'get_safeindexpath', None):
-            return obj.get_safeindexpath()
-        else:
-            return repr(obj)
-
-    @classmethod
     def write_if_open(cls, error_type, rp, exc):
         """Call cls.write(...) if error log open, only log otherwise"""
         if not Globals.isbackup_writer and Globals.backup_writer:
@@ -337,7 +329,7 @@ class ErrorLog:
         assert (error_type == "ListError" or error_type == "UpdateError"
                 or error_type == "SpecialFileError"), (
             "Unknown error type {etype}".format(etype=error_type))
-        return "%s: '%s' %s" % (error_type, cls.get_indexpath(rp), exc)
+        return "%s: '%s' %s" % (error_type, str(rp), exc)
 
 
 def _to_bytes(logline, encoding=LOGFILE_ENCODING):

--- a/src/rdiff_backup/longname.py
+++ b/src/rdiff_backup/longname.py
@@ -144,7 +144,7 @@ def get_mirror_inc_rps(rorp_pair, mirror_root, inc_root=None):
         index = new_rorp.index
     else:
         log.Log.FatalError(
-            "Neither old '{orp!s}' nor new path '{nrp!s}' is existing.".format(
+            "Neither old '{orp}' nor new path '{nrp}' is existing.".format(
                 orp=old_rorp, nrp=new_rorp))
 
     alt_inc, inc_rp = find_inc_pair(index, mirror_rp, alt_mirror, alt_inc)
@@ -169,9 +169,8 @@ def update_rf(rf, rorp, mirror_root):
 
     def update_incs(rf, inc_base):
         """Swap inclist in rf with those with base inc_base and return"""
-        log.Log(
-            "Restoring with increment base %s for file %s" %
-            (_safe_str(inc_base), rorp.get_safeindexpath()), 6)
+        log.Log("Restoring with increment base {inc} for file {rp}".format(
+            inc=_safe_str(inc_base), rp=rf), 6)
         rf.inc_rp = _get_long_rp(inc_base)
         rf.inc_list = _get_inclist(inc_base)
         rf.set_relevant_incs()
@@ -281,7 +280,7 @@ def _get_next_free_filename():
     filename = b'%i' % _free_name_counter
     rp = _get_long_rp(filename)
     assert not rp.lstat(), (
-        "Unexpected file '{rp!s}' found".format(rp=rp))
+        "Unexpected file '{rp}' found".format(rp=rp))
     _free_name_counter += 1
     write_next_free(_free_name_counter)
     return filename

--- a/src/rdiff_backup/manage.py
+++ b/src/rdiff_backup/manage.py
@@ -95,7 +95,7 @@ def delete_earlier_than_local(baserp, time):
     for rp in yield_files(baserp):
         if ((rp.isincfile() and rp.getinctime() < time)
                 or (rp.isdir() and not rp.listdir())):
-            Log("Deleting increment file %s" % rp.get_safepath(), 5)
+            Log("Deleting increment file {rp}".format(rp=rp), 5)
             rp.delete()
 
 

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -295,7 +295,7 @@ class FlatFile:
                 compress = 1
             else:
                 log.Log.FatalError(
-                    "Checking the path '{rp!s}' went wrong.".format(rp=rp_base))
+                    "Checking the path '{rp}' went wrong.".format(rp=rp_base))
         if mode == 'r' or mode == 'rb':
             self.rp = rp_base
             self.fileobj = self.rp.open("rb", compress)
@@ -309,7 +309,7 @@ class FlatFile:
             else:
                 self.rp = rp_base
                 assert not self.rp.lstat(), (
-                    "Path '{rp!s}' can't exist before it's opened.".format(
+                    "Path '{rp}' can't exist before it's opened.".format(
                         rp=self.rp))
                 self.fileobj = self.rp.open("wb", compress=compress)
         else:
@@ -537,7 +537,7 @@ class Manager:
     def _add_incrp(self, rp):
         """Add rp to list of inc rps in the rbdir"""
         assert rp.isincfile(), (
-            "Path '{irp!s}' must be an increment file.".format(irp=rp))
+            "Path '{irp}' must be an increment file.".format(irp=rp))
         self.rplist.append(rp)
         time = rp.getinctime()
         if time in self.timerpmap:
@@ -607,9 +607,9 @@ class Manager:
         triple = map(os.fsencode, (prefix, timestr, typestr))
         filename = b'.'.join(triple)
         rp = Globals.rbdir.append(filename)
-        assert not rp.lstat(), "File '{rp!s}' shouldn't exist.".format(rp=rp)
+        assert not rp.lstat(), "File '{rp}' shouldn't exist.".format(rp=rp)
         assert rp.isincfile(), (
-            "Path '{irp!s}' must be an increment file.".format(irp=rp))
+            "Path '{irp}' must be an increment file.".format(irp=rp))
         return flatfileclass(rp, 'w', callback=self._add_incrp)
 
 
@@ -656,20 +656,19 @@ class PatchDiffMan(Manager):
         for (time, rp) in sortlist:
             if time in unique_set:
                 if Globals.allow_duplicate_timestamps:
-                    log.Log("Warning: metadata file '%s' has a duplicate "
+                    log.Log("Warning: metadata file '{rp}' has a duplicate "
                             "timestamp date, you might not be able to "
                             "recover files on or earlier than this date. "
                             "Assuming you're in the process of cleaning up "
-                            "your repository." %
-                            rp.get_safepath(), 2)
+                            "your repository.".format(rp=rp), 2)
                 else:
                     log.Log.FatalError(
-                        "Metadata file '%s' has a duplicate timestamp date, "
-                        "you might not be able to recover files on or earlier "
-                        "than this date. "
+                        "Metadata file '{rp}' has a duplicate timestamp "
+                        "date, you might not be able to recover files on or "
+                        "earlier than this date. "
                         "Check the man page on how to clean up your repository "
-                        "using the '--allow-duplicate-timestamps' option." %
-                        rp.get_safepath())
+                        "using the '--allow-duplicate-timestamps' "
+                        "option.".format(rp=rp))
             else:
                 unique_set.add(time)
 
@@ -685,7 +684,7 @@ class PatchDiffMan(Manager):
             return (None, None)
         newrp, oldrp = inclist[:2]
         assert newrp.getinctype() == oldrp.getinctype() == b'snapshot', (
-            "New '{nrp!s}' and old '{orp!s}' paths must be of "
+            "New '{nrp}' and old '{orp}' paths must be of "
             "type 'snapshot'.".format(nrp=newrp, orp=oldrp))
 
         chainlen = 1

--- a/src/rdiff_backup/regress.py
+++ b/src/rdiff_backup/regress.py
@@ -115,9 +115,7 @@ class RegressITRB(rorpiter.ITRBranch):
     def fast_process_file(self, index, rf):
         """Process when nothing is a directory"""
         if not rf.metadata_rorp.equal_loose(rf.mirror_rp):
-            log.Log(
-                "Regressing file %s" % (rf.metadata_rorp.get_safeindexpath()),
-                5)
+            log.Log("Regressing file {rp}".format(rp=rf.metadata_rorp), 5)
             if rf.metadata_rorp.isreg():
                 self._restore_orig_regfile(rf)
             else:
@@ -129,7 +127,7 @@ class RegressITRB(rorpiter.ITRBranch):
                 else:
                     rpath.copy_with_attribs(rf.metadata_rorp, rf.mirror_rp)
         if rf.regress_inc:
-            log.Log("Deleting increment %s" % rf.regress_inc.get_safepath(), 5)
+            log.Log("Deleting increment {rp}".format(rp=rf.regress_inc), 5)
             rf.regress_inc.delete()
 
     def start_process_directory(self, index, rf):
@@ -151,26 +149,24 @@ class RegressITRB(rorpiter.ITRBranch):
             if rf.mirror_rp.isdir():
                 rf.mirror_rp.setdata()
                 if not rf.metadata_rorp.equal_loose(rf.mirror_rp):
-                    log.Log(
-                        "Regressing attributes of %s" %
-                        rf.mirror_rp.get_safepath(), 5)
+                    log.Log("Regressing attributes of {rp}".format(rp=rf), 5)
                     rpath.copy_attribs(rf.metadata_rorp, rf.mirror_rp)
             else:
                 rf.mirror_rp.delete()
-                log.Log("Regressing file %s" % rf.mirror_rp.get_safepath(), 5)
+                log.Log("Regressing file {rp}".format(rp=rf.mirror_rp), 5)
                 rpath.copy_with_attribs(rf.metadata_rorp, rf.mirror_rp)
         else:  # replacing a dir with some other kind of file
             assert rf.mirror_rp.isdir(), (
-                "Mirror '{mrp!s}' can only be a directory.".format(
+                "Mirror '{mrp!r}' can only be a directory.".format(
                     mrp=rf.mirror_rp))
-            log.Log("Replacing directory %s" % rf.mirror_rp.get_safepath(), 5)
+            log.Log("Replacing directory {rp}".format(rp=rf), 5)
             if rf.metadata_rorp.isreg():
                 self._restore_orig_regfile(rf)
             else:
                 rf.mirror_rp.delete()
                 rpath.copy_with_attribs(rf.metadata_rorp, rf.mirror_rp)
         if rf.regress_inc:
-            log.Log("Deleting increment %s" % rf.regress_inc.get_safepath(), 5)
+            log.Log("Deleting increment {rp}".format(rp=rf), 5)
             rf.regress_inc.delete()
 
     def _restore_orig_regfile(self, rf):
@@ -182,7 +178,7 @@ class RegressITRB(rorpiter.ITRBranch):
 
         """
         assert rf.metadata_rorp.isreg(), (
-            "Metadata path '{mrp!s}' can only be regular file.".format(
+            "Metadata path '{mrp}' can only be regular file.".format(
                 mrp=rf.metadata_rorp))
         if rf.mirror_rp.isreg():
             tf = rf.mirror_rp.get_temp_rpath(sibling=True)
@@ -361,7 +357,7 @@ def _regress_rbdir(meta_manager):
 
     for new_rp in meta_manager.timerpmap[unsuccessful_backup_time]:
         if new_rp.getincbase_bname() != b'current_mirror':
-            log.Log("Deleting old diff at %s" % new_rp.get_safepath(), 5)
+            log.Log("Deleting old diff at {rp}".format(rp=new_rp), 5)
             new_rp.delete()
 
     for rp in meta_diffs:
@@ -390,7 +386,7 @@ def _recreate_meta(meta_manager):
     finalrp = Globals.rbdir.append(
         b"mirror_metadata.%b.snapshot.gz" % Time.timetobytes(regress_time))
     assert not finalrp.lstat(), (
-        "Metadata path '{mrp!s}' shouldn't exist.".format(mrp=finalrp))
+        "Metadata path '{mrp}' shouldn't exist.".format(mrp=finalrp))
     rpath.rename(temprp[0], finalrp)
     if Globals.fsync_directories:
         Globals.rbdir.fsync()
@@ -434,10 +430,9 @@ def _iterate_meta_rfs(mirror_rp, inc_rp):
     for raw_rf, metadata_rorp in collated:
         raw_rf = longname.update_regressfile(raw_rf, metadata_rorp, mirror_rp)
         if not raw_rf:
-            log.Log(
-                "Warning, metadata file has entry for %s,\n"
-                "but there are no associated files." %
-                (metadata_rorp.get_safeindexpath(), ), 2)
+            log.Log("Warning, metadata file has entry for {rp}, "
+                    "but there are no associated files.".format(
+                        rp=metadata_rorp), 2)
             continue
         raw_rf.set_metadata_rorp(metadata_rorp)
         yield raw_rf

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -75,7 +75,7 @@ def listrp(rp):
     """Like rp.listdir() but return [] if error, and sort results"""
 
     def error_handler(exc):
-        log.Log("Error listing directory %s" % rp.get_safepath(), 2)
+        log.Log("Error listing directory {rp}".format(rp=rp), 2)
         return []
 
     dir_listing = check_common_error(error_handler, rp.listdir)

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -91,7 +91,7 @@ class Select:
     def __init__(self, rootrp):
         """Select initializer.  rpath is the root directory"""
         assert isinstance(rootrp, rpath.RPath), (
-            "Root path '{rp!s}' must be a real remote path.".format(rp=rootrp))
+            "Root path '{rp}' must be a real remote path.".format(rp=rootrp))
         self.selection_functions = []
         self.rpath = rootrp
         self.prefix = self.rpath.path

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -345,7 +345,7 @@ class FileStats:
         suffix = Globals.compression and 'data.gz' or 'data'
         cls._rp = increment.get_inc(rpbase, suffix, Time.curtime)
         assert not cls._rp.lstat(), (
-            "Path '{rp!s}' shouldn't be existing.".format(rp=cls._rp))
+            "Path '{rp}' shouldn't be existing.".format(rp=cls._rp))
         cls._fileobj = cls._rp.open("wb", compress=Globals.compression)
 
         cls._line_sep = Globals.null_separator and b'\0' or b'\n'

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -82,9 +82,8 @@ class ACL:
             sd = rp.conn.win32security.GetNamedSecurityInfo(
                 os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
         except (OSError, IOError, pywintypes.error) as exc:
-            log.Log(
-                "Warning: unable to read ACL from %s: %s" % (repr(rp.path),
-                                                             exc), 4)
+            log.Log("Warning: unable to read ACL from {rp}: {exc}".format(
+                rp=rp, exc=exc), 4)
             return
 
         if skip_inherit_only:
@@ -176,9 +175,8 @@ class ACL:
                 and sd.GetSecurityDescriptorSacl() or None
             )
         except (OSError, IOError, pywintypes.error) as exc:
-            log.Log(
-                "Warning: unable to set ACL on %s: %s" % (repr(rp.path), exc),
-                4)
+            log.Log("Warning: unable to set ACL on {rp}: {exc}".format(
+                rp=rp, exc=exc), 4)
 
     def from_string(self, acl_str):
 

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -173,13 +173,12 @@ class BackupAction(actions.BaseAction):
         # if not Globals.select_mirror.Select(relative_rpout):
         #     return
 
-        self.log("The target directory '{tgt}' may be contained in the "
-                 "source directory '{src}'. "
+        self.log("The target directory '{trp}' may be contained in the "
+                 "source directory '{srp}'. "
                  "This could cause an infinite recursion. "
                  "You may need to use the --exclude option "
                  "(which you might already have done).".format(
-                     tgt=rpout.get_safepath(), src=rpin.get_safepath()),
-                 self.log.WARNING)
+                     trp=rpout, srp=rpin), self.log.WARNING)
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -149,13 +149,13 @@ class ListAction(actions.BaseAction):
         for rorp in self.source.base_dir.conn.restore.ListChangedSince(
                 self.mirror_rpath, self.inc_rpath, self.action_time):
             # This is a hack, see restore.ListChangedSince for rationale
-            print(rorp.get_safeindexpath())
+            print(str(rorp))
 
     def _list_files_at_time(self):
         """List files in archive under rp that are present at restoretime"""
         for rorp in self.source.base_dir.conn.restore.ListAtTime(
                 self.mirror_rpath, self.inc_rpath, self.action_time):
-            print(rorp.get_safeindexpath())
+            print(str(rorp))
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -66,12 +66,11 @@ class RemoveAction(actions.BaseAction):
         # the source directory must directly point at the base directory of
         # the repository
         if self.source.restore_index:
-            self.log("Increments for directory '{odir}' cannot be removed "
+            self.log("Increments for directory '{orp}' cannot be removed "
                      "separately.\n"
-                     "Instead run on entire directory '{bdir}'.".format(
-                         odir=self.source.orig_path.get_safepath(),
-                         bdir=self.source.base_dir.get_safepath()),
-                     self.log.ERROR)
+                     "Instead run on entire directory '{brp}'.".format(
+                         orp=self.source.orig_path,
+                         brp=self.source.base_dir), self.log.ERROR)
             return_code |= 1
 
         return return_code

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -160,17 +160,16 @@ class RestoreAction(actions.BaseAction):
             # source could be read-only, so we don't try to regress it
             self.log("Previous backup to {rp} seems to have failed. "
                      "Use rdiff-backup to 'regress' first the failed backup, "
-                     "then try again to restore.".format(
-                         rp=self.source.base_dir.get_safepath()),
-                     self.log.ERROR)
+                     "then try again to restore".format(
+                         rp=self.source.base_dir), self.log.ERROR)
             return 1
         try:
             restore.Restore(
                 self.source.base_dir.new_index(self.source.restore_index),
                 self.inc_rpath, self.target.base_dir, self.action_time)
         except IOError as exc:
-            self.log("Could not complete restore due to\n{exc}".format(exc=exc),
-                     self.log.ERROR)
+            self.log("Could not complete restore due to '{exc}'".format(
+                exc=exc), self.log.ERROR)
             return 1
         else:
             self.log("Restore successfully finished", self.log.INFO)

--- a/src/rdiffbackup/locations/__init__.py
+++ b/src/rdiffbackup/locations/__init__.py
@@ -39,11 +39,11 @@ class ReadLocation(Location):
         # check that the source exists and is a directory
         if not self.base_dir.lstat():
             self.log("Source path {rp} does not exist".format(
-                rp=self.base_dir.get_safepath()), self.log.ERROR)
+                rp=self.base_dir), self.log.ERROR)
             return_code |= 1
         elif not self.base_dir.isdir():
             self.log("Source path {rp} is not a directory".format(
-                rp=self.base_dir.get_safepath()), self.log.ERROR)
+                rp=self.base_dir), self.log.ERROR)
             return_code |= 1
         return return_code
 
@@ -63,17 +63,13 @@ class WriteLocation(Location):
         # check that target is a directory or doesn't exist
         if (self.base_dir.lstat() and not self.base_dir.isdir()):
             if self.force:
-                self.log(
-                    "Target {rp} exists but isn't a directory, "
-                    "and will be force deleted".format(
-                        rp=self.base_dir.get_safepath()),
-                    self.log.WARNING)
+                self.log("Target {rp} exists but isn't a directory, "
+                         "and will be force deleted".format(
+                             rp=self.base_dir), self.log.WARNING)
             else:
-                self.log(
-                    "Target {rp} exists and is not a directory, "
-                    "call with '--force' to overwrite".format(
-                        rp=self.base_dir.get_safepath()),
-                    self.log.ERROR)
+                self.log("Target {rp} exists and is not a directory, "
+                         "call with '--force' to overwrite".format(
+                             rp=self.base_dir), self.log.ERROR)
                 ret_code |= 1
 
         return ret_code
@@ -95,7 +91,7 @@ class WriteLocation(Location):
                 self.base_dir.chmod(0o700)  # only read-writable by its owner
         except os.error:
             self.log("Unable to delete and/or create directory {rp}".format(
-                rp=self.base_dir.get_safepath()), self.log.ERROR)
+                rp=self.base_dir), self.log.ERROR)
             return 1
 
         return 0  # all is good

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -68,17 +68,13 @@ class WriteDir(Dir, locations.WriteLocation):
                 and self.base_dir.isdir()
                 and self.base_dir.listdir()):
             if self.force:
-                self.log(
-                    "Target {rp} exists and isn't empty, "
-                    "content might be force overwritten by restore".format(
-                        rp=self.base_dir.get_safepath()),
-                    self.log.WARNING)
+                self.log("Target {rp} exists and isn't empty, content might "
+                         "be force overwritten by restore".format(
+                             rp=self.base_dir), self.log.WARNING)
             else:
-                self.log(
-                    "Target {rp} exists and isn't empty, "
-                    "call with '--force' to overwrite".format(
-                        rp=self.base_dir.get_safepath()),
-                    self.log.ERROR)
+                self.log("Target {rp} exists and isn't empty, "
+                         "call with '--force' to overwrite".format(
+                             rp=self.base_dir), self.log.ERROR)
                 ret_code |= 1
 
         return ret_code

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -106,7 +106,7 @@ class Repo():
                 """Bad rdiff-backup-data dir on destination side
 
 The rdiff-backup data directory
-{data}
+{drp}
 exists, but we cannot find a valid current_mirror marker.  You can
 avoid this message by removing the rdiff-backup-data directory;
 however any data in it will be lost.
@@ -116,7 +116,7 @@ into a new directory failed.  If this is the case it is safe to delete
 the rdiff-backup-data directory because there is no important
 information in it.
 
-""".format(data=self.data_dir.get_safepath()))
+""".format(drp=self.data_dir))
         elif len(curmir_incs) == 1:
             return False
         else:
@@ -128,7 +128,7 @@ information in it.
                         "Could not check if rdiff-backup is currently"
                         "running due to\n{exc}".format(exc=exc))
             assert len(curmir_incs) == 2, (
-                "Found more than 2 current_mirror incs in '{rp!s}'.".format(
+                "Found more than 2 current_mirror incs in '{rp}'.".format(
                     rp=self.data_dir))
             return True
 
@@ -175,17 +175,16 @@ class ReadRepo(Repo, locations.ReadLocation):
             # there is nothing to save, the user must first give a correct path
             return 1
         else:
-            self.log("Using repository '{rp}'".format(
-                rp=self.base_dir.get_safepath()), self.log.INFO)
+            self.log("Using repository '{rp}'".format(rp=self.base_dir),
+                     self.log.INFO)
         ret_code = super().check()
         if not self.data_dir.isdir():
             self.log("Source '{rp}' doesn't have an 'rdiff-backup-data' "
-                     "sub-directory".format(rp=self.base_dir.get_safepath()),
-                     self.log.ERROR)
+                     "sub-directory".format(rp=self.base_dir), self.log.ERROR)
             ret_code |= 1
         elif not self.incs_dir.isdir():
             self.log("Data directory '{rp}' doesn't have an 'increments' "
-                     "sub-directory".format(rp=self.data_dir.get_safepath()),
+                     "sub-directory".format(rp=self.data_dir),
                      self.log.WARNING)  # used to be normal  # compat200
             # ret_code |= 1  # compat200
         return ret_code
@@ -240,18 +239,13 @@ class WriteRepo(Repo, locations.WriteLocation):
                 and self.base_dir.listdir()
                 and not self.data_dir.lstat()):
             if self.force:
-                self.log(
-                    "Target '{repo}' does not look like a rdiff-backup "
-                    "repository but will be force overwritten".format(
-                        repo=self.base_dir.get_safepath()),
-                    self.log.WARNING)
+                self.log("Target '{rp}' does not look like a rdiff-backup "
+                         "repository but will be force overwritten".format(
+                             rp=self.base_dir), self.log.WARNING)
             else:
-                self.log(
-                    "Target '{repo}' does not look like a rdiff-backup "
-                    "repository, "
-                    "call with '--force' to overwrite".format(
-                        repo=self.base_dir.get_safepath()),
-                    self.log.ERROR)
+                self.log("Target '{rp}' does not look like a rdiff-backup "
+                         "repository, call with '--force' to overwrite".format(
+                             rp=self.base_dir), self.log.ERROR)
                 ret_code |= 1
 
         return ret_code
@@ -315,8 +309,7 @@ class WriteRepo(Repo, locations.WriteLocation):
         trying to do a regression, which would probably anyway fail.
         """
         self.log("Found interrupted initial backup in {rp}. "
-                 "Removing...".format(rp=self.data_dir.get_safepath()),
-                 self.log.NOTE)
+                 "Removing...".format(rp=self.data_dir), self.log.NOTE)
         rbdir_files = self.data_dir.listdir()
 
         # Try to delete the increments dir first

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -726,7 +726,7 @@ class FinalCorrupt(PathSetter):
                      current_time=10000)
 
         out_subdir = Local.rpout.append(in_subdir.index[-1])
-        log.Log("Deleting %s" % out_subdir.get_safepath(), 3)
+        log.Log("Deleting {rp}".format(rp=out_subdir), 3)
         out_subdir.delete()
         rdiff_backup(True,
                      True,

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -431,10 +431,10 @@ def compare_recursive(src_rp, dest_rp,
 
     """
 
-    Log(
-        "Comparing %s and %s, hardlinks %s, eas %s, acls %s" %
-        (src_rp.get_safepath(), dest_rp.get_safepath(), compare_hardlinks,
-         compare_eas, compare_acls), 3)
+    Log("Comparing {srp} and {drp}, hardlinks {chl}, "
+        "eas {cea}, acls {cacl}".format(
+            srp=src_rp, drp=dest_rp, chl=compare_hardlinks,
+            cea=compare_eas, cacl=compare_acls), 3)
     if compare_hardlinks:
         reset_hardlink_dicts()
     src_iter, dest_iter = _get_selection_functions(

--- a/testing/errorsrecovertest.py
+++ b/testing/errorsrecovertest.py
@@ -33,7 +33,7 @@ class BrokenRepoTest(unittest.TestCase):
         source_rp.mkdir()
         for suffix in range(1, 15):
             source_rp.append("file%02d" % suffix).touch()
-            rdiff_backup(1, 1, source_rp.get_path(), target_rp.get_path(),
+            rdiff_backup(1, 1, source_rp.__fspath__(), target_rp.__fspath__(),
                          current_time=suffix * 10000)
         # identify the oldest (aka first) mirror metadata snapshot
         # and sort the list because some filesystems don't respect the order
@@ -48,26 +48,26 @@ class BrokenRepoTest(unittest.TestCase):
         rpath.copy(meta_snapshot_rp, meta_dupldiff_rp)
 
         # this succeeds
-        rdiff_backup(1, 1, target_rp.get_path(), None,
+        rdiff_backup(1, 1, target_rp.__fspath__(), None,
                      extra_options=b"--check-destination-dir")
         # now this should fail
         source_rp.append("file15").touch()
-        rdiff_backup(1, 1, source_rp.get_path(), target_rp.get_path(),
+        rdiff_backup(1, 1, source_rp.__fspath__(), target_rp.__fspath__(),
                      current_time=15 * 10000, expected_ret_val=1)
         # and this should also fail
-        rdiff_backup(1, 1, target_rp.get_path(), None, expected_ret_val=1,
+        rdiff_backup(1, 1, target_rp.__fspath__(), None, expected_ret_val=1,
                      extra_options=b"--check-destination-dir")
         # but this should succeed
-        rdiff_backup(1, 1, target_rp.get_path(), None,
+        rdiff_backup(1, 1, target_rp.__fspath__(), None,
                      extra_options=b"--allow-duplicate-timestamps --check-destination-dir")
         # now we can clean-up, getting rid of the duplicate metadata mirrors
         # NOTE: we could have cleaned-up even without checking/fixing the directory
         #       but this shouldn't be the recommended practice.
-        rdiff_backup(1, 1, target_rp.get_path(), None,
+        rdiff_backup(1, 1, target_rp.__fspath__(), None,
                      extra_options=b"--remove-older-than 100000 --force")
         # and this should at last succeed
         source_rp.append("file16").touch()
-        rdiff_backup(1, 1, source_rp.get_path(), target_rp.get_path(),
+        rdiff_backup(1, 1, source_rp.__fspath__(), target_rp.__fspath__(),
                      current_time=16 * 10000)
 
 

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -530,7 +530,7 @@ class CommandTest(unittest.TestCase):
         self.assertTrue(
             backuprp.append('rdiff-backup-data').isdir()
             and backuprp.append('empty').isdir(),
-            "Backup to %s didn't happen properly." % backuprp.get_safepath())
+            "Backup to {rp} didn't happen properly.".format(rp=backuprp))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
DEV: RORPath and RPath classes are now PathAlike and can be safely output as string, closes #84
This meant also getting rid of the get_safepath and get_safeindex
functions, and refactoring a lot of log messages.