### PR TITLE
Fix Windows long name error + get rid of alias exceptions

### DIFF
--- a/src/rdiff_backup/Hardlink.py
+++ b/src/rdiff_backup/Hardlink.py
@@ -147,14 +147,14 @@ def link_rp(diff_rorp, dest_rpath, dest_root=None):
     dest_link_rpath = dest_root.new_index(diff_rorp.get_link_flag())
     try:
         dest_rpath.hardlink(dest_link_rpath.path)
-    except EnvironmentError as exc:
+    except OSError as exc:
         # This can happen if the source of dest_link_rpath was deleted
         # after it's linking info was recorded but before
         # dest_link_rpath was written.
         if exc.errno == errno.ENOENT:
             dest_rpath.touch()  # This will cause an UpdateError later
         else:
-            raise Exception("EnvironmentError '%s' linking %s to %s" %
+            raise Exception("OS error '%s' linking %s to %s" %
                             (exc, dest_rpath.path, dest_link_rpath.path))
 
 

--- a/src/rdiff_backup/backup.py
+++ b/src/rdiff_backup/backup.py
@@ -268,7 +268,7 @@ class DestinationStruct:
             dest_rp.chmod(0o400 | dest_rp.getperms())
         try:
             return Rdiff.get_signature(dest_rp)
-        except IOError as e:
+        except OSError as e:
             if (e.errno == errno.EPERM or e.errno == errno.EACCES):
                 try:
                     # Try chmod'ing anyway -- This can work on NFS and AFS
@@ -276,7 +276,7 @@ class DestinationStruct:
                     # above for performance reasons.
                     dest_rp.chmod(0o400 | dest_rp.getperms())
                     return Rdiff.get_signature(dest_rp)
-                except (IOError, OSError):
+                except OSError:
                     log.Log.FatalError(
                         "Could not open {rp} for reading. Check "
                         "permissions on file.".format(rp=dest_rp))

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -264,14 +264,14 @@ class LowLevelPipeConnection(Connection):
             self.outpipe.write(headerchar + self._i2b(req_num, 1) + self._i2b(len(data), 7))
             self.outpipe.write(data)
             self.outpipe.flush()
-        except (IOError, AttributeError):
+        except (OSError, AttributeError):
             raise ConnectionWriteError()
 
     def _read(self, length):
         """Read length bytes from inpipe, returning result"""
         try:
             return self.inpipe.read(length)
-        except IOError:
+        except OSError:
             raise ConnectionReadError()
 
     def _b2i(self, b):

--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -70,7 +70,7 @@ class ExtendedAttributes:
         """Set the extended attributes from an rpath"""
         try:
             attr_list = rp.conn.xattr.list(rp.path, rp.issym())
-        except IOError as exc:
+        except OSError as exc:
             if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.ETXTBSY):
                 return  # if not supported, consider empty
             if exc.errno in (errno.EACCES, errno.ENOENT, errno.ELOOP):
@@ -88,7 +88,7 @@ class ExtendedAttributes:
             try:
                 self.attr_dict[attr] = \
                     rp.conn.xattr.get(rp.path, attr, rp.issym())
-            except IOError as exc:
+            except OSError as exc:
                 # File probably modified while reading, just continue
                 if exc.errno == errno.ENODATA:
                     continue
@@ -106,7 +106,7 @@ class ExtendedAttributes:
         for (name, value) in self.attr_dict.items():
             try:
                 rp.conn.xattr.set(rp.path, name, value, 0, rp.issym())
-            except IOError as exc:
+            except OSError as exc:
                 # Mac and Linux attributes have different namespaces, so
                 # fail gracefully if can't call xattr.set
                 if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.EACCES,
@@ -503,7 +503,7 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
 
     try:
         acl.applyto(rp.path)
-    except IOError as exc:
+    except OSError as exc:
         if exc.errno == errno.EOPNOTSUPP:
             log.Log("Warning: unable to set ACL on {rp}: {exc}".format(
                 rp=rp, exc=exc), 4)
@@ -531,7 +531,7 @@ def get_acl_lists_from_rp(rp):
         log.Log("Warning: unable to read ACL from {rp}: {exc}".format(
             rp=rp, exc=exc), 3)
         acl = None
-    except IOError as exc:
+    except OSError as exc:
         if exc.errno == errno.EOPNOTSUPP:
             acl = None
         else:
@@ -543,7 +543,7 @@ def get_acl_lists_from_rp(rp):
             log.Log("Warning: unable to read default ACL from {rp}: "
                     "{exc}".format(rp=rp, exc=exc), 3)
             def_acl = None
-        except IOError as exc:
+        except OSError as exc:
             if exc.errno == errno.EOPNOTSUPP:
                 def_acl = None
             else:

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -183,7 +183,7 @@ class FSAbilities:
         try:
             tmp_rp.chown(uid // 2 + 1, gid // 2 + 1)  # just choose random uid/gid
             tmp_rp.chown(0, 0)
-        except (IOError, OSError, AttributeError):
+        except (OSError, AttributeError):
             self.ownership = 0
         else:
             self.ownership = 1
@@ -199,8 +199,8 @@ class FSAbilities:
         try:
             hl_dest.hardlink(hl_source.path)
             if hl_source.getinode() != hl_dest.getinode():
-                raise IOError(errno.EOPNOTSUPP, "Hard links don't compare")
-        except (IOError, OSError, AttributeError):
+                raise OSError(errno.EOPNOTSUPP, "Hard links don't compare")
+        except (OSError, AttributeError):
             if Globals.preserve_hardlinks != 0:
                 log.Log("Warning: hard linking not supported by filesystem "
                         "at {rp}".format(rp=self.root_rp), 3)
@@ -212,7 +212,7 @@ class FSAbilities:
         """Set self.fsync_dirs if directories can be fsync'd"""
         try:
             testdir.fsync()
-        except (IOError, OSError):
+        except OSError:
             log.Log("Directories on file system at {rp} are not fsyncable."
                     "Assuming it's unnecessary.".format(rp=testdir), 4)
             self.fsync_dirs = 0
@@ -229,7 +229,7 @@ class FSAbilities:
             ord_rp = subdir.append(ordinary_filename)
             ord_rp.touch()
             ord_rp.delete()
-        except (IOError, OSError) as exc:
+        except OSError as exc:
             log.Log.FatalError(
                 "File with normal name '{rp}' couldn't be created, "
                 "and failed with '{exc}'.".format(rp=ord_rp, exc=exc))
@@ -241,14 +241,14 @@ class FSAbilities:
         try:
             ext_rp = subdir.append(extended_filename)
             ext_rp.touch()
-        except (IOError, OSError):
+        except OSError:
             if ext_rp and ext_rp.lstat():
                 ext_rp.delete()  # just to be very sure
             self.extended_filenames = 0
         else:
             try:
                 ext_rp.delete()
-            except (IOError, OSError):
+            except OSError:
                 # Broken CIFS setups will sometimes create UTF-8 files
                 # and even stat them, but not let us perform file operations
                 # on them. Test file cannot be deleted. UTF-8 chars not in the
@@ -270,14 +270,14 @@ class FSAbilities:
         try:
             win_rp = subdir.append(win_reserved_filename)
             win_rp.touch()
-        except (IOError, OSError):
+        except OSError:
             if win_rp and win_rp.lstat():
                 win_rp.delete()  # just to be very sure
             self.win_reserved_filenames = 1
         else:
             try:
                 win_rp.delete()
-            except (IOError, OSError):
+            except OSError:
                 self.win_reserved_filenames = 1
             else:
                 self.win_reserved_filenames = 0
@@ -302,7 +302,7 @@ class FSAbilities:
 
         try:
             posix1e.ACL(file=rp.path)
-        except IOError:
+        except OSError:
             log.Log("POSIX ACLs not supported by filesystem at {rp}".format(
                 rp=rp), 4)
             self.acls = 0
@@ -407,7 +407,7 @@ class FSAbilities:
             if write:
                 xattr.set(rp.path, b"user.test", test_ea)
                 read_ea = xattr.get(rp.path, b"user.test")
-        except IOError:
+        except OSError:
             log.Log("Extended attributes not supported by "
                     "filesystem at {rp}".format(rp=rp), 4)
             self.eas = 0
@@ -530,7 +530,7 @@ class FSAbilities:
                 os.path.join(reg_rp.path, b'..namedfork', b'rsrc'), 'rb')
             s_back = fp_read.read()
             fp_read.close()
-        except (OSError, IOError):
+        except OSError:
             self.resource_forks = 0
         else:
             self.resource_forks = (s_back == s)
@@ -551,7 +551,7 @@ class FSAbilities:
                     fp = rfork.open('rb')
                     fp.read()
                     fp.close()
-                except (OSError, IOError):
+                except OSError:
                     self.resource_forks = 0
                     return
                 self.resource_forks = 1
@@ -569,7 +569,7 @@ class FSAbilities:
             tmpf_rp.chmod(0o7777, 4)
             tmpd_rp.chmod(0o7000, 4)
             tmpd_rp.chmod(0o7777, 4)
-        except (OSError, IOError):
+        except OSError:
             self.high_perms = 0
         else:
             self.high_perms = 1
@@ -628,7 +628,7 @@ class FSAbilities:
         Windows and Linux/FAT32 will not preserve trailing spaces or periods.
         Linux/FAT32 behaves inconsistently: It will give an OSError,22 if
         os.mkdir() is called on a directory name with a space at the end, but
-        will give an IOError("invalid mode") if you attempt to create a filename
+        will give an OSError("invalid mode") if you attempt to create a filename
         with a space at the end. However, if a period is placed at the end of
         the name, Linux/FAT32 is consistent with Cygwin and Native Windows.
         """

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -143,8 +143,8 @@ class Logger:
         exception_string = self._exception_to_string()
         try:
             logging_func(exception_string, verbosity)
-        except IOError:
-            print("IOError while trying to log exception!")
+        except OSError:
+            print("OS error while trying to log exception!")
             print(exception_string)
 
     # @API(Log.setverbosity, 200)
@@ -194,7 +194,7 @@ class Logger:
                 conn=rpath.conn))
         try:
             self.logfp = rpath.open("ab")
-        except (OSError, IOError) as e:
+        except OSError as e:
             raise LoggerError(
                 "Unable to open logfile {rp}: {exc}".format(rp=rpath, exc=e))
         self.log_file_local = 1

--- a/src/rdiff_backup/longname.py
+++ b/src/rdiff_backup/longname.py
@@ -297,8 +297,13 @@ def _check_new_index(base, index, make_dirs=0):
     def wrap_call(func, *args):
         try:
             result = func(*args)
-        except EnvironmentError as exc:
-            if (exc.errno == errno.ENAMETOOLONG):
+        except OSError as exc:
+            # Windows with enabled long paths seems to consider too long
+            # filenames as having an incorrect syntax, but only under certain
+            # circumstances
+            if (exc.errno == errno.ENAMETOOLONG
+                    or (exc.errno == errno.EINVAL
+                        and hasattr(exc, "winerror") and exc.winerror == 123)):
                 return None
             raise
         return result

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -110,19 +110,20 @@ def check_common_error(error_handler, function, args=[]):
 
 
 def catch_error(exc):
-    """Return true if exception exc should be caught"""
-    for exception_class in (rpath.SkipFileException, rpath.RPathException,
-                            librsync.librsyncError, C.UnknownFileTypeError,
-                            zlib.error):
-        if isinstance(exc, exception_class):
-            return 1
-    if (isinstance(exc, EnvironmentError)
+    """
+    Return True if exception exc should be caught, else False.
+    """
+    if isinstance(exc, (rpath.SkipFileException, rpath.RPathException,
+                        librsync.librsyncError, C.UnknownFileTypeError,
+                        zlib.error)):
+        return True
+    if (isinstance(exc, OSError)
             # the invalid mode shows up in backups of /proc for some reason
             and ('invalid mode: rb' in str(exc)
                  or 'Not a gzipped file' in str(exc)
                  or exc.errno in _robust_errno_list)):
-        return 1
-    return 0
+        return True
+    return False
 
 
 def is_routine_fatal(exc):
@@ -139,7 +140,7 @@ def is_routine_fatal(exc):
         return "Lost connection to the remote system"
     elif isinstance(exc, SignalException):
         return "Killed with signal %s" % (exc, )
-    elif isinstance(exc, EnvironmentError) and exc.errno == errno.ENOTCONN:
+    elif isinstance(exc, OSError) and exc.errno == errno.ENOTCONN:
         return ("Filesystem reports connection failure:\n%s" % exc)
     return None
 

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1356,7 +1356,7 @@ class RPath(RORPath):
                     os.path.join(self.path, b'..namedfork', b'rsrc'), 'rb')
                 rfork = rfork_fp.read()
                 rfork_fp.close()
-            except (IOError, OSError):
+            except OSError:
                 rfork = b''
             self.data['resourcefork'] = rfork
         return rfork
@@ -1580,10 +1580,10 @@ def copy_reg_file(rpin, rpout, compress=0):
         pass
     try:
         return rpout.write_from_fileobj(rpin.open("rb"), compress=compress)
-    except IOError as e:
+    except OSError as e:
         if (e.errno == errno.ERANGE):
             log.Log.FatalError(
-                "'IOError - Result too large' while reading {rp}. "
+                "'OSError - Result too large' while reading {rp}. "
                 "If you are using a Mac, this is probably "
                 "the result of HFS+ filesystem corruption. "
                 "Please exclude this file from your backup "

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -81,7 +81,7 @@ class ACL:
         try:
             sd = rp.conn.win32security.GetNamedSecurityInfo(
                 os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
-        except (OSError, IOError, pywintypes.error) as exc:
+        except (OSError, pywintypes.error) as exc:
             log.Log("Warning: unable to read ACL from {rp}: {exc}".format(
                 rp=rp, exc=exc), 4)
             return
@@ -119,7 +119,7 @@ class ACL:
         try:
             self.__acl = rp.conn.win32security.ConvertSecurityDescriptorToStringSecurityDescriptor(
                 sd, SDDL_REVISION_1, ACL.flags)
-        except (OSError, IOError, pywintypes.error) as exc:
+        except (OSError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to convert ACL from %s to string: %s" % (repr(
                     rp.path), exc), 4)
@@ -133,7 +133,7 @@ class ACL:
         try:
             sd = rp.conn.win32security.ConvertStringSecurityDescriptorToSecurityDescriptor(
                 os.fsdecode(self.__acl), SDDL_REVISION_1)
-        except (OSError, IOError, pywintypes.error) as exc:
+        except (OSError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to convert string %s to ACL: %s" % (repr(
                     self.__acl), exc), 4)
@@ -174,7 +174,7 @@ class ACL:
                 (ACL.flags & SACL_SECURITY_INFORMATION)
                 and sd.GetSecurityDescriptorSacl() or None
             )
-        except (OSError, IOError, pywintypes.error) as exc:
+        except (OSError, pywintypes.error) as exc:
             log.Log("Warning: unable to set ACL on {rp}: {exc}".format(
                 rp=rp, exc=exc), 4)
 
@@ -204,7 +204,7 @@ class ACL:
         try:
             sd = rp.conn.win32security.GetNamedSecurityInfo(
                 os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
-        except (OSError, IOError, pywintypes.error) as exc:
+        except (OSError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to read ACL from %s for clearing: %s" % (repr(
                     rp.path), exc), 4)
@@ -240,7 +240,7 @@ class ACL:
                 (ACL.flags & SACL_SECURITY_INFORMATION)
                 and sd.GetSecurityDescriptorSacl() or None
             )
-        except (OSError, IOError, pywintypes.error) as exc:
+        except (OSError, pywintypes.error) as exc:
             log.Log(
                 "Warning: unable to set ACL on %s after clearing: %s" % (repr(
                     rp.path), exc), 4)

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -114,7 +114,7 @@ class RestoreAction(actions.BaseAction):
         try:
             self.target.base_dir.conn.fs_abilities.restore_set_globals(
                 self.target.base_dir)
-        except IOError as exc:
+        except OSError as exc:
             self.log("Could not begin restore due to\n{exc}".format(exc=exc),
                      self.log.ERROR)
             return 1
@@ -167,7 +167,7 @@ class RestoreAction(actions.BaseAction):
             restore.Restore(
                 self.source.base_dir.new_index(self.source.restore_index),
                 self.inc_rpath, self.target.base_dir, self.action_time)
-        except IOError as exc:
+        except OSError as exc:
             self.log("Could not complete restore due to '{exc}'".format(
                 exc=exc), self.log.ERROR)
             return 1

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -123,7 +123,7 @@ information in it.
             if not self.force:
                 try:
                     curmir_incs[0].conn.regress.check_pids(curmir_incs)
-                except (OSError, IOError) as exc:
+                except OSError as exc:
                     self.log.FatalError(
                         "Could not check if rdiff-backup is currently"
                         "running due to\n{exc}".format(exc=exc))
@@ -261,7 +261,7 @@ class WriteRepo(Repo, locations.WriteLocation):
         if not self.data_dir.lstat():
             try:
                 self.data_dir.mkdir()
-            except (OSError, IOError) as exc:
+            except OSError as exc:
                 self.log("Could not create 'rdiff-backup-data' sub-directory "
                          "in '{rp}' due to '{exc}'. "
                          "Please fix the access rights and retry.".format(
@@ -272,7 +272,7 @@ class WriteRepo(Repo, locations.WriteLocation):
         if not self.incs_dir.lstat():
             try:
                 self.incs_dir.mkdir()
-            except (OSError, IOError) as exc:
+            except OSError as exc:
                 self.log("Could not create 'increments' sub-directory "
                          "in '{rp}' due to '{exc}'. "
                          "Please fix the access rights and retry.".format(

--- a/testing/iterfiletest.py
+++ b/testing/iterfiletest.py
@@ -17,7 +17,7 @@ class FileException:
     def read(self, chars):
         self.count += chars
         if self.count > self.max:
-            raise IOError(13, "Permission Denied")
+            raise OSError(13, "Permission Denied")
         return b"a" * chars
 
     def close(self):
@@ -55,7 +55,7 @@ class testIterFile(unittest.TestCase):
         new_iter = IterWrappingFile(FileWrappingIter(iter([f, b"foo"])))
         f_out = next(new_iter)
         self.assertEqual(f_out.read(50000), b"a" * 50000)
-        with self.assertRaises(IOError):
+        with self.assertRaises(OSError):
             buf = f_out.read(190 * 1024)  # noqa: F841
 
         self.assertEqual(next(new_iter), b"foo")

--- a/testing/longnametest.py
+++ b/testing/longnametest.py
@@ -28,7 +28,7 @@ class LongNameTest(unittest.TestCase):
         really_long.touch()
 
         with self.assertRaises(
-            EnvironmentError,
+            OSError,
             msg="File name could exceed max length '{max}'.".format(
                 max=NAME_MAX_LEN)) as cm:
             self.out_rp.append("a" * (NAME_MAX_LEN + 1)).touch()

--- a/testing/server.py
+++ b/testing/server.py
@@ -29,7 +29,7 @@ try:
     import rdiff_backup.Globals
     import rdiff_backup.Security
     from rdiff_backup.connection import PipeConnection
-except (OSError, IOError, ImportError):
+except (OSError, ImportError):
     print_usage()
     raise
 


### PR DESCRIPTION
FIX: catch properly long name errors under Windows when long paths registry option is set, closes #558
Also get rid of EnvironmentError and IOError which are just aliases of OSError since Python 3.3

Main problem was that Windows doesn't know about errno.ENAMETOOLONG and sends errno.EINVAL with winerror==123 if long names are enabled, and errno.ENOTFOUND if it isn't enabled (which is even more difficult to catch properly, and isn't the topic of this PR).