### PR TITLE
Fix server failing on NoneType not iterable

### DIFF
--- a/docs/arch/plugins_actions.md
+++ b/docs/arch/plugins_actions.md
@@ -40,8 +40,8 @@ The Action class has the following interface:
   name will be used in the code, and it doesn't need to be aligned with the name
   of the module or of the class (but it should). Only requirement is that it is
   unique or plug-ins will overwrite each other.
-* the class method `cls.get_security_class()` returns the security class of
-  the action plug-in, one of `backup`, `restore` or `validate`.
+* the class method `cls.get_security_class()` returns the security class of the action plug-in, one of `backup`, `restore`, `server` or `validate`.
+  A security class of `None` is only applicable to actions without client/server context (e.g. `info`).
 * the class method `cls.get_version()` returns the version of the plug-in as a
   string.
 * the class method `cls.add_action_subparser(sub_handler)` returns a subparser

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -116,7 +116,7 @@ def _set_security_level(security_class, cmdpairs):
     def getpath(cmdpair):
         return cmdpair[1]
 
-    if security_class == "server":
+    if security_class is None or security_class == "server":
         return
     cp1 = cmdpairs[0]
     if len(cmdpairs) > 1:

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -265,7 +265,7 @@ class BaseAction:
     name = None
 
     # type of action for security purposes, one of backup, restore, validate
-    # or server
+    # or server (or None if client/server isn't relevant)
     security = None
 
     # version of the action
@@ -419,6 +419,11 @@ class BaseAction:
         if self.values.tempdir and not os.path.isdir(self.values.tempdir):
             self.log("Temporary directory '{dir}' doesn't exist.".format(
                      dir=self.values.tempdir), self.log.ERROR)
+            return_code |= 1
+        if (self.security is None
+                and "locations" in self.values and self.values.locations):
+            self.log("Action '{act}' must have a security class to handle "
+                     "locations".format(act=self.name), self.log.ERROR)
             return_code |= 1
         return return_code
 

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -446,6 +446,7 @@ class BaseAction:
             self.connected_locations = list(
                 map(SetConnections.get_connected_rpath, cmdpairs))
         else:
+            Security.initialize(self.get_security_class(), [])
             self.connected_locations = []
 
         # once the connection is set, we can define "now" as being the current

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -34,7 +34,7 @@ class InfoAction(actions.BaseAction):
     in a bug report, and exits.
     """
     name = "info"
-    security = "validate"  # FIXME introduce a "none" security level?
+    security = None
     # information has no specific sub-options
 
     def setup(self):


### PR DESCRIPTION
FIX: calling with remote-schema containing the new server action would fail with NoneType not being iterable, closes #565