### PR TITLE
Fix handling of backslashes in locations

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -240,13 +240,13 @@ def parse_location(file_desc):
     # before colons.
     # Hence we split along double ones, remove single ones in each element,
     # and join back with a single backslash.
-    # And then we make sure that paths under Windows use / instead of \
     if file_host:
         file_host = b'\\'.join(
             [x.replace(b'\\:', b':') for x in file_host.split(b'\\\\')])
-        file_host = file_host.replace(b"\\", b"/")
     file_path = b'\\'.join(
         [x.replace(b'\\:', b':') for x in file_path.split(b'\\\\')])
+    # And then we make sure that paths under Windows use / instead of \
+    # (we don't do it for the host part because it could be a shell command)
     file_path = file_path.replace(b"\\", b"/")
 
     return (file_host, file_path, None)

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -194,31 +194,60 @@ def parse_location(file_desc):
     # paths and similar objects must always be bytes
     file_desc = os.fsencode(file_desc)
     # match double colon not preceded by an odd number of backslashes
-    file_match = re.fullmatch(rb"^(?P<host>.*[^\\](?:\\\\)*)::(?P<path>.*)$",
-                              file_desc)
-    if file_match:
-        file_host = file_match.group("host")
-        # According to description, the backslashes must be unquoted, i.e.
-        # double backslashes replaced by single ones, and single ones removed.
-        # Hence we split along double ones, remove single ones in each element,
-        # and join back with a single backslash.
-        file_host = b'\\'.join(
-            [x.replace(b'\\', b'') for x in re.split(rb'\\\\', file_host) if x])
-        file_path = file_match.group("path")
-    else:
-        if re.match(rb"^::", file_desc):
-            return (None, None,
-                    "No file host in {desc} starting with '::'.".format(
-                        desc=file_desc))
+    file_parts = [x for x in re.split(rb"(?<!\\)(\\{2})*::", file_desc)
+                  if x is not None]
+    # because even numbers of backslashes are grouped as part of the split,
+    # we need to stitch them back together,e.g.
+    # "host\\\\::path" becomes ["host","\\\\","path"]
+    # which then becomes ["host\\\\", "path"]
+    concat_parts = []
+    keep = None
+    for part in reversed(file_parts):
+        if re.match(rb"^(\\{2})+$", part):
+            keep = part
+        else:
+            if keep:
+                part += keep
+                keep = None
+            concat_parts.append(part)
+    concat_parts.reverse()
+
+    if len(concat_parts) > 2:
+        return (None, None,
+                "Too many parts separated by double colon in '{desc}'".format(
+                    desc=file_desc))
+    elif len(concat_parts) == 0:  # it's probably not possible but...
+        return (None, None,
+                "No location could be identified in '{desc}'".format(
+                    desc=file_desc))
+    elif len(concat_parts) == 1:  # a local path without remote host
         file_host = None
-        file_path = file_desc
+        file_path = concat_parts[0]
+    else:  # length of 2 is given
+        if not concat_parts[0]:
+            return (None, None,
+                    "No file host in '{desc}' starting with '::'".format(
+                        desc=file_desc))
+        elif not concat_parts[1]:
+            return (None, None,
+                    "No file path in '{desc}' ending with '::'".format(
+                        desc=file_desc))
+        file_host = concat_parts[0]
+        file_path = concat_parts[1]
 
-    # make sure paths under Windows use / instead of \
-    if os.path.altsep:  # only Windows has an alternative separator for paths
-        file_path = file_path.replace(os.fsencode(os.path.sep), b'/')
-
-    if not file_path:
-        return (None, None, "No file path in {desc}.".format(desc=file_desc))
+    # According to description, the backslashes must be unquoted, i.e.
+    # double backslashes replaced by single ones, and single ones removed
+    # before colons.
+    # Hence we split along double ones, remove single ones in each element,
+    # and join back with a single backslash.
+    # And then we make sure that paths under Windows use / instead of \
+    if file_host:
+        file_host = b'\\'.join(
+            [x.replace(b'\\:', b':') for x in file_host.split(b'\\\\')])
+        file_host = file_host.replace(b"\\", b"/")
+    file_path = b'\\'.join(
+        [x.replace(b'\\:', b':') for x in file_path.split(b'\\\\')])
+    file_path = file_path.replace(b"\\", b"/")
 
     return (file_host, file_path, None)
 

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -140,7 +140,10 @@ def _get_locations(src_local, dest_local, src_dir, dest_dir):
     """
     Return a tuple of remote or local source and destination locations
     """
-    remote_location = "cd {rdir}; {tdir}/server.py::{dir}"
+    if os.name == "nt":
+        remote_location = "cd {rdir} & {tdir}\\server.py::{dir}"
+    else:
+        remote_location = "cd {rdir}; {tdir}/server.py::{dir}"
 
     if not src_local:
         src_dir = remote_location.format(

--- a/testing/setconnectionstest.py
+++ b/testing/setconnectionstest.py
@@ -17,7 +17,7 @@ class SetConnectionsTest(unittest.TestCase):
         self.assertEqual(pl(b"a:b:c:d::e"), (b"a:b:c:d", b"e", None))
         self.assertEqual(pl(b"foobar"), (None, b"foobar", None))
         self.assertEqual(pl(rb"test\\ing\::more::and more\\.."),
-                         (b"test/ing::more", b"and more/..", None))
+                         (b"test\\ing::more", b"and more/..", None))
         self.assertEqual(pl(rb"strangely named\::file"),
                          (None, b"strangely named::file", None))
         self.assertEqual(pl(rb"foobar\\"), (None, b"foobar/", None))

--- a/testing/setconnectionstest.py
+++ b/testing/setconnectionstest.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from rdiff_backup import SetConnections
 
@@ -17,16 +16,18 @@ class SetConnectionsTest(unittest.TestCase):
                          (b"hello there", b"/goodbye:euoeu", None))
         self.assertEqual(pl(b"a:b:c:d::e"), (b"a:b:c:d", b"e", None))
         self.assertEqual(pl(b"foobar"), (None, b"foobar", None))
-        if os.name != "nt":  # FIXME must adapt escape handling for Windows
-            self.assertEqual(pl(rb"test\\ing\::more::and more\\.."),
-                             (rb"test\ing::more", rb"and more\\..", None))
-            self.assertEqual(pl(rb"hello\::there"),
-                             (None, rb"hello\::there", None))
-            self.assertEqual(pl(rb"foobar\\"), (None, rb"foobar\\", None))
+        self.assertEqual(pl(rb"test\\ing\::more::and more\\.."),
+                         (b"test/ing::more", b"and more/..", None))
+        self.assertEqual(pl(rb"strangely named\::file"),
+                         (None, b"strangely named::file", None))
+        self.assertEqual(pl(rb"foobar\\"), (None, b"foobar/", None))
+        self.assertEqual(pl(rb"not\::too::many\\\::paths"),
+                         (b"not::too", b"many/::paths", None))
 
         # test missing path and missing host
-        self.assertIsNotNone(pl(rb"hello\:there::")[2])
+        self.assertIsNotNone(pl(rb"a host without\:path::")[2])
         self.assertIsNotNone(pl(b"::some/path/without/host")[2])
+        self.assertIsNotNone(pl(b"too::many::paths")[2])
 
 
 if __name__ == "__main__":

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -54,8 +54,8 @@ commands =
     python testing/rdifftest.py
 #    python testing/securitytest.py  # no os.getuid + backslash in path handlingon --server
 #    python testing/killtest.py  # cannot create symbolic link
-#    python testing/backuptest.py  # backslash in path handling on --server
-#    python testing/comparetest.py  # backslash in path handling on --server
+#    python testing/backuptest.py  # No module named rdiff_backup in server.py
+#    python testing/comparetest.py  # No module named rdiff_backup in server.py
 #    python testing/regresstest.py  # issue with : in date/time/string
 #    python testing/restoretest.py  # too many issues to count
 #    python testing/cmdlinetest.py  # too many issues to count


### PR DESCRIPTION
FIX: backslashes were removed too eagerly in locations, making the use of Windows paths impossible, closes #585

The fix doesn't yet allow to run more tests under Windows but it's an important step towards this possibility, as it allows now to give Windows commands (with backslashes in the path). And, if you wonder, as the OS' own shell is used, it can't be slashes, they must be backslashes.