### PR TITLE
rdiff-backup-delete permissions fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
     librsync-dev \
     python3-all-dev \
     python3-pylibacl \
-    python3-pyxattr
+    python3-pyxattr \
+    pandoc
 
 # Build dependencies specific for rdiff-backup development and testing
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \

--- a/src/rdiff-backup-delete
+++ b/src/rdiff-backup-delete
@@ -164,7 +164,8 @@ def _remove_from_metadata(repopath, file, dry_run):
             return line == b'File ' + repopath.metaquote + b'\n' or line.startswith(b'File ' + repopath.metaquote + b'/')
 
     elif (os.path.basename(file).startswith(b'extended_attributes')
-          or os.path.basename(file).startswith(b'access_control_lists')):
+          or os.path.basename(file).startswith(b'access_control_lists')
+          or os.path.basename(file).startswith(b'win_access_control_lists')):
         start_marker = b'# file: '
 
         def matches(line):

--- a/src/rdiff-backup-delete
+++ b/src/rdiff-backup-delete
@@ -226,23 +226,49 @@ def _remove_increments(path, dry_run):
 
 def _rmtree(path, dry_run):
     """
-    Custom implementation of shutil.rmtree() to support deletion of symlink.
+    Custom implementation of shutil.rmtree() to handle permission errors,
+    fifo and symlink deletion.
     """
+    if dry_run:
+        return
+
+    # Try to change the permissions of the file or directory to delete them.
+    def on_error(func, path, exc):
+        """
+        Handle permissions error while deleting file or directory by changing
+        the permissions to allow deletion.
+        """
+        # Parent directory must allow o+rwx
+        parent_dir = os.path.dirname(path)
+        if not os.access(parent_dir, os.W_OK | os.R_OK | os.X_OK):
+            prev_mode = os.stat(parent_dir).st_mode
+            os.chmod(parent_dir, prev_mode | stat.S_IRWXU)
+        if not os.access(path, os.W_OK | os.R_OK):
+            os.chmod(path, 0o0600)
+        return func(path)
+
     try:
         mode = os.lstat(path).st_mode
-    except os.error:
+    except FileNotFoundError:
+        # Nothing to delete
         mode = 0
+    except PermissionError as exc:
+        mode = on_error(os.lstat, path, exc).st_mode
     if stat.S_ISDIR(mode):
         names = []
         names = os.listdir(path)
         for name in names:
             fullname = os.path.join(path, name)
             _rmtree(fullname, dry_run)
-        if not dry_run:
+        try:
             os.rmdir(path)
+        except PermissionError as exc:
+            on_error(os.rmdir, path, exc)
     elif mode:
-        if not dry_run:
+        try:
             os.remove(path)
+        except PermissionError as exc:
+            on_error(os.remove, path, exc)
 
 
 def _unquote(name):


### PR DESCRIPTION
I've discovert two issues with rdiff-backup-delete lately.
1. Permissions error are raised when the directories has `r-x` This seams to happen often for windows to Linux backup
2. Need to support `win_access_control_lists`