### PR TITLE
Improve logfiles handling

### DIFF
--- a/docs/CODING.adoc
+++ b/docs/CODING.adoc
@@ -36,21 +36,20 @@ It should explain _why_ it went wrong rather than the test result itself.
 
 == TEXT OUTPUT
 
-* any text output should start with a capital letter and end with a dot.
-* text output with variables is formatted with named placeholders using the form `+"Some error message regarding '{xyz}'.".format(xyz=actual_var)+`.
-* complex placeholders should be kept between single quotes in the string.
-* name of placeholders should be short, unique, meaningful, only using letters (with an optional counter at the end) and not be named after existing functions or keywords.
-Examples:
- ** `+{itype}+` instead of `+{type}+` or `+{increment_type}+`
- ** `+"The two types '{type1}' and '{type2}' are different.".format(...)+`
-* use `{rp!s}` (or similar name) for the representation of RPath/RORPath in order to enforce complete path representation (it is somewhat equivalent to `str(rp)`).
-* each text string should be a one-liner and leave formatting to the `log.Log` class.
-TODO: the code isn't yet that far but it should be the direction.
-* the explanation should be meant first for the user, and explain ways to solve the potential issue, then for the developer to troubleshoot.
+* any text output starts with a capital letter and does _not_ end with a dot.
+* text output with variables is formatted with named placeholders using the form `"Some message regarding broken object '{bo}'".format(bo=actual_var)`.
+  This simple example highlights a few important rules:
+** complex placeholders are kept between single quotes in the string.
+** the placeholder is characterized by a specific description "broken object", so that the user has an idea about the context even if the variable `actual_var` happens to be empty.
+** name of placeholders are two letters for the initials of this context (`bo` for "**b**roken **o**bject") and _not_ the variable name (`av` for "**a**ctual **v**ar").
+   This will help translators to better understand how variables fit in the message without having to look at the code itself.
+   If the context consists only of one word, use the first two letters (e.g. `ob` for "object"), but consider that one word might not be quite enough as context!
+   Avoid two letter combinations with a meaning in Python (e.g. if, in, or).
+* each text string is a one-liner _not_ starting with the severity level (error, warning, etc), leaving the formatting to the `log.Log` class.
+* the explanation is meant first for the user, and explains ways to solve the potential issue, then for the developer to troubleshoot.
 
-____
-*NOTE:* one of the main driver for the above recommendations is the 	possibility to translate those strings in the future.
-____
+NOTE: one of the main driver for the above recommendations is the possibility to translate those strings in the future.
+      For this reason, exception and especially assert messages can be handled less strictly.
 
 == BYTES VS. STR
 

--- a/docs/api/v200.adoc
+++ b/docs/api/v200.adoc
@@ -33,6 +33,11 @@ bytes).
 * `Globals.set`
 * `Globals.set_local`
 * `Hardlink.initialize_dictionaries`
+* `log.ErrorLog.close`
+* `log.ErrorLog.isopen`
+* `log.ErrorLog.open`
+* `log.ErrorLog.write`
+* `log.ErrorLog.write_if_open`
 * `log.Log.close_logfile_allconn`
 * `log.Log.close_logfile_local`
 * `log.Log.log_to_file`

--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -32,6 +32,11 @@
 * `Globals.set`
 * `Globals.set_local`
 * `Hardlink.initialize_dictionaries`
+* `log.ErrorLog.close`
+* `log.ErrorLog.isopen`
+* `log.ErrorLog.open`
+* `log.ErrorLog.write`
+* `log.ErrorLog.write_if_open`
 * `log.Log.close_logfile_allconn`
 * `log.Log.close_logfile_local`
 * `log.Log.log_to_file`

--- a/src/rdiff_backup/FilenameMapping.py
+++ b/src/rdiff_backup/FilenameMapping.py
@@ -123,8 +123,9 @@ def set_init_quote_vals_local():
     global chars_to_quote, quoting_char
     chars_to_quote = Globals.chars_to_quote
     if len(Globals.quoting_char) != 1:
-        log.Log.FatalError("Expected single character for quoting char,"
-                           "got '%s' instead." % _safe_str(Globals.quoting_char))
+        log.Log.FatalError("Expected single character for quoting char, "
+                           "got '{qc}' instead.".format(
+                               qc=_safe_str(Globals.quoting_char)))
     quoting_char = Globals.quoting_char
     _init_quoting_regexps()
 
@@ -199,8 +200,8 @@ def update_quoting(rbdir):
                 list.append(new_name)
             name_rp = dirpath_rp.append(name)
             new_rp = dirpath_rp.append(new_name)
-            log.Log("Re-quoting {orp} to {nrp}".format(
-                orp=name_rp, nrp=new_rp), 5)
+            log.Log("Re-quoting old path {op} to new path {np}".format(
+                op=name_rp, np=new_rp), log.INFO)
             rpath.move(name_rp, new_rp)
 
     assert rbdir.conn is Globals.local_connection, (
@@ -209,7 +210,7 @@ def update_quoting(rbdir):
     mirror_rp = rbdir.get_parent_rp()
     mirror = mirror_rp.path
 
-    log.Log("Re-quoting repository {rp}".format(rp=mirror_rp), 3)
+    log.Log("Re-quoting repository {re}".format(re=mirror_rp), log.NOTE)
 
     for dirpath, dirs, files in os.walk(mirror):
         dirpath_rp = mirror_rp.newpath(dirpath)
@@ -230,9 +231,10 @@ def _init_quoting_regexps():
         chars_to_quote_regexp = re.compile(b"[%b]|%b" %
                                            (chars_to_quote, quoting_char), re.S)
         unquoting_regexp = re.compile(b"%b[0-9]{3}" % quoting_char, re.S)
-    except re.error:
-        log.Log.FatalError("Error '%s' when processing char quote list %r" %
-                           (re.error, chars_to_quote))
+    except re.error as exc:
+        log.Log.FatalError(
+            "Regex error '{er}' when processing char quote list {ql}".format(
+                er=exc, ql=chars_to_quote))
 
 
 def _quote_single(match):

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -318,48 +318,9 @@ def set_integer(name, val):
     try:
         intval = int(val)
     except ValueError:
-        log.Log.FatalError("Variable %s must be set to an integer -\n"
-                           "received %s instead." % (name, val))
+        log.Log.FatalError("Variable {vr} must be set to an integer, received "
+                           "value '{vl}' instead".format(vr=name, vl=val))
     set(name, intval)
-
-
-def set_float(name, val, min=None, max=None, inclusive=1):
-    """Like set, but make sure val is float within given bounds"""
-
-    def error():
-        s = "Variable %s must be set to a float" % (name, )
-        if min is not None and max is not None:
-            s += " between %s and %s " % (min, max)
-            if inclusive:
-                s += "inclusive"
-            else:
-                s += "not inclusive"
-        elif min is not None or max is not None:
-            if inclusive:
-                inclusive_string = "or equal to "
-            else:
-                inclusive_string = ""
-            if min is not None:
-                s += " greater than %s%s" % (inclusive_string, min)
-            else:
-                s += " less than %s%s" % (inclusive_string, max)
-        log.Log.FatalError(s)
-
-    try:
-        f = float(val)
-    except ValueError:
-        error()
-    if min is not None:
-        if inclusive and f < min:
-            error()
-        elif not inclusive and f <= min:
-            error()
-    if max is not None:
-        if inclusive and f > max:
-            error()
-        elif not inclusive and f >= max:
-            error()
-    set(name, f)
 
 
 def get_dict_val(name, key):
@@ -394,15 +355,12 @@ def set_api_version(val):
     try:
         intval = int(val)
     except ValueError:
-        log.Log.FatalError(
-            "API version must be set to an integer, "
-            "received {val} instead.".format(val=val))
+        log.Log.FatalError("API version must be set to an integer, "
+                           "received value {va} instead.".format(va=val))
     if intval < api_version["min"] or intval > api_version["max"]:
         log.Log.FatalError(
-            "API version {val} must be between {api_min} and {api_max}.".format(
-                val=val,
-                api_min=api_version["min"],
-                api_max=api_version["max"]))
+            "API version {av} must be between {mi} and {ma}.".format(
+                av=val, mi=api_version["min"], ma=api_version["max"]))
     api_version["actual"] = intval
 
 

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -72,8 +72,8 @@ def _main_run(arglist, security_override=False):
     # validate that everything looks good before really starting
     ret_val = action.pre_check()
     if ret_val != 0:
-        log.Log("Action {act} failed on {func}.".format(
-            act=parsed_args.action, func="pre_check"), log.Log.ERROR)
+        log.Log("Action {ac} failed on step {st}".format(
+            ac=parsed_args.action, st="pre_check"), log.ERROR)
         return ret_val
 
     # now start for real, conn_act and action are the same object
@@ -87,20 +87,20 @@ def _main_run(arglist, security_override=False):
 
         ret_val = conn_act.check()
         if ret_val != 0:
-            log.Log("Action {act} failed on {func}.".format(
-                act=parsed_args.action, func="check"), log.Log.ERROR)
+            log.Log("Action {ac} failed on step {st}".format(
+                ac=parsed_args.action, st="check"), log.ERROR)
             return ret_val
 
         ret_val = conn_act.setup()
         if ret_val != 0:
-            log.Log("Action {act} failed on {func}.".format(
-                act=parsed_args.action, func="setup"), log.Log.ERROR)
+            log.Log("Action {ac} failed on step {st}".format(
+                ac=parsed_args.action, st="setup"), log.ERROR)
             return ret_val
 
         ret_val = conn_act.run()
         if ret_val != 0:
-            log.Log("Action {act} failed on {func}.".format(
-                act=parsed_args.action, func="run"), log.Log.ERROR)
+            log.Log("Action {ac} failed on step {st}".format(
+                ac=parsed_args.action, st="run"), log.ERROR)
             return ret_val
 
     return ret_val
@@ -121,7 +121,7 @@ def backup_touch_curmirror_local(rpin, rpout):
     """
     mirrorrp = Globals.rbdir.append(b'.'.join(
         map(os.fsencode, (b"current_mirror", Time.curtimestr, "data"))))
-    log.Log("Writing mirror marker {rp}".format(rp=mirrorrp), 6)
+    log.Log("Writing mirror marker {mm}".format(mm=mirrorrp), log.DEBUG)
     try:
         pid = os.getpid()
     except BaseException:

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -67,8 +67,7 @@ def _main_run(arglist, security_override=False):
 
     # instantiate the action object from the dictionary, handing over the
     # parsed arguments
-    action = discovered_actions[parsed_args.action](parsed_args,
-                                                    log.Log, log.ErrorLog)
+    action = discovered_actions[parsed_args.action](parsed_args)
 
     # validate that everything looks good before really starting
     ret_val = action.pre_check()

--- a/src/rdiff_backup/Rdiff.py
+++ b/src/rdiff_backup/Rdiff.py
@@ -25,23 +25,23 @@ def get_signature(rp, blocksize=None):
     """Take signature of rpin file and return in file object"""
     if not blocksize:
         blocksize = _find_blocksize(rp.getsize())
-    log.Log("Getting signature of {rp} with blocksize {blks}".format(
-        rp=rp, blks=blocksize), 7)
+    log.Log("Getting signature of file {fi} with blocksize {bs}".format(
+        fi=rp, bs=blocksize), log.DEBUG)
     return librsync.SigFile(rp.open("rb"), blocksize)
 
 
 def get_delta_sigrp_hash(rp_signature, rp_new):
     """Like above but also calculate hash of new as close() value"""
-    log.Log("Getting delta (with hash) of {rp} with signature {srp}".format(
-        rp=rp_new, srp=rp_signature), 7)
+    log.Log("Getting delta (with hash) of file {fi} with signature {si}".format(
+        fi=rp_new, si=rp_signature), log.DEBUG)
     return librsync.DeltaFile(
         rp_signature.open("rb"), hash.FileWrapper(rp_new.open("rb")))
 
 
 def write_delta(basis, new, delta, compress=None):
     """Write rdiff delta which brings basis to new"""
-    log.Log("Writing delta {brp} from {nrp} -> {drp}".format(
-        brp=basis, nrp=new, drp=delta), 7)
+    log.Log("Writing delta {de} from basis {ba} to new {ne}".format(
+        ba=basis, ne=new, de=delta), log.DEBUG)
     deltafile = librsync.DeltaFile(get_signature(basis), new.open("rb"))
     delta.write_from_fileobj(deltafile, compress)
 

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -214,7 +214,7 @@ def _set_allowed_requests(sec_class, sec_level):
         "VirtualFile.readfromid", "VirtualFile.closebyid", "Globals.get",
         "Globals.is_not_None", "Globals.get_dict_val",
         "log.Log.open_logfile_allconn", "log.Log.close_logfile_allconn",
-        "Log.log_to_file", "FilenameMapping.set_init_quote_vals_local",
+        "log.Log.log_to_file", "FilenameMapping.set_init_quote_vals_local",
         "FilenameMapping.set_init_quote_vals", "Time.setcurtime_local",
         "SetConnections.add_redirected_conn", "RedirectedRun",
         "sys.stdout.write", "robust.install_signal_handlers"

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -180,8 +180,8 @@ def _set_security_level(security_class, security_level, restrict_path,
             if restore_type is None:
                 # the error will be catched later more cleanly, so that the
                 # connections can be properly closed
-                log.Log("Invalid restore directory '{path}'".format(
-                    path=getpath(cp1)), log.Log.ERROR)
+                log.Log("Invalid restore directory '{rd}'".format(
+                    rd=getpath(cp1)), log.ERROR)
             rdir = base_dir.path
         else:  # cp2 is local but not cp1
             sec_level = "read-write"

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -230,7 +230,7 @@ def parse_location(file_desc):
                         lo=file_desc))
         elif not concat_parts[1]:
             return (None, None,
-                    "No file path in location '{desc}' ending with '::'".format(
+                    "No file path in location '{lo}' ending with '::'".format(
                         lo=file_desc))
         file_host = concat_parts[0]
         file_path = concat_parts[1]

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -76,8 +76,8 @@ def get_cmd_pairs(locations, remote_schema=None, ssh_compression=True,
 
     if remote_schema and not [x for x in desc_triples if x[0]]:
         # remote schema defined but no remote location found
-        log.Log("Remote schema option ignored - no remote file "
-                "descriptions.", 2)
+        log.Log("Remote schema option ignored - no remote file descriptions",
+                log.WARNING)
 
     # strip the error field from the triples to get pairs
     desc_pairs = [triple[:2] for triple in desc_triples]
@@ -126,38 +126,39 @@ def UpdateGlobal(setting_name, val):
 
 def BackupInitConnections(reading_conn, writing_conn):
     """Backup specific connection initialization"""
-    reading_conn.Globals.set("isbackup_reader", 1)
-    writing_conn.Globals.set("isbackup_writer", 1)
+    reading_conn.Globals.set("isbackup_reader", True)
+    writing_conn.Globals.set("isbackup_writer", True)
     UpdateGlobal("backup_reader", reading_conn)
     UpdateGlobal("backup_writer", writing_conn)
 
 
 def CloseConnections():
     """Close all connections.  Run by client"""
-    assert not Globals.server, "Connections can't be closed by server."
+    assert not Globals.server, "Connections can't be closed by server"
     for conn in Globals.connections:
         if conn:  # could be None, if the connection failed
             conn.quit()
     del Globals.connections[1:]  # Only leave local connection
     Globals.connection_dict = {0: Globals.local_connection}
-    Globals.backup_reader = Globals.isbackup_reader = \
-        Globals.backup_writer = Globals.isbackup_writer = None
+    Globals.backup_reader = Globals.backup_writer = None
+    Globals.isbackup_reader = Globals.isbackup_writer = False
 
 
 def TestConnections(rpaths):
     """Test connections, printing results.
     Returns 0 if all connections work, 1 if one or more failed,
     2 if the length of the list of connections isn't correct, most probably
-    because the user called rdiff-backup incorrectly."""
+    because the user called rdiff-backup incorrectly"""
     # the function doesn't use the log functions because it might not have
     # an error or log file to use.
     conn_len = len(Globals.connections)
     if conn_len == 1:
-        print("No remote connections specified, only local one available.")
+        log.Log("No remote connections specified, only local one available",
+                log.ERROR)
         return 2
     elif conn_len != len(rpaths) + 1:
-        print("All %d parameters must be remote of the form 'server::path'." %
-              len(rpaths))
+        print("All {pa} parameters must be remote of the form "
+              "'server::path'".format(pa=len(rpaths)), log.ERROR)
         return 2
 
     # we create a list of all test results, skipping the connection 0, which
@@ -225,12 +226,12 @@ def parse_location(file_desc):
     else:  # length of 2 is given
         if not concat_parts[0]:
             return (None, None,
-                    "No file host in '{desc}' starting with '::'".format(
-                        desc=file_desc))
+                    "No file host in location '{lo}' starting with '::'".format(
+                        lo=file_desc))
         elif not concat_parts[1]:
             return (None, None,
-                    "No file path in '{desc}' ending with '::'".format(
-                        desc=file_desc))
+                    "No file path in location '{desc}' ending with '::'".format(
+                        lo=file_desc))
         file_host = concat_parts[0]
         file_path = concat_parts[1]
 
@@ -256,7 +257,7 @@ def _fill_schema(host_info):
     Fills host_info and optionally the version into the schema and returns remote command.
     """
     assert isinstance(host_info, bytes), (
-        "host_info parameter must be bytes not {thi}.".format(
+        "host_info parameter must be bytes not {thi}".format(
             thi=type(host_info)))
     try:
         # for security reasons, we accept only specific format placeholders
@@ -276,8 +277,8 @@ def _fill_schema(host_info):
         else:  # compat200: accepts "%s" as host place-holder
             return __cmd_schema % host_info
     except (TypeError, KeyError):
-        log.Log.FatalError("Invalid remote schema:\n\n{schema}\n".format(
-            schema=_safe_str(__cmd_schema)))
+        log.Log.FatalError("Invalid remote schema: {rs}".format(
+            rs=_safe_str(__cmd_schema)))
 
 
 def _init_connection(remote_cmd):
@@ -292,7 +293,8 @@ def _init_connection(remote_cmd):
     if not remote_cmd:
         return Globals.local_connection
 
-    log.Log("Executing %s" % _safe_str(remote_cmd), 4)
+    log.Log("Executing remote command {rc}".format(rc=_safe_str(remote_cmd)),
+            log.INFO)
     try:
         # we need buffered read on SSH communications, hence using
         # default value for bufsize parameter
@@ -319,7 +321,7 @@ def _init_connection(remote_cmd):
 
     if not _validate_connection_version(conn, remote_cmd):
         return None
-    log.Log("Registering connection %d" % conn_number, 7)
+    log.Log("Registering connection {co}".format(co=conn_number), log.DEBUG)
     _init_connection_routing(conn, conn_number, remote_cmd)
     _init_connection_settings(conn)
     return conn
@@ -337,33 +339,28 @@ def _validate_connection_version(conn, remote_cmd):
         remote_version = conn.Globals.get('version')
     except connection.ConnectionError as exception:
         log.Log(
-            """%s
-
-Couldn't start up the remote connection by executing
-
-    %s
+            """Couldn't start up the remote connection by executing '{rc}'
+due to exception '{ex}'.
 
 Remember that, under the default settings, rdiff-backup must be
 installed in the PATH on the remote system.  See the man page for more
 information on this.  This message may also be displayed if the remote
-version of rdiff-backup is quite different from the local version (%s).""" %
-            (exception, _safe_str(remote_cmd), Globals.version), 1)
+version of rdiff-backup is quite different from the local version ({lv})
+""".format(ex=exception, rc=_safe_str(remote_cmd), lv=Globals.version),
+            log.ERROR)
         return False
     except OverflowError:
         log.Log(
             """Integer overflow while attempting to establish the
-remote connection by executing
-
-    %s
+remote connection by executing {rc}
 
 Please make sure that nothing is printed (e.g., by your login shell) when this
-command executes. Try running this command:
+command executes. Try running this command: {co}
 
-    %s
-
-which should only print out the text: rdiff-backup <version>""" %
-            (_safe_str(remote_cmd),
-             _safe_str(remote_cmd.replace(b"--server", b"--version"))), 1)
+which should only print out the text: rdiff-backup <version>""".format(
+                rc=_safe_str(remote_cmd),
+                co=_safe_str(remote_cmd.replace(b"--server", b"--version"))),
+            log.ERROR)
         return False
 
     try:
@@ -375,18 +372,17 @@ which should only print out the text: rdiff-backup <version>""" %
                 and (Globals.api_version["actual"]
                      or Globals.api_version["min"]) == 200):
             Globals.api_version["actual"] == 200
-            log.Log(
-                "Warning: remote version {rem_ver} doesn't know about API "
-                "versions but should be compatible with 200.".format(
-                    rem_ver=remote_version), 2)
+            log.Log("Remote version {rv} doesn't know about API "
+                    "versions but should be compatible with 200".format(
+                        rv=remote_version), log.NOTE)
             return True
         else:
             log.Log(
-                "Fatal: remote version {rem_ver} isn't compatible with local "
-                "API version {api_ver}.".format(
-                    rem_ver=remote_version,
-                    api_ver=(Globals.api_version["actual"]
-                             or Globals.api_version["min"])), 1)
+                "Remote version {rv} isn't compatible with local "
+                "API version {av}".format(
+                    rv=remote_version,
+                    av=(Globals.api_version["actual"]
+                        or Globals.api_version["min"])), log.ERROR)
             return False
 
     # servers don't validate the API version, client does
@@ -399,16 +395,16 @@ which should only print out the text: rdiff-backup <version>""" %
     if (min(remote_api_version["max"], Globals.api_version["max"])
             < max(remote_api_version["min"], Globals.api_version["min"])):
         log.Log(
-            """Fatal: local and remote rdiff-backup have no common API version:
-Remote API version for {rem_ver} must be between {rem_min} and {rem_max}.
-Local API version for {loc_ver} must be between {loc_min} and {loc_max}.
-Please make sure you have compatible versions of rdiff-backup.""".format(
-                rem_ver=remote_version,
-                rem_min=remote_api_version["min"],
-                rem_max=remote_api_version["max"],
-                loc_ver=Globals.version,
-                loc_min=Globals.api_version["min"],
-                loc_max=Globals.api_version["max"]), 1)
+            """Local and remote rdiff-backup have no common API version:
+Remote API version for {rv} must be between min {ri} and max {ra}.
+Local API version for {lv} must be between min {li} and max {la}.
+Please make sure you have compatible versions of rdiff-backup""".format(
+                rv=remote_version,
+                ri=remote_api_version["min"],
+                ra=remote_api_version["max"],
+                lv=Globals.version,
+                li=Globals.api_version["min"],
+                la=Globals.api_version["max"]), log.ERROR)
         return False
     # is there an actual API version and does it fit the other side?
     if Globals.api_version["actual"]:
@@ -416,19 +412,20 @@ Please make sure you have compatible versions of rdiff-backup.""".format(
                 and Globals.api_version["actual"] <= remote_api_version["max"]):
             conn.Globals.set('api_version["actual"]',
                              Globals.api_version["actual"])
-            log.Log("API version agreed to be actual {api_ver} "
-                    "with {cmd}.".format(api_ver=Globals.api_version["actual"],
-                                         cmd=remote_cmd), 4)
+            log.Log("API version agreed to be actual {av} "
+                    "with command {co}".format(
+                        av=Globals.api_version["actual"], co=remote_cmd),
+                    log.INFO)
             return True
         else:  # the actual version doesn't fit the other side
             log.Log(
-                "Fatal: remote rdiff-backup doesn't accept the API version "
-                "explicitly set locally to {api_ver}. "
-                "It should be between {rem_min} and {rem_max}. "
-                "Use '--api-version' to set another API version.".format(
-                    api_ver=Globals.api_version["actual"],
-                    rem_min=remote_api_version["min"],
-                    rem_max=remote_api_version["max"]), 1)
+                "Remote rdiff-backup doesn't accept the API version "
+                "explicitly set locally to {av}. "
+                "It should be between min {ri} and max {ra}. "
+                "Use '--api-version' to set another API version".format(
+                    av=Globals.api_version["actual"],
+                    ri=remote_api_version["min"],
+                    ra=remote_api_version["max"]), log.ERROR)
             return False
     else:
         # use the default local value but make make sure it's between min
@@ -438,8 +435,8 @@ Please make sure you have compatible versions of rdiff-backup.""".format(
                                      Globals.api_version["default"]))
         Globals.api_version["actual"] = actual_api_version
         conn.Globals.set('api_version["actual"]', actual_api_version)
-        log.Log("API version agreed to be {api_ver} with {cmd}.".format(
-                api_ver=actual_api_version, cmd=remote_cmd), 4)
+        log.Log("API version agreed to be {av} with command {co}".format(
+            av=actual_api_version, co=remote_cmd), log.INFO)
         return True
 
 

--- a/src/rdiff_backup/backup.py
+++ b/src/rdiff_backup/backup.py
@@ -732,7 +732,7 @@ class PatchITRB(rorpiter.ITRBranch):
             return 1
         log.ErrorLog.write_if_open(
             "UpdateError", diff_rorp, "Updated mirror "
-            "temp file '{rp}' does not match source".format(rp=new_rp))
+            "temp file '{tf}' does not match source".format(tf=new_rp))
         return 0
 
     def _write_special(self, diff_rorp, new):

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -397,7 +397,7 @@ class PipeConnection(LowLevelPipeConnection):
         """Start server's read eval return loop"""
         Globals.server = 1
         Globals.connections.append(self)
-        log.Log("Starting server", 6)
+        log.Log("Starting server", log.INFO)
         self._get_response(-1)
         return 0  # all is well...
 
@@ -480,10 +480,11 @@ class PipeConnection(LowLevelPipeConnection):
         if robust.is_routine_fatal(sys.exc_info()[1]):
             raise  # Fatal error--No logging necessary, but connection down
         if log.Log.verbosity >= 5 or log.Log.term_verbosity >= 5:
-            log.Log(
-                "Sending back exception %s of type %s: \n%s" %
-                (sys.exc_info()[1], sys.exc_info()[0], "".join(
-                    traceback.format_tb(sys.exc_info()[2]))), 5)
+            log.Log("Sending back exception {ex} of type {ty} with "
+                    "traceback {tb}".format(
+                        ex=sys.exc_info()[1], ty=sys.exc_info()[0],
+                        tb="".join(traceback.format_tb(sys.exc_info()[2]))),
+                    log.INFO)
         return sys.exc_info()[1]
 
     def _get_new_req_num(self):

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -480,7 +480,7 @@ class PipeConnection(LowLevelPipeConnection):
         if robust.is_routine_fatal(sys.exc_info()[1]):
             raise  # Fatal error--No logging necessary, but connection down
         if log.Log.verbosity >= 5 or log.Log.term_verbosity >= 5:
-            log.Log("Sending back exception {ex} of type {ty} with "
+            log.Log("Sending back exception '{ex}' of type {ty} with "
                     "traceback {tb}".format(
                         ex=sys.exc_info()[1], ty=sys.exc_info()[0],
                         tb="".join(traceback.format_tb(sys.exc_info()[2]))),

--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -75,7 +75,7 @@ class ExtendedAttributes:
                 return  # if not supported, consider empty
             if exc.errno in (errno.EACCES, errno.ENOENT, errno.ELOOP):
                 log.Log("Listing extended attributes of path {pa} produced "
-                        "exception {ex}, ignored".format(pa=rp, ex=exc),
+                        "exception '{ex}', ignored".format(pa=rp, ex=exc),
                         log.INFO)
                 return
             raise
@@ -113,7 +113,7 @@ class ExtendedAttributes:
                 if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.EACCES,
                                  errno.ENOENT, errno.EINVAL):
                     log.Log("Unable to write xattr {xa} to path {pa} "
-                            "due to exception {ex}, ignoring".format(
+                            "due to exception '{ex}', ignoring".format(
                                 xa=name, pa=rp, ex=exc), log.INFO)
                     continue
                 else:
@@ -159,7 +159,8 @@ class ExtendedAttributes:
             return  # if not supported, consider empty
         except FileNotFoundError as exc:
             log.Log("Unable to clear extended attributes on path {pa} due to "
-                    "exception {ex}, ignoring".format(pa=rp, ex=exc), log.NOTE)
+                    "exception '{ex}', ignoring".format(pa=rp, ex=exc),
+                    log.NOTE)
             return
 
 
@@ -509,7 +510,7 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
     except OSError as exc:
         if exc.errno == errno.EOPNOTSUPP:
             log.Log(
-                "Unable to set ACL on path {pa} due to exception {ex}".format(
+                "Unable to set ACL on path {pa} due to exception '{ex}'".format(
                     pa=rp, ex=exc), log.INFO)
             return
         else:
@@ -533,7 +534,7 @@ def get_acl_lists_from_rp(rp):
         acl = posix1e.ACL(file=rp.path)
     except (FileNotFoundError, UnicodeEncodeError) as exc:
         log.Log(
-            "Unable to read ACL from path {pa} due to exception {ex}".format(
+            "Unable to read ACL from path {pa} due to exception '{ex}'".format(
                 pa=rp, ex=exc), log.NOTE)
         acl = None
     except OSError as exc:
@@ -546,7 +547,7 @@ def get_acl_lists_from_rp(rp):
             def_acl = posix1e.ACL(filedef=os.fsdecode(rp.path))
         except (FileNotFoundError, UnicodeEncodeError) as exc:
             log.Log("Unable to read default ACL from path {pa} due to "
-                    "exception {ex}".format(pa=rp, ex=exc), log.NOTE)
+                    "exception '{ex}'".format(pa=rp, ex=exc), log.NOTE)
             def_acl = None
         except OSError as exc:
             if exc.errno == errno.EOPNOTSUPP:

--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -74,8 +74,9 @@ class ExtendedAttributes:
             if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.ETXTBSY):
                 return  # if not supported, consider empty
             if exc.errno in (errno.EACCES, errno.ENOENT, errno.ELOOP):
-                log.Log("Warning: listattr({rp}): {exc}".format(
-                    rp=rp, exc=exc), 4)
+                log.Log("Listing extended attributes of path {pa} produced "
+                        "exception {ex}, ignored".format(pa=rp, ex=exc),
+                        log.INFO)
                 return
             raise
         for attr in attr_list:
@@ -111,8 +112,9 @@ class ExtendedAttributes:
                 # fail gracefully if can't call xattr.set
                 if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.EACCES,
                                  errno.ENOENT, errno.EINVAL):
-                    log.Log("Warning: unable to write xattr "
-                            "{xat} to {rp}".format(xat=name, rp=rp), 6)
+                    log.Log("Unable to write xattr {xa} to path {pa} "
+                            "due to exception {ex}, ignoring".format(
+                                xa=name, pa=rp, ex=exc), log.INFO)
                     continue
                 else:
                     raise
@@ -142,12 +144,13 @@ class ExtendedAttributes:
                 except PermissionError:  # errno.EACCES
                     # SELinux attributes cannot be removed, and we don't want
                     # to bail out or be too noisy at low log levels.
-                    log.Log("Warning: unable to remove xattr "
-                            "{xat} from {rp}".format(xat=name, rp=rp), 7)
+                    log.Log("Not allowed to remove extended attribute "
+                            "{ea} from path {pa}".format(ea=name, pa=rp),
+                            log.DEBUG)
                     continue
                 except OSError as exc:
-                    # can happen because trusted.SGI_ACL_FILE is deleted together with
-                    # system.posix_acl_access on XFS file systems.
+                    # can happen because trusted.SGI_ACL_FILE is deleted
+                    # together with system.posix_acl_access on XFS file systems.
                     if exc.errno == errno.ENODATA:
                         continue
                     else:  # can be anything, just fail
@@ -155,8 +158,8 @@ class ExtendedAttributes:
         except io.UnsupportedOperation:  # errno.EOPNOTSUPP or errno.EPERM
             return  # if not supported, consider empty
         except FileNotFoundError as exc:
-            log.Log("Warning: unable to clear xattrs on {rp}: {exc}".format(
-                rp=rp, exc=exc), 3)
+            log.Log("Unable to clear extended attributes on path {pa} due to "
+                    "exception {ex}, ignoring".format(pa=rp, ex=exc), log.NOTE)
             return
 
 
@@ -505,8 +508,9 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
         acl.applyto(rp.path)
     except OSError as exc:
         if exc.errno == errno.EOPNOTSUPP:
-            log.Log("Warning: unable to set ACL on {rp}: {exc}".format(
-                rp=rp, exc=exc), 4)
+            log.Log(
+                "Unable to set ACL on path {pa} due to exception {ex}".format(
+                    pa=rp, ex=exc), log.INFO)
             return
         else:
             raise
@@ -528,8 +532,9 @@ def get_acl_lists_from_rp(rp):
     try:
         acl = posix1e.ACL(file=rp.path)
     except (FileNotFoundError, UnicodeEncodeError) as exc:
-        log.Log("Warning: unable to read ACL from {rp}: {exc}".format(
-            rp=rp, exc=exc), 3)
+        log.Log(
+            "Unable to read ACL from path {pa} due to exception {ex}".format(
+                pa=rp, ex=exc), log.NOTE)
         acl = None
     except OSError as exc:
         if exc.errno == errno.EOPNOTSUPP:
@@ -540,8 +545,8 @@ def get_acl_lists_from_rp(rp):
         try:
             def_acl = posix1e.ACL(filedef=os.fsdecode(rp.path))
         except (FileNotFoundError, UnicodeEncodeError) as exc:
-            log.Log("Warning: unable to read default ACL from {rp}: "
-                    "{exc}".format(rp=rp, exc=exc), 3)
+            log.Log("Unable to read default ACL from path {pa} due to "
+                    "exception {ex}".format(pa=rp, ex=exc), log.NOTE)
             def_acl = None
         except OSError as exc:
             if exc.errno == errno.EOPNOTSUPP:
@@ -653,15 +658,13 @@ def _list_to_acl(entry_list, map_names=1):
         """Warn about acl with name getting dropped"""
         global dropped_acl_names
         if Globals.never_drop_acls:
-            log.Log.FatalError(
-                "--never-drop-acls specified but cannot map name\n"
-                "%s occurring inside an ACL." % (name, ))
+            log.Log.FatalError("--never-drop-acls specified but cannot map "
+                               "ACL name {an}".format(an=name))
         if name in dropped_acl_names:
             return
-        log.Log(
-            "Warning: name %s not found on system, dropping ACL entry.\n"
-            "Further ACL entries dropped with this name will not "
-            "trigger further warnings" % (name, ), 2)
+        log.Log("ACL name {an} not found on system, dropping entry. "
+                "Further ACL entries dropped with this name will not "
+                "trigger further warnings".format(an=name), log.WARNING)
         dropped_acl_names[name] = name
 
     acl = posix1e.ACL()
@@ -675,16 +678,16 @@ def _list_to_acl(entry_list, map_names=1):
                     id = user_group.acl_group_map(*owner_pair)
                 else:
                     raise ValueError(
-                        "Type '{tchar}' must be one of 'u' or 'g'.".format(
-                            tchar=typechar))
+                        "Type '{tc}' must be one of 'u' or 'g'.".format(
+                            tc=typechar))
                 if id is None:
                     warn_drop(owner_pair[1])
                     continue
             else:
                 assert owner_pair[0] is not None, (
-                    "First owner can't be None with type={tchar}, "
+                    "First owner can't be None with type={tc}, "
                     "owner pair={own}, perms={perms}".format(
-                        tchar=typechar, own=owner_pair, perms=perms))
+                        tc=typechar, own=owner_pair, perms=perms))
                 id = owner_pair[0]
 
         entry = posix1e.Entry(acl)

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -305,7 +305,7 @@ class FSAbilities:
             posix1e.ACL(file=rp.path)
         except OSError as exc:
             log.Log("POSIX ACLs not supported by filesystem at path {pa} "
-                    "due to exception {ex}".format(pa=rp, ex=exc), log.INFO)
+                    "due to exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
             self.acls = 0
         else:
             self.acls = 1
@@ -411,7 +411,7 @@ class FSAbilities:
                 read_ea = xattr.get(rp.path, b"user.test")
         except OSError as exc:
             log.Log("Extended attributes not supported by filesystem at "
-                    "path {pa} due to exception {ex}".format(pa=rp, ex=exc),
+                    "path {pa} due to exception '{ex}'".format(pa=rp, ex=exc),
                     log.NOTE)
             self.eas = 0
         else:

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -202,8 +202,9 @@ class FSAbilities:
                 raise OSError(errno.EOPNOTSUPP, "Hard links don't compare")
         except (OSError, AttributeError):
             if Globals.preserve_hardlinks != 0:
-                log.Log("Warning: hard linking not supported by filesystem "
-                        "at {rp}".format(rp=self.root_rp), 3)
+                log.Log("Hard linking not supported by filesystem at "
+                        "path {pa}, hard links will be copied instead".format(
+                            pa=self.root_rp), log.NOTE)
             self.hardlinks = None
         else:
             self.hardlinks = 1
@@ -213,8 +214,9 @@ class FSAbilities:
         try:
             testdir.fsync()
         except OSError:
-            log.Log("Directories on file system at {rp} are not fsyncable."
-                    "Assuming it's unnecessary.".format(rp=testdir), 4)
+            log.Log("Directories on file system at path {pa} are not "
+                    "fsyncable. Assuming it's unnecessary.".format(pa=testdir),
+                    log.INFO)
             self.fsync_dirs = 0
         else:
             self.fsync_dirs = 1
@@ -231,8 +233,8 @@ class FSAbilities:
             ord_rp.delete()
         except OSError as exc:
             log.Log.FatalError(
-                "File with normal name '{rp}' couldn't be created, "
-                "and failed with '{exc}'.".format(rp=ord_rp, exc=exc))
+                "File with normal name '{nn}' couldn't be created, "
+                "and failed with exception '{ex}'.".format(nn=ord_rp, ex=exc))
 
         # Try path with UTF-8 encoded character
         extended_filename = (
@@ -254,10 +256,10 @@ class FSAbilities:
                 # on them. Test file cannot be deleted. UTF-8 chars not in the
                 # underlying codepage get translated to '?'
                 log.Log.FatalError(
-                    "Could not delete extended filenames test "
-                    "file. If you are using a CIFS share, please"
-                    " see the FAQ entry about characters being "
-                    "transformed to a '?'")
+                    "Could not delete extended filenames test file {tf}. "
+                    "If you are using a CIFS share, please see the FAQ entry "
+                    "about characters being transformed to a '?'".format(
+                        tf=ext_rp))
             self.extended_filenames = 1
 
     def _detect_win_reserved_filenames(self, subdir):
@@ -285,9 +287,8 @@ class FSAbilities:
     def _detect_acls(self, rp):
         """Set self.acls based on rp.  Does not write.  Needs to be local"""
         if Globals.acls_active == 0:
-            log.Log(
-                "POSIX ACLs test skipped. rdiff-backup run "
-                "with --no-acls option.", 4)
+            log.Log("POSIX ACLs test skipped as rdiff-backup was started "
+                    "with --no-acls option", log.INFO)
             self.acls = 0
             return
 
@@ -295,16 +296,16 @@ class FSAbilities:
             import posix1e
         except ImportError:
             log.Log("Unable to import module posix1e from pylibacl package. "
-                    "POSIX ACLs not supported on filesystem at {rp}".format(
-                        rp=rp), 4)
+                    "POSIX ACLs not supported on filesystem at "
+                    "path {pa}".format(pa=rp), log.INFO)
             self.acls = 0
             return
 
         try:
             posix1e.ACL(file=rp.path)
-        except OSError:
-            log.Log("POSIX ACLs not supported by filesystem at {rp}".format(
-                rp=rp), 4)
+        except OSError as exc:
+            log.Log("POSIX ACLs not supported by filesystem at path {pa} "
+                    "due to exception {ex}".format(pa=rp, ex=exc), log.INFO)
             self.acls = 0
         else:
             self.acls = 1
@@ -322,10 +323,10 @@ class FSAbilities:
                 # we know that (fuse-)exFAT 1.3.0 takes 1sec to register the
                 # deletion (July 2020)
                 log.Log.FatalError(
-                    "We're sorry but the target file system at '{rp}' isn't "
-                    "deemed reliable enough for a backup. It takes too long "
-                    "or doesn't register case insensitive deletion of "
-                    "files.".format(rp=subdir))
+                    "We're sorry but the target file system at path '{pa}' "
+                    "isn't deemed reliable enough for a backup. "
+                    "It takes too long or doesn't register case insensitive "
+                    "deletion of files.".format(pa=subdir))
             self.case_sensitive = 0
         else:
             upper_a.delete()
@@ -368,10 +369,11 @@ class FSAbilities:
         triple = find_letter(rp)
         if not triple:
             log.Log(
-                "Warning: could not determine case sensitivity of "
-                "source directory at\n  {rp}\n"
-                "because we can't find any files with letters in them.\n"
-                "It will be treated as case sensitive.".format(rp=rp), 2)
+                "Could not determine case sensitivity of source directory {sd} "
+                "because we can't find any files with letters in them. "
+                "It will be treated as case sensitive, meaning only that "
+                "capital letters might be quoted in the target "
+                "repository".format(sd=rp), log.WARNING)
             self.case_sensitive = 1
             return
 
@@ -384,9 +386,8 @@ class FSAbilities:
                 conn=rp.conn))
         assert rp.lstat(), "Path '{rp}' must exist to test EAs.".format(rp=rp)
         if Globals.eas_active == 0:
-            log.Log(
-                "Extended attributes test skipped. rdiff-backup run "
-                "with --no-eas option.", 4)
+            log.Log("Extended attributes test skipped as rdiff-backup was "
+                    "started with --no-eas option", log.INFO)
             self.eas = 0
             return
         try:
@@ -397,7 +398,8 @@ class FSAbilities:
             except ImportError:
                 log.Log(
                     "Unable to import module (py)xattr. Extended attributes "
-                    "not supported on filesystem at {rp}".format(rp=rp), 4)
+                    "not supported on filesystem at path {pa}".format(pa=rp),
+                    log.INFO)
                 self.eas = 0
                 return
 
@@ -407,18 +409,19 @@ class FSAbilities:
             if write:
                 xattr.set(rp.path, b"user.test", test_ea)
                 read_ea = xattr.get(rp.path, b"user.test")
-        except OSError:
-            log.Log("Extended attributes not supported by "
-                    "filesystem at {rp}".format(rp=rp), 4)
+        except OSError as exc:
+            log.Log("Extended attributes not supported by filesystem at "
+                    "path {pa} due to exception {ex}".format(pa=rp, ex=exc),
+                    log.NOTE)
             self.eas = 0
         else:
             if write and read_ea != test_ea:
                 log.Log(
                     "Extended attributes support is broken on filesystem at "
-                    "{rp}. Please upgrade the filesystem driver, contact the "
-                    "developers, or use the --no-eas option to disable "
+                    "path {pa}. Please upgrade the filesystem driver, contact "
+                    "the developers, or use the --no-eas option to disable "
                     "extended attributes support and suppress this "
-                    "message.".format(rp=rp), 1)
+                    "message".format(pa=rp), log.WARNING)
                 self.eas = 0
             else:
                 self.eas = 1
@@ -431,9 +434,8 @@ class FSAbilities:
         assert dir_rp.lstat(), "Path '{rp}' must exist to test ACLs.".format(
             rp=dir_rp)
         if Globals.win_acls_active == 0:
-            log.Log(
-                "Windows ACLs test skipped. rdiff-backup run "
-                "with --no-acls option.", 4)
+            log.Log("Windows ACLs test skipped as rdiff-backup was started "
+                    "with --no-acls option", log.INFO)
             self.win_acls = 0
             return
 
@@ -442,7 +444,8 @@ class FSAbilities:
             import pywintypes
         except ImportError:
             log.Log("Unable to import win32security module. Windows ACLs not "
-                    "supported by filesystem at {rp}".format(rp=dir_rp), 4)
+                    "supported by filesystem at path {pa}".format(pa=dir_rp),
+                    log.INFO)
             self.win_acls = 0
             return
         try:
@@ -464,7 +467,7 @@ class FSAbilities:
                     sd.GetSecurityDescriptorDacl(), None)
         except (OSError, AttributeError, pywintypes.error):
             log.Log("Unable to load a Windows ACL. Windows ACLs not supported "
-                    "by filesystem at {rp}".format(rp=dir_rp), 4)
+                    "by filesystem at path {pa}".format(pa=dir_rp), log.INFO)
             self.win_acls = 0
             return
 
@@ -472,7 +475,7 @@ class FSAbilities:
             win_acls.init_acls()
         except (OSError, AttributeError, pywintypes.error):
             log.Log("Unable to init win_acls. Windows ACLs not supported by "
-                    "filesystem at {rp}".format(rp=dir_rp), 4)
+                    "filesystem at path {pa}".format(pa=dir_rp), log.INFO)
             self.win_acls = 0
             return
         self.win_acls = 1
@@ -636,16 +639,16 @@ class FSAbilities:
         period_rp = testdir.append("foo.")
         if period_rp.lstat():
             log.Log.FatalError(
-                "File '{rp}' already exists where it shouldn't, something "
-                "is very wrong with your file system.".format(rp=period_rp))
+                "Test file '{tf}' already exists where it shouldn't, something "
+                "is very wrong with your file system".format(tf=period_rp))
 
         tmp_rp = testdir.append("foo")
         tmp_rp.touch()
         if not tmp_rp.lstat():
             log.Log.FatalError(
-                "File '{rp}' doesn't exist even though it's been created, "
-                "something is very wrong with your file system.".format(
-                    rp=tmp_rp))
+                "Test file '{tf}' doesn't exist even though it's been created, "
+                "something is very wrong with your file system".format(
+                    tf=tmp_rp))
 
         period_rp.setdata()
         # either the foo and foo. files are the same, or foo. can't be created,
@@ -693,10 +696,11 @@ class FSAbilities:
                 return
 
         # no file could be found to do any test
-        log.Log("Warning: could not determine if source directory at "
-                "  {rp} permits trailing spaces or periods in "
-                "filenames because we can't find any files. "
-                "It will be treated as permitting such files.".format(rp=rp), 2)
+        log.Log("Could not determine if source directory {sd} permits "
+                "trailing spaces or periods in filenames because we can't "
+                "find any files with trailing dot/period. "
+                "It will be treated as permitting such files".format(sd=rp),
+                log.WARNING)
         self.escape_trailing_spaces = 0
 
 
@@ -720,7 +724,7 @@ class SetGlobals:
         self._update_triple(self.src_fsa.acls, self.dest_fsa.acls,
                             ('acls_active', 'acls_write', 'acls_conn'))
         if Globals.never_drop_acls and not Globals.acls_active:
-            log.Log.FatalError("--never-drop-acls specified, but ACL support\n"
+            log.Log.FatalError("--never-drop-acls specified, but ACL support "
                                "missing from source filesystem")
 
     def set_win_acls(self):
@@ -765,7 +769,7 @@ class SetGlobals:
             SetConnections.UpdateGlobal('use_compatible_timestamps', 1)
             Time.setcurtime(
                 Time.curtime)  # update Time.curtimestr on all conns
-            log.Log("Enabled use_compatible_timestamps", 4)
+            log.Log("Enabled use_compatible_timestamps", log.INFO)
 
 
 class BackupSetGlobals(SetGlobals):
@@ -802,20 +806,22 @@ class BackupSetGlobals(SetGlobals):
             actual_ets = ("escape_trailing_spaces" in se)
 
             if actual_edd != suggested_edd and not suggested_edd:
-                log.Log(
-                    "Warning: System no longer needs DOS devices escaped, "
-                    "but we will retain for backwards compatibility.", 2)
+                log.Log("System no longer needs DOS devices to be escaped, "
+                        "but we will retain for backwards compatibility",
+                        log.WARNING)
             if actual_ets != suggested_ets and not suggested_ets:
                 log.Log(
-                    "Warning: System no longer needs trailing spaces or "
-                    "periods escaped, but we will retain for backwards "
-                    "compatibility.", 2)
+                    "System no longer needs trailing spaces or periods to be "
+                    "escaped, but we will retain for backwards compatibility",
+                    log.WARNING)
 
         SetConnections.UpdateGlobal('escape_dos_devices', actual_edd)
-        log.Log("Backup: escape_dos_devices = %d" % actual_edd, 4)
+        log.Log("Backup: escape_dos_devices = {dd}".format(dd=actual_edd),
+                log.INFO)
 
         SetConnections.UpdateGlobal('escape_trailing_spaces', actual_ets)
-        log.Log("Backup: escape_trailing_spaces = %d" % actual_ets, 4)
+        log.Log("Backup: escape_trailing_spaces = {ts}".format(ts=actual_ets),
+                log.INFO)
 
     def set_chars_to_quote(self, rbdir, force):
         """Set chars_to_quote setting for backup session
@@ -887,26 +893,25 @@ class BackupSetGlobals(SetGlobals):
         if actual_ctq == suggested_ctq:
             return (actual_ctq, None)
         if suggested_ctq == b"":
-            log.Log(
-                "Warning: File system no longer needs quoting, "
-                "but we will retain for backwards compatibility.", 2)
+            log.Log("File system no longer needs quoting, "
+                    "but we will retain for backwards compatibility",
+                    log.WARNING)
             return (actual_ctq, None)
         if Globals.chars_to_quote is None:
             if force:
-                log.Log(
-                    "Warning: migrating rdiff-backup repository from"
-                    "old quoting chars %r to new quoting chars %r" %
-                    (actual_ctq, suggested_ctq), 2)
+                log.Log("Migrating rdiff-backup repository from old "
+                        "quoting chars {oq} to new quoting chars {nq}".format(
+                            oq=actual_ctq, nq=suggested_ctq), log.WARNING)
                 ctq_rp.delete()
                 ctq_rp.write_bytes(suggested_ctq)
                 return (suggested_ctq, 1)
             else:
                 log.Log.FatalError("""New quoting requirements!
 
-The quoting chars this session needs '{sctq}' do not match
-the repository settings '{actq}' listed in
+The quoting chars this session needs '{nq}' do not match
+the actual quotings '{aq}' listed in the repository settings file
 
-{rp}
+{sf}
 
 This may be caused when you copy an rdiff-backup repository from a
 normal file system onto a windows one that cannot support the same
@@ -916,7 +921,7 @@ backed up onto it.
 
 By specifying the --force option, rdiff-backup will migrate the
 repository from the old quoting chars to the new ones.""".format(
-                    sctq=suggested_ctq, actq=actual_ctq, rp=ctq_rp))
+                    nq=suggested_ctq, aq=actual_ctq, sf=ctq_rp))
         return (actual_ctq, None)  # Maintain Globals override
 
 
@@ -932,10 +937,10 @@ class RestoreSetGlobals(SetGlobals):
             actual_edd = ("escape_dos_devices" in se)
             actual_ets = ("escape_trailing_spaces" in se)
         else:
-            log.Log(
-                "Warning: special_escapes file not found,\n"
-                "will assume need to escape DOS devices and trailing "
-                "spaces based on file systems.", 2)
+            log.Log("The special escapes file '{ef}' was not found, "
+                    "will assume need to escape DOS devices and trailing "
+                    "spaces based on file systems".format(ef=se_rp),
+                    log.WARNING)
             if getattr(self, "src_fsa", None) is not None:
                 actual_edd = (self.src_fsa.escape_dos_devices
                               and not self.dest_fsa.escape_dos_devices)
@@ -947,10 +952,12 @@ class RestoreSetGlobals(SetGlobals):
                 actual_ets = self.dest_fsa.escape_trailing_spaces
 
         SetConnections.UpdateGlobal('escape_dos_devices', actual_edd)
-        log.Log("Backup: escape_dos_devices = %d" % actual_edd, 4)
+        log.Log("Backup: escape_dos_devices = {dd}".format(dd=actual_edd),
+                log.INFO)
 
         SetConnections.UpdateGlobal('escape_trailing_spaces', actual_ets)
-        log.Log("Backup: escape_trailing_spaces = %d" % actual_ets, 4)
+        log.Log("Backup: escape_trailing_spaces = {ts}".format(ts=actual_ets),
+                log.INFO)
 
     def set_chars_to_quote(self, rbdir):
         """Set chars_to_quote from rdiff-backup-data dir"""
@@ -961,9 +968,9 @@ class RestoreSetGlobals(SetGlobals):
         if ctq_rp.lstat():
             SetConnections.UpdateGlobal("chars_to_quote", ctq_rp.get_bytes())
         else:
-            log.Log(
-                "Warning: chars_to_quote file not found,\n"
-                "assuming no quoting in backup repository.", 2)
+            log.Log("chars_to_quote file '{qf}' not found, assuming no quoting "
+                    "required in backup repository".format(qf=ctq_rp),
+                    log.WARNING)
             SetConnections.UpdateGlobal("chars_to_quote", b"")
 
     def _update_triple(self, src_support, dest_support, attr_triple):
@@ -1043,8 +1050,8 @@ def get_readonly_fsa(desc_string, rp):
     the security module.
 
     """
-    if os.name == 'nt':
-        log.Log("Hardlinks disabled by default on Windows", 4)
+    if os.name == "nt":
+        log.Log("Hardlinks disabled by default on Windows", log.INFO)
         SetConnections.UpdateGlobal('preserve_hardlinks', 0)
     return FSAbilities(desc_string, rp, read_only=True)
 
@@ -1061,9 +1068,9 @@ def backup_set_globals(rpin, force):
         "Action only foreseen locally and not over {conn}.".format(
             conn=Globals.rbdir.conn))
     src_fsa = rpin.conn.fs_abilities.get_readonly_fsa('source', rpin)
-    log.Log(str(src_fsa), 4)
+    log.Log(str(src_fsa), log.INFO)
     dest_fsa = FSAbilities('destination', Globals.rbdir)
-    log.Log(str(dest_fsa), 4)
+    log.Log(str(dest_fsa), log.INFO)
 
     bsg = BackupSetGlobals(rpin.conn, Globals.rbdir.conn, src_fsa, dest_fsa)
     bsg.set_eas()
@@ -1092,9 +1099,9 @@ def restore_set_globals(rpout):
             conn=rpout.conn))
     src_fsa = Globals.rbdir.conn.fs_abilities.get_readonly_fsa(
         'rdiff-backup repository', Globals.rbdir)
-    log.Log(str(src_fsa), 4)
+    log.Log(str(src_fsa), log.INFO)
     dest_fsa = FSAbilities('restore target', rpout)
-    log.Log(str(dest_fsa), 4)
+    log.Log(str(dest_fsa), log.INFO)
 
     rsg = RestoreSetGlobals(Globals.rbdir.conn, rpout.conn, src_fsa, dest_fsa)
     rsg.set_eas()
@@ -1119,7 +1126,7 @@ def single_set_globals(rp, read_only=None):
         fsa = rp.conn.fs_abilities.get_readonly_fsa(rp.path, rp)
     else:
         fsa = FSAbilities(rp.path, rp)
-    log.Log(str(fsa), 4)
+    log.Log(str(fsa), log.INFO)
 
     ssg = SingleSetGlobals(rp.conn, fsa)
     ssg.set_eas()

--- a/src/rdiff_backup/increment.py
+++ b/src/rdiff_backup/increment.py
@@ -33,7 +33,7 @@ def Increment(new, mirror, incpref):
     file to incpref.
 
     """
-    log.Log("Incrementing mirror file {rp}".format(rp=mirror), 5)
+    log.Log("Incrementing mirror file {mf}".format(mf=mirror), log.INFO)
     if ((new and new.isdir()) or mirror.isdir()) and not incpref.lstat():
         incpref.mkdir()
 
@@ -70,8 +70,8 @@ def get_inc(rp, typestr, time=None):
         incrp = rp.__class__(rp.conn, dirname, (addtostr(basename), ))
     if incrp.lstat():
         log.Log.FatalError(
-            "New increment path '{rp}' shouldn't exist, something went "
-            "really wrong.".format(rp=incrp))
+            "New increment path '{ip}' shouldn't exist, something went "
+            "really wrong.".format(ip=incrp))
     return incrp
 
 

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -233,8 +233,8 @@ class Logger:
         try:
             self.logfp = log_rp.open("ab")
         except OSError as exc:
-            raise LoggerError(
-                "Unable to open logfile {lf}: {ex}".format(lf=log_rp, ex=exc))
+            raise LoggerError("Unable to open logfile {lf} due to "
+                              "exception '{ex}'".format(lf=log_rp, ex=exc))
         self.log_file_local = 1
 
     def close_logfile(self):

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -127,7 +127,7 @@ class Logger:
                         tmpstr, subsequent_indent=" " * 9,
                         break_long_words=False,
                         break_on_hyphens=False,
-                        width=shutil.get_terminal_size().columns) + "\n",
+                        width=shutil.get_terminal_size().columns - 1) + "\n",
                     encoding=sys.stdout.encoding))
             else:
                 termfp.write(_to_bytes(tmpstr, encoding=sys.stdout.encoding))

--- a/src/rdiff_backup/longname.py
+++ b/src/rdiff_backup/longname.py
@@ -144,8 +144,8 @@ def get_mirror_inc_rps(rorp_pair, mirror_root, inc_root=None):
         index = new_rorp.index
     else:
         log.Log.FatalError(
-            "Neither old '{orp}' nor new path '{nrp}' is existing.".format(
-                orp=old_rorp, nrp=new_rorp))
+            "Neither old '{op}' nor new path '{np}' is existing".format(
+                op=old_rorp, np=new_rorp))
 
     alt_inc, inc_rp = find_inc_pair(index, mirror_rp, alt_mirror, alt_inc)
     update_rorp(new_rorp, alt_mirror, alt_inc)
@@ -169,8 +169,8 @@ def update_rf(rf, rorp, mirror_root):
 
     def update_incs(rf, inc_base):
         """Swap inclist in rf with those with base inc_base and return"""
-        log.Log("Restoring with increment base {inc} for file {rp}".format(
-            inc=_safe_str(inc_base), rp=rf), 6)
+        log.Log("Restoring with increment base {ib} for file {rp}".format(
+            ib=_safe_str(inc_base), rp=rf), log.DEBUG)
         rf.inc_rp = _get_long_rp(inc_base)
         rf.inc_list = _get_inclist(inc_base)
         rf.set_relevant_incs()
@@ -247,7 +247,7 @@ def _get_next_free_filename():
 
     def scan_next_free():
         """Return value of _free_name_counter by listing long filename dir"""
-        log.Log("Setting next free from long filenames dir", 5)
+        log.Log("Setting next free from long filenames dir", log.INFO)
         cur_high = 0
         for filename in _get_long_rp().listdir():
             try:

--- a/src/rdiff_backup/manage.py
+++ b/src/rdiff_backup/manage.py
@@ -19,8 +19,9 @@
 """list, delete, and otherwise manage increments"""
 
 import os
-from .log import Log
-from . import Globals, Time, statistics, restore, selection, FilenameMapping
+from . import (
+    FilenameMapping, Globals, log, restore, selection, statistics, Time
+)
 
 
 class ManageException(Exception):
@@ -95,7 +96,7 @@ def delete_earlier_than_local(baserp, time):
     for rp in yield_files(baserp):
         if ((rp.isincfile() and rp.getinctime() < time)
                 or (rp.isdir() and not rp.listdir())):
-            Log("Deleting increment file {rp}".format(rp=rp), 5)
+            log.Log("Deleting increment file {rp}".format(rp=rp), 5)
             rp.delete()
 
 
@@ -194,7 +195,7 @@ def _get_inc_type(inc):
     elif inc_type == b"snapshot":
         return _get_file_type(inc)
     else:
-        Log.FatalError(
+        log.Log.FatalError(
             "Unknown type '{itype}' of increment '{ifile!s}'.".format(
                 itype=inc_type, ifile=inc))
 

--- a/src/rdiff_backup/manage.py
+++ b/src/rdiff_backup/manage.py
@@ -96,7 +96,7 @@ def delete_earlier_than_local(baserp, time):
     for rp in yield_files(baserp):
         if ((rp.isincfile() and rp.getinctime() < time)
                 or (rp.isdir() and not rp.listdir())):
-            log.Log("Deleting increment file {rp}".format(rp=rp), 5)
+            log.Log("Deleting increment file {fi}".format(fi=rp), log.INFO)
             rp.delete()
 
 
@@ -195,9 +195,8 @@ def _get_inc_type(inc):
     elif inc_type == b"snapshot":
         return _get_file_type(inc)
     else:
-        log.Log.FatalError(
-            "Unknown type '{itype}' of increment '{ifile!s}'.".format(
-                itype=inc_type, ifile=inc))
+        log.Log.FatalError("Unknown type '{ut}' of increment '{ic}'".format(
+            ut=inc_type, ic=inc))
 
 
 def _get_file_type(rp):

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -106,7 +106,7 @@ class FlatExtractor:
                 if self.at_end:
                     break  # Ignore whitespace/bad records at end
                 log.Log("Error parsing flat file {ff} of type {ty} due to "
-                        "exception {ex}, metadata record ignored".format(
+                        "exception '{ex}', metadata record ignored".format(
                             ex=e, ty=type(self),
                             ff=self.fileobj.fileobj.name), log.WARNING)
 

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -105,9 +105,10 @@ class FlatExtractor:
             except (ParsingError, ValueError) as e:
                 if self.at_end:
                     break  # Ignore whitespace/bad records at end
-                log.Log(
-                    "Error parsing flat file: %s [%s(%s)]" %
-                    (e, type(self), self.fileobj.fileobj.name), 2)
+                log.Log("Error parsing flat file {ff} of type {ty} due to "
+                        "exception {ex}, metadata record ignored".format(
+                            ex=e, ty=type(self),
+                            ff=self.fileobj.fileobj.name), log.WARNING)
 
     def _iterate_records(self):
         """Yield all text records in order"""
@@ -131,7 +132,9 @@ class FlatExtractor:
             try:
                 obj = self._record_to_object(self.buf[:next_pos])
             except (ParsingError, ValueError) as e:
-                log.Log("Error parsing metadata file: %s" % (e, ), 2)
+                log.Log("Error parsing metadata file at given index {gi} due "
+                        "to exception '{ex}'".format(ex=e, gi=index),
+                        log.WARNING)
             else:
                 if obj.index[:len(index)] != index:
                     break
@@ -256,7 +259,8 @@ class RorpExtractor(FlatExtractor):
             elif field == "AlternateIncrementName":
                 data_dict['incname'] = data
             else:
-                log.Log("Unknown field in line '%s %s'" % (field, data), 2)
+                log.Log("Unknown field in line field/data '{uf}/{ud}'".format(
+                    uf=field, ud=data), log.WARNING)
         return rpath.RORPath(index, data_dict)
 
 
@@ -295,7 +299,7 @@ class FlatFile:
                 compress = 1
             else:
                 log.Log.FatalError(
-                    "Checking the path '{rp}' went wrong.".format(rp=rp_base))
+                    "Checking the path '{pa}' went wrong.".format(pa=rp_base))
         if mode == 'r' or mode == 'rb':
             self.rp = rp_base
             self.fileobj = self.rp.open("rb", compress)
@@ -314,8 +318,8 @@ class FlatFile:
                 self.fileobj = self.rp.open("wb", compress=compress)
         else:
             log.Log.FatalError(
-                "File opening mode '{omode}' should have been one of "
-                "r, rb, w or wb.".format(omode=mode))
+                "File opening mode '{om}' should have been one of "
+                "r, rb, w or wb".format(om=mode))
 
     def write_object(self, object):
         """Convert one object to record and write to file"""
@@ -484,29 +488,28 @@ class Manager:
         """Return combined metadata iter with ea/acl info if necessary"""
         cur_iter = self.get_meta_at_time(time, restrict_index)
         if not cur_iter:
-            log.Log(
-                "Warning, could not find mirror_metadata file.\n"
-                "Metadata will be read from filesystem instead.", 2)
+            log.Log("Could not find mirror_metadata file. "
+                    "Metadata will be read from filesystem instead",
+                    log.WARNING)
             return None
 
         if Globals.acls_active:
             acl_iter = self._get_acls_at_time(time, restrict_index)
             if not acl_iter:
-                log.Log("Warning: Access Control List file not found", 2)
+                log.Log("Access Control List file not found", log.WARNING)
                 acl_iter = iter([])
             cur_iter = eas_acls.join_acl_iter(cur_iter, acl_iter)
         if Globals.eas_active:
             ea_iter = self._get_eas_at_time(time, restrict_index)
             if not ea_iter:
-                log.Log("Warning: Extended Attributes file not found", 2)
+                log.Log("Extended Attributes file not found", log.WARNING)
                 ea_iter = iter([])
             cur_iter = eas_acls.join_ea_iter(cur_iter, ea_iter)
         if Globals.win_acls_active:
             wacl_iter = self._get_win_acls_at_time(time, restrict_index)
             if not wacl_iter:
-                log.Log(
-                    "Warning: Windows Access Control List file not"
-                    " found.", 2)
+                log.Log("Windows Access Control List file not found",
+                        log.WARNING)
                 wacl_iter = iter([])
             cur_iter = win_acls.join_wacl_iter(cur_iter, wacl_iter)
 
@@ -656,19 +659,19 @@ class PatchDiffMan(Manager):
         for (time, rp) in sortlist:
             if time in unique_set:
                 if Globals.allow_duplicate_timestamps:
-                    log.Log("Warning: metadata file '{rp}' has a duplicate "
+                    log.Log("Metadata file '{mf}' has a duplicate "
                             "timestamp date, you might not be able to "
                             "recover files on or earlier than this date. "
                             "Assuming you're in the process of cleaning up "
-                            "your repository.".format(rp=rp), 2)
+                            "your repository".format(mf=rp), log.WARNING)
                 else:
                     log.Log.FatalError(
-                        "Metadata file '{rp}' has a duplicate timestamp "
+                        "Metadata file '{mf}' has a duplicate timestamp "
                         "date, you might not be able to recover files on or "
                         "earlier than this date. "
                         "Check the man page on how to clean up your repository "
                         "using the '--allow-duplicate-timestamps' "
-                        "option.".format(rp=rp))
+                        "option".format(mf=rp))
             else:
                 unique_set.add(time)
 
@@ -701,7 +704,7 @@ class PatchDiffMan(Manager):
         newrp, oldrp = self._check_needs_diff()
         if not newrp:
             return
-        log.Log("Writing mirror_metadata diff", 6)
+        log.Log("Writing mirror_metadata diff", log.DEBUG)
 
         diff_writer = self._get_meta_writer(b'diff', oldrp.getinctime())
         new_iter = MetadataFile(newrp, 'r').get_objects()
@@ -729,16 +732,16 @@ class PatchDiffMan(Manager):
         if not inclist:
             return inclist
         assert inclist[-1].getinctime() == time, (
-            "The time of the last increment '{itime}' must be equal to "
-            "the given time '{time}'.".format(itime=inclist[-1].getinctime(),
-                                              time=time))
+            "The time of the last increment '{it}' must be equal to "
+            "the given time '{gt}'.".format(it=inclist[-1].getinctime(),
+                                            gt=time))
         for i in range(len(inclist) - 1, -1, -1):
             if inclist[i].getinctype() == b'snapshot':
                 return inclist[i:]
         else:
             log.Log.FatalError(
-                "Increments list '{ilist}' contains no snapshots".format(
-                    ilist=inclist))
+                "Increments list '{il}' contains no snapshots".format(
+                    il=inclist))
 
     def _iterate_patched_meta(self, meta_iter_list):
         """Return an iter of metadata rorps by combining the given iters
@@ -776,7 +779,7 @@ def quote_path(path_string):
             return b"\\\\"
         else:
             log.Log.FatalError(
-                "Bad char '{char}' shouldn't need quoting.".format(char=char))
+                "Bad char '{bc}' shouldn't need quoting".format(bc=char))
 
     return _chars_to_quote.sub(replacement_func, path_string)
 
@@ -791,7 +794,8 @@ def unquote_path(quoted_string):
             return b"\n"
         elif two_chars == b"\\\\":
             return b"\\"
-        log.Log("Warning, unknown quoted sequence %s found" % two_chars, 2)
+        log.Log("Warning, unknown quoted sequence {qs} found".format(
+            qs=two_chars), log.WARNING)
         return two_chars
 
     return re.sub(b"\\\\n|\\\\\\\\", replacement_func, quoted_string)
@@ -815,7 +819,8 @@ def _carbonfile2string(cfile):
     try:
         retvalparts.append('createDate:%d' % cfile['createDate'])
     except KeyError:
-        log.Log("Writing pre-1.1.6 style metadata, without creation date", 9)
+        log.Log("Writing pre-1.1.6 style metadata, without creation date",
+                log.DEBUG)
     return '|'.join(retvalparts)
 
 

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -75,7 +75,7 @@ def listrp(rp):
     """Like rp.listdir() but return [] if error, and sort results"""
 
     def error_handler(exc):
-        log.Log("Error listing directory {rp}".format(rp=rp), 2)
+        log.Log("Failed listing directory {di}".format(di=rp), log.WARNING)
         return []
 
     dir_listing = check_common_error(error_handler, rp.listdir)
@@ -103,9 +103,9 @@ def check_common_error(error_handler, function, args=[]):
             else:
                 return None
         if is_routine_fatal(exc):
-            log.Log.exception(1, 6)
+            log.Log.exception(1, log.INFO)
         else:
-            log.Log.exception(1, 2)
+            log.Log.exception(1, log.WARNING)
         raise
 
 

--- a/src/rdiff_backup/rorpiter.py
+++ b/src/rdiff_backup/rorpiter.py
@@ -132,8 +132,8 @@ class IterTreeReducer:
             self.index = index
             return 1
         if index == self.index:
-            log.Log("Warning, repeated index %s, bad filesystem?" % (index, ),
-                    2)
+            log.Log("Repeated index {ri}, bad filesystem?".format(ri=index),
+                    log.WARNING)
         elif index < self.index:
             raise ValueError(
                 "Bad index order: {sidx} should be lower than {idx}.".format(
@@ -257,9 +257,8 @@ class CacheIndexable:
             try:
                 del self.cache_dict[self.cache_indices[0]]
             except KeyError:
-                log.Log(
-                    "Warning: index %s missing from iterator cache" %
-                    (self.cache_indices[0], ), 2)
+                log.Log("Index {ix} missing from iterator cache".format(
+                    ix=self.cache_indices[0]), self.WARNING)
             del self.cache_indices[0]
 
         return next_elem
@@ -399,10 +398,11 @@ def FillInIter(rpiter, rootrp):
                     filler_rp = rootrp.new_index(cur_index[:i])
                     if not filler_rp.isdir():
                         log.Log(
-                            "Warning: expected %s to be a directory but "
-                            "found %s instead.\nThis is probably caused "
-                            "by a bug in versions 1.0.0 and earlier." %
-                            (filler_rp.path, filler_rp.lstat()), 2)
+                            "Expected path {pa} to be a directory but "
+                            "found type {ty} instead. This is probably caused "
+                            "by a bug in versions 1.0.0 and earlier.".format(
+                                pa=filler_rp, ty=filler_rp.lstat()),
+                            log.WARNING)
                         filler_rp.make_zero_dir(rootrp)
                     yield filler_rp
         yield rp

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1734,7 +1734,7 @@ def rename(rp_source, rp_dest):
                     rp_source.conn.os.unlink(rp_dest.path)
                     rp_source.conn.os.rename(rp_source.path, rp_dest.path)
                 else:
-                    log.Log("Exception {ex} while renaming from path {fp} "
+                    log.Log("Exception '{ex}' while renaming from path {fp} "
                             "to path {tp}".format(
                                 ex=error, fp=rp_source, tp=rp_dest), log.ERROR)
                     raise

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -569,11 +569,11 @@ class RORPath:
                        compare_win_acls=0,
                        compare_size=1,
                        compare_type=1,
-                       verbosity=2):
+                       verbosity=log.WARNING):
         """Like __eq__, but log more information.  Useful when testing"""
         if check_index and self.index != other.index:
-            log.Log("Index {idx} != index {oidx}".format(
-                idx=self.get_safeindex(), oidx=other.get_safeindex()),
+            log.Log("Index {ix} != other index {oi}".format(
+                ix=self.get_safeindex(), oi=other.get_safeindex()),
                 verbosity)
             return None
 
@@ -602,12 +602,15 @@ class RORPath:
                 pass
             elif (key not in other.data or self.data[key] != other.data[key]):
                 if key not in other.data:
-                    log.Log("Second is missing key %s" % (key, ), verbosity)
+                    log.Log("Second is missing key {mk}".format(mk=key),
+                            verbosity)
                 else:
                     log.Log(
-                        "Value of %s differs between %s and %s: %s vs %s" %
-                        (key, self.get_indexpath(), other.get_indexpath(),
-                         self.data[key], other.data[key]), verbosity)
+                        "Values of key {ke} differ between this path {tp} "
+                        "and other path {op}: {tv} vs. {ov}".format(
+                            ke=key, tp=self.get_indexpath(),
+                            op=other.get_indexpath(), tv=self.data[key],
+                            ov=other.data[key]), verbosity)
                 return None
         return 1
 
@@ -700,7 +703,7 @@ class RPath(RORPath):
         if self.lstat():
             self.conn.rpath.setdata_local(self)
 
-    def chmod(self, permissions, loglevel=2):
+    def chmod(self, permissions, loglevel=log.WARNING):
         """Wrapper around os.chmod"""
         try:
             self.conn.os.chmod(self.path,
@@ -711,9 +714,10 @@ class RPath(RORPath):
                 # Some systems throw this error if try to set sticky bit
                 # on a non-directory. Remove sticky bit and try again.
                 log.Log(
-                    "Warning: Unable to set permissions of %s to %o - "
-                    "trying again without sticky bit (%o)" %
-                    (self.path, permissions, permissions & 0o6777), loglevel)
+                    "Unable to set permissions of path {pa} to {pe:o} - "
+                    "trying again without sticky bit ({ws:o})".format(
+                        pa=self.path, pe=permissions,
+                        ws=(permissions & 0o6777)), loglevel)
                 self.conn.os.chmod(
                     self.path, permissions
                     & 0o6777 & Globals.permission_mask)
@@ -723,31 +727,32 @@ class RPath(RORPath):
 
     def settime(self, accesstime, modtime):
         """Change file modification times"""
-        log.Log("Setting time of {rp} to {mtim}".format(
-            rp=self, mtim=modtime), 7)
+        log.Log("Setting time of path {pa} to modified time {md}".format(
+            pa=self, md=modtime), log.DEBUG)
         try:
             self.conn.os.utime(self.path, (accesstime, modtime))
         except OverflowError:
-            log.Log("Cannot change times of {rp} to {times} - "
+            log.Log("Cannot change times of path {pa} to times {ti} - "
                     "problem is probably 64->32bit conversion".format(
-                        rp=self, times=(accesstime, modtime)), 2)
+                        pa=self, ti=(accesstime, modtime)), log.WARNING)
         else:
             self.data['atime'] = accesstime
             self.data['mtime'] = modtime
 
     def setmtime(self, modtime):
         """Set only modtime (access time to present)"""
-        log.Log(lambda: "Setting time of {rp} to {mtim}".format(
-            rp=self, mtim=modtime), 7)
+        log.Log(
+            lambda: "Setting time of path {pa} to modified time {mt}".format(
+                pa=self, mt=modtime), log.DEBUG)
         if modtime < 0:
-            log.Log("Warning: modification time of {rp} is"
-                    "before 1970".format(rp=self), 2)
+            log.Log("Modification time {mt} of path {pa} is"
+                    "before 1970".format(mt=modtime, pa=self), log.WARNING)
         try:
             self.conn.os.utime(self.path, (int(time.time()), modtime))
         except OverflowError:
-            log.Log("Cannot change mtime of {rp} to {mtim} - "
+            log.Log("Cannot change path {pa} to modified time {mt} - "
                     "problem is probably 64->32bit conversion".format(
-                        rp=self, mtim=modtime), 2)
+                        pa=self, mt=modtime), log.WARNING)
         except OSError:
             # It's not possible to set a modification time for
             # directories on Windows.
@@ -762,8 +767,8 @@ class RPath(RORPath):
             try:
                 self.conn.os.lchown(self.path, uid, gid)
             except AttributeError:
-                log.Log("Warning: lchown missing, cannot change ownership "
-                        "of symlink {rp}".format(rp=self), 2)
+                log.Log("Function lchown missing, cannot change ownership "
+                        "of symlink {sl}".format(sl=self), log.WARNING)
         else:
             self.conn.os.chown(self.path, uid, gid)
         # uid/gid equal to -1 is ignored by chown/lchown
@@ -773,17 +778,17 @@ class RPath(RORPath):
             self.data['gid'] = gid
 
     def mkdir(self):
-        log.Log("Making directory {rp}".format(rp=self), 6)
+        log.Log("Making directory {di}".format(di=self), log.DEBUG)
         self.conn.os.mkdir(self.path)
         self.setdata()
 
     def makedirs(self):
-        log.Log("Making directory path {rp}".format(rp=self), 6)
+        log.Log("Making directory path {dp}".format(dp=self), log.DEBUG)
         self.conn.os.makedirs(self.path)
         self.setdata()
 
     def rmdir(self):
-        log.Log("Removing directory {rp}".format(rp=self), 6)
+        log.Log("Removing directory {di}".format(di=self), log.DEBUG)
         self.conn.os.chmod(self.path, 0o700)
         self.conn.os.rmdir(self.path)
         self.data = {'type': None}
@@ -803,8 +808,8 @@ class RPath(RORPath):
 
     def hardlink(self, linkpath):
         """Make self into a hardlink joined to linkpath"""
-        log.Log("Hard linking {frp} to {trp}".format(
-            frp=self, trp=self.__str__(linkpath)), 6)
+        log.Log("Hard linking source path {sp} to target path {tp}".format(
+            sp=self, tp=self.__str__(linkpath)), log.DEBUG)
         self.conn.os.link(linkpath, self.path)
         self.setdata()
 
@@ -826,7 +831,7 @@ class RPath(RORPath):
 
     def touch(self):
         """Make sure file at self.path exists"""
-        log.Log("Touching {rp}".format(rp=self), 7)
+        log.Log("Touching file {fi}".format(fi=self), log.DEBUG)
         self.conn.open(self.path, "wb").close()
         self.setdata()
         if not self.isreg():
@@ -876,7 +881,7 @@ class RPath(RORPath):
 
     def delete(self):
         """Delete file at self.path.  Recursively deletes directories."""
-        log.Log("Deleting {rp}".format(rp=self), 7)
+        log.Log("Deleting (recursively) path {pa}".format(pa=self), log.DEBUG)
         if self.isdir():
             try:
                 self.rmdir()
@@ -900,8 +905,8 @@ class RPath(RORPath):
 
     def contains_files(self):
         """Returns true if self (or subdir) contains any regular files."""
-        log.Log("Determining if directory contains files: {rp}".format(
-            rp=self), 7)
+        log.Log("Determining if directory {di} contains files".format(di=self),
+                log.DEBUG)
         if not self.isdir():
             return False
         dir_entries = self.listdir()
@@ -984,9 +989,9 @@ class RPath(RORPath):
         path_list = self._get_path_as_list()
         if self.isincfile():
             if (b"rdiff-backup-data" not in path_list):
-                log.Log("Path '{rp}' looks like an increment but doesn't "
+                log.Log("Path '{pa}' looks like an increment but doesn't "
                         "have 'rdiff-backup-data' in its path".format(
-                            rp=self), log.Log.ERROR)
+                            pa=self), log.ERROR)
                 return (self, [], None)
             else:
                 data_idx = path_list.index(b"rdiff-backup-data")
@@ -1003,9 +1008,9 @@ class RPath(RORPath):
                 else:
                     inc_idx = -1
                 if (inc_idx != data_idx + 1):
-                    log.Log("Path '{rp}' looks like an increment but "
+                    log.Log("Path '{pa}' looks like an increment but "
                             "doesn't have 'rdiff-backup-data/increments' "
-                            "in its path.".format(rp=self), log.Log.ERROR)
+                            "in its path.".format(pa=self), log.ERROR)
                     return (self, [], None)
                 # base_dir is the directory above the data directory
                 base_dir = RPath(self.conn, b"/".join(path_list[:data_idx]))
@@ -1022,9 +1027,9 @@ class RPath(RORPath):
                 if (parent_rp.lstat() and parent_rp.isdir()
                         and b"rdiff-backup-data" in parent_rp.listdir()):
                     return (parent_rp, path_list[-element:], "subdir")
-            log.Log("Path '{rp}' couldn't be identified as being within "
-                    "an existing backup repository".format(rp=self),
-                    log.Log.ERROR)
+            log.Log("Path '{pa}' couldn't be identified as being within "
+                    "an existing backup repository".format(pa=self),
+                    log.ERROR)
             return (self, [], None)
 
     def newpath(self, newpath, index=()):
@@ -1064,7 +1069,7 @@ class RPath(RORPath):
         # obsolete and we just want a name agnostic regarding file vs. dir
         while True:
             if self.__class__._temp_file_index > 100000000:
-                log.Log("Warning: Resetting tempfile index", 2)
+                log.Log("Resetting tempfile index", log.NOTE)
                 self.__class__._temp_file_index = 0
 
             # When the file system hosting the rdiff-backup-data directory
@@ -1120,7 +1125,7 @@ class RPath(RORPath):
         written to self.  Returns closing value of fp.
 
         """
-        log.Log("Writing file object to {rp}".format(rp=self), 7)
+        log.Log("Writing file object to file {fi}".format(fi=self), log.DEBUG)
         assert not self.lstat(), "File '{rp!r}' already exists".format(rp=self)
         outfp = self.open("wb", compress=compress)
         copyfileobj(fp, outfp)
@@ -1206,8 +1211,8 @@ class RPath(RORPath):
             if isinstance(e, AttributeError) or e.errno == errno.EPERM:
                 # AttributeError will be raised by Python 2.2, which
                 # doesn't have os.mknod
-                log.Log("unable to mknod {rp} -- using touch instead".format(
-                    rp=self), 4)
+                log.Log("unable to mknod device file {df} - "
+                        "using touch instead".format(df=self), log.INFO)
                 self.touch()
         self.setdata()
 
@@ -1320,7 +1325,7 @@ class RPath(RORPath):
         """Write new carbon data to self."""
         if not cfile:
             return
-        log.Log("Writing carbon data to {rp}".format(rp=self), 7)
+        log.Log("Writing carbon data to path {pa}".format(pa=self), log.DEBUG)
         from Carbon.File import FSSpec
         from Carbon.File import FSRef
         import Carbon.Files
@@ -1363,7 +1368,7 @@ class RPath(RORPath):
 
     def write_resource_fork(self, rfork_data):
         """Write new resource fork to self"""
-        log.Log("Writing resource fork to {rp}".format(rp=self), 7)
+        log.Log("Writing resource fork to path {pa}".format(pa=self), log.DEBUG)
         fp = self.conn.open(
             os.path.join(self.path, b'..namedfork', b'rsrc'), 'wb')
         fp.write(rfork_data)
@@ -1532,7 +1537,8 @@ def copy(rpin, rpout, compress=0):
     Returns close value of input for regular file, which can be used
     to pass hashes on.
     """
-    log.Log("Regular copying {irp} to {orp}".format(irp=rpin, orp=rpout), 6)
+    log.Log("Regular copying input path {ip} to output path {op}".format(
+        ip=rpin, op=rpout), log.DEBUG)
     if not rpin.lstat():
         if rpout.lstat():
             rpout.delete()
@@ -1583,11 +1589,11 @@ def copy_reg_file(rpin, rpout, compress=0):
     except OSError as e:
         if (e.errno == errno.ERANGE):
             log.Log.FatalError(
-                "'OSError - Result too large' while reading {rp}. "
+                "'OSError - Result too large' while reading file {fi}. "
                 "If you are using a Mac, this is probably "
                 "the result of HFS+ filesystem corruption. "
                 "Please exclude this file from your backup "
-                "before proceeding.".format(rp=rpin))
+                "before proceeding".format(fi=rpin))
         else:
             raise
 
@@ -1629,8 +1635,8 @@ def copy_attribs(rpin, rpout):
     timestamps, so both must already exist.
 
     """
-    log.Log("Copying attributes from {irp} to {orp}".format(
-        irp=rpin, orp=rpout), 7)
+    log.Log("Copying attributes from path {fp} to path {tp}".format(
+        fp=rpin, tp=rpout), log.DEBUG)
     assert rpin.lstat() == rpout.lstat() or rpin.isspecial(), (
         "Input '{irp!r}' and output '{orp!r}' paths must exist likewise, "
         "or input be special.".format(irp=rpin, orp=rpout))
@@ -1662,8 +1668,8 @@ def copy_attribs_inc(rpin, rpout):
     permissions.
 
     """
-    log.Log("Copying inc attrs from {irp} to {orp}".format(
-        irp=rpin, orp=rpout), 7)
+    log.Log("Copying inc attributes from path {fp} to path {tp}".format(
+        fp=rpin, tp=rpout), log.DEBUG)
     _check_for_files(rpin, rpout)
     if Globals.change_ownership:
         rpout.chown(*rpin.getuidgid())
@@ -1699,15 +1705,16 @@ def rename(rp_source, rp_dest):
     assert rp_source.conn is rp_dest.conn, (
         "Source '{srp!r}' and destination '{drp!r}' paths must have the "
         "same connection for renaming.".format(srp=rp_source, drp=rp_dest))
-    log.Log(lambda: "Renaming {srp} to {drp}".format(
-        srp=rp_source, drp=rp_dest), 7)
+    log.Log(lambda: "Renaming from path {fp} to path {tp}".format(
+        fp=rp_source, tp=rp_dest), log.DEBUG)
     if not rp_source.lstat():
         rp_dest.delete()
     else:
-        if rp_dest.lstat() and rp_source.getinode() == rp_dest.getinode() and \
-           rp_source.getinode() != 0:
-            log.Log("Warning: Attempt to rename over same inode: "
-                    "{srp} to {drp}".format(srp=rp_source, drp=rp_dest), 2)
+        if (rp_dest.lstat() and rp_source.getinode() == rp_dest.getinode()
+                and rp_source.getinode() != 0):
+            log.Log("Attempt to rename over same inode: from path "
+                    "{fp} to path {tp}".format(
+                        fp=rp_source, tp=rp_dest), log.WARNING)
             # You can't rename one hard linked file over another
             rp_source.delete()
         else:
@@ -1727,8 +1734,9 @@ def rename(rp_source, rp_dest):
                     rp_source.conn.os.unlink(rp_dest.path)
                     rp_source.conn.os.rename(rp_source.path, rp_dest.path)
                 else:
-                    log.Log("OSError while renaming {srp} to {drp}".format(
-                        srp=rp_source, drp=rp_dest), 1)
+                    log.Log("Exception {ex} while renaming from path {fp} "
+                            "to path {tp}".format(
+                                ex=error, fp=rp_source, tp=rp_dest), log.ERROR)
                     raise
 
         rp_dest.data = rp_source.data
@@ -1763,7 +1771,8 @@ def make_file_dict(filename):
     except (FileNotFoundError, NotADirectoryError, PermissionError):
         # FIXME not sure if this shouldn't trigger a warning but doing it
         # generates (too) many messages during the tests
-        # log.Log("Warning: missing file '%s' couldn't be assessed." % filename, 2)
+        # log.Log("Missing file '{mf}' couldn't be assessed".format(
+        #             mf=filename), log.WARNING)
         # FIXME perhaps we should have a different type/flag for this case?
         return {'type': None}
     data = {}
@@ -1924,7 +1933,7 @@ def setdata_local(rpath):
         rpath.chmod(rpath.getperms() & ~0o400)
 
 
-def _carbonfile_get(rpath):
+def _carbonfile_get(rp):
     """Return carbonfile value for local rpath"""
     # Note, after we drop support for Mac OS X 10.0 - 10.3, it will no longer
     # be necessary to read the finderinfo struct since it is a strict subset
@@ -1935,7 +1944,7 @@ def _carbonfile_get(rpath):
     import Carbon.Files
     import MacOS
     try:
-        fsobj = FSSpec(rpath.path)
+        fsobj = FSSpec(rp.path)
         finderinfo = fsobj.FSpGetFInfo()
         cataloginfo, d1, d2, d3 = FSRef(fsobj).FSGetCatalogInfo(
             Carbon.Files.kFSCatInfoCreateDate)
@@ -1948,8 +1957,8 @@ def _carbonfile_get(rpath):
         }
         return cfile
     except MacOS.Error:
-        log.Log("Cannot read carbonfile information from %s" % (rpath.path, ),
-                2)
+        log.Log("Cannot read carbonfile information from path {pa}".format(
+            pa=rp), log.WARNING)
         return None
 
 
@@ -1974,8 +1983,8 @@ def _cmp_file_attribs(rp1, rp2):
     else:
         result = ((rp1.getctime() == rp2.getctime())
                   and (rp1.getmtime() == rp2.getmtime()))
-    log.Log("Compare attribs of {rp1!s} and {rp2!s}: {res}".format(
-            rp1=rp1, rp2=rp2, res=result), 7)
+    log.Log("Compare attribs of paths {p1} and {p2} gives result: {re}".format(
+            p1=rp1, p2=rp2, re=result), log.DEBUG)
     return result
 
 

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -290,7 +290,7 @@ pattern (such as '**') which matches the base directory""".format(
                 fs=exc, bd=self.prefix))
         elif isinstance(exc, GlobbingError):
             log.Log.FatalError("Fatal Error while processing expression "
-                               "{ex}".format(ex=exc))
+                               "'{ex}'".format(ex=exc))
         else:
             raise
 

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -283,16 +283,14 @@ class Select:
     def _parse_catch_error(self, exc):
         """Deal with selection error exc"""
         if isinstance(exc, FilePrefixError):
-            log.Log.FatalError("""Fatal Error: The file specification
-    '%s'
-cannot match any files in the base directory
-    '%s'
+            log.Log.FatalError("""The file specification '{fs}'
+cannot match any files in the base directory '{bd}'.
 Useful file specifications begin with the base directory or some
-pattern (such as '**') which matches the base directory.""" % (exc,
-                                                               self.prefix))
+pattern (such as '**') which matches the base directory""".format(
+                fs=exc, bd=self.prefix))
         elif isinstance(exc, GlobbingError):
-            log.Log.FatalError("Fatal Error while processing expression\n"
-                               "%s" % exc)
+            log.Log.FatalError("Fatal Error while processing expression "
+                               "{ex}".format(ex=exc))
         else:
             raise
 
@@ -300,11 +298,10 @@ pattern (such as '**') which matches the base directory.""" % (exc,
         """Exit with error if last selection function isn't an exclude"""
         if (self.selection_functions
                 and not self.selection_functions[-1].exclude):
-            log.Log.FatalError("""Last selection expression:
-    %s
+            log.Log.FatalError("""Last selection expression {se}
 only specifies that files be included.  Because the default is to
 include all files, the expression is redundant.  Exiting because this
-probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
+probably isn't what you meant""".format(se=self.selection_functions[-1].name))
 
     def _add_selection_func(self, sel_func, add_to_start=None):
         """Add another selection function at the end or beginning"""
@@ -323,10 +320,10 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
         filelist_name is just a string used for logging.
 
         """
-        log.Log("Reading filelist %s" % filelist_name, 4)
+        log.Log("Reading filelist {fl}".format(fl=filelist_name), log.INFO)
         tuple_list, something_excluded = \
             self._filelist_read(filelist_fp, inc_default, filelist_name)
-        log.Log("Sorting filelist %s" % filelist_name, 4)
+        log.Log("Sorting filelist {fl}".format(fl=filelist_name), log.INFO)
         tuple_list.sort()
         i = [0]  # We have to put index in list because of stupid scoping rules
 
@@ -354,11 +351,12 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
             prefix_warnings[0] += 1
             if prefix_warnings[0] < 6:
                 log.Log(
-                    "Warning: file specification '%s' in filelist %s\n"
-                    "doesn't start with correct prefix %s.  Ignoring." %
-                    (exc, filelist_name, self.prefix), 2)
+                    "File specification '{fs}' in filelist {fl} "
+                    "doesn't start with correct prefix {cp}. Ignoring.".format(
+                        fs=exc, fl=filelist_name, cp=self.prefix), log.WARNING)
                 if prefix_warnings[0] == 5:
-                    log.Log("Future prefix errors will not be logged.", 2)
+                    log.Log("Future prefix errors will not be logged",
+                            log.WARNING)
 
         something_excluded, tuple_list = None, []
         separator = Globals.null_separator and b"\0" or b"\n"
@@ -375,7 +373,8 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
             if not tuple[1]:
                 something_excluded = 1
         if filelist_fp.close():
-            log.Log("Error closing filelist %s" % filelist_name, 2)
+            log.Log("Failed closing filelist {fl}".format(fl=filelist_name),
+                    log.WARNING)
         return (tuple_list, something_excluded)
 
     def _filelist_parse_line(self, line, include):
@@ -438,7 +437,7 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
         See the man page on --[include/exclude]-globbing-filelist
 
         """
-        log.Log("Reading globbing filelist %s" % list_name, 4)
+        log.Log("Reading globbing filelist {gf}".format(gf=list_name), log.INFO)
         separator = Globals.null_separator and b"\0" or b"\n"
         for line in filelist_fp.read().split(separator):
             line = line.rstrip(b'\r')  # for Windows/DOS endings
@@ -474,7 +473,8 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
         try:
             regexp = re.compile(os.fsencode(regexp_string))
         except re.error:
-            log.Log("Error compiling regular expression %s" % regexp_string, 1)
+            log.Log("Failed compiling regular expression {rx}".format(
+                rx=regexp_string), log.ERROR)
             raise
 
         def sel_func(rp):
@@ -557,7 +557,7 @@ probably isn't what you meant.""" % (self.selection_functions[-1].name, ))
         except ValueError:
             log.Log.FatalError(
                 "Max and min file size must be a positive integer "
-                "and not '{size}'.".format(size=sizestr))
+                "and not '{fs}'".format(fs=sizestr))
 
         def sel_func(rp):
             if not rp.isreg():

--- a/src/rdiff_backup/user_group.py
+++ b/src/rdiff_backup/user_group.py
@@ -108,8 +108,8 @@ class _DefinedMap(_Map):
                 continue
             comps = line.split(':')
             if not len(comps) == 2:
-                log.Log.FatalError("Error parsing mapping file, bad line: "
-                                   + line)
+                log.Log.FatalError("Failed parsing user/group mapping file, "
+                                   "bad line {bl}".format(bl=line))
             old, new = comps
 
             try:
@@ -148,8 +148,8 @@ class _DefinedMap(_Map):
             try:
                 return self.name2id(id_or_name)
             except KeyError:
-                log.Log.FatalError("Cannot get id for user or group name "
-                                   + id_or_name)
+                log.Log.FatalError("Cannot get id for user or group "
+                                   "name {ug}".format(ug=id_or_name))
 
 
 class _NumericalMap:

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -83,7 +83,7 @@ class ACL:
                 os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
         except (OSError, pywintypes.error) as exc:
             log.Log("Unable to read ACL from path {pa} due to "
-                    "exception {ex}".format(pa=rp, ex=exc), log.INFO)
+                    "exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
             return
 
         if skip_inherit_only:

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -82,8 +82,8 @@ class ACL:
             sd = rp.conn.win32security.GetNamedSecurityInfo(
                 os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
         except (OSError, pywintypes.error) as exc:
-            log.Log("Warning: unable to read ACL from {rp}: {exc}".format(
-                rp=rp, exc=exc), 4)
+            log.Log("Unable to read ACL from path {pa} due to "
+                    "exception {ex}".format(pa=rp, ex=exc), log.INFO)
             return
 
         if skip_inherit_only:
@@ -120,9 +120,8 @@ class ACL:
             self.__acl = rp.conn.win32security.ConvertSecurityDescriptorToStringSecurityDescriptor(
                 sd, SDDL_REVISION_1, ACL.flags)
         except (OSError, pywintypes.error) as exc:
-            log.Log(
-                "Warning: unable to convert ACL from %s to string: %s" % (repr(
-                    rp.path), exc), 4)
+            log.Log("Unable to convert ACL of path {pa} to string "
+                    "due to exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
             self.__acl = ''
         self.__acl = os.fsencode(self.__acl)
 
@@ -134,9 +133,9 @@ class ACL:
             sd = rp.conn.win32security.ConvertStringSecurityDescriptorToSecurityDescriptor(
                 os.fsdecode(self.__acl), SDDL_REVISION_1)
         except (OSError, pywintypes.error) as exc:
-            log.Log(
-                "Warning: unable to convert string %s to ACL: %s" % (repr(
-                    self.__acl), exc), 4)
+            log.Log("Unable to convert ACL string '{st!r}' to security "
+                    "descriptor due to exception '{ex}'".format(
+                        st=self.__acl, ex=exc), log.INFO)
 
         # Enable next block of code for dirs after we have a mechanism in
         # backup.py (and similar) to do a first pass to see if a directory
@@ -175,8 +174,8 @@ class ACL:
                 and sd.GetSecurityDescriptorSacl() or None
             )
         except (OSError, pywintypes.error) as exc:
-            log.Log("Warning: unable to set ACL on {rp}: {exc}".format(
-                rp=rp, exc=exc), 4)
+            log.Log("Unable to set ACL on path '{pa}' "
+                    "due to exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
 
     def from_string(self, acl_str):
 
@@ -205,9 +204,8 @@ class ACL:
             sd = rp.conn.win32security.GetNamedSecurityInfo(
                 os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
         except (OSError, pywintypes.error) as exc:
-            log.Log(
-                "Warning: unable to read ACL from %s for clearing: %s" % (repr(
-                    rp.path), exc), 4)
+            log.Log("Unable to read ACL from path {pa} for clearing them "
+                    "due to exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
             return
 
         acl = sd.GetSecurityDescriptorDacl()
@@ -241,9 +239,8 @@ class ACL:
                 and sd.GetSecurityDescriptorSacl() or None
             )
         except (OSError, pywintypes.error) as exc:
-            log.Log(
-                "Warning: unable to set ACL on %s after clearing: %s" % (repr(
-                    rp.path), exc), 4)
+            log.Log("Unable to set ACL on path {pa} after clearing them "
+                    "due to exception '{ex}".format(pa=rp, ex=exc), log.INFO)
 
 
 class WACLExtractor(metadata.FlatExtractor):
@@ -294,7 +291,8 @@ def init_acls():
         hnd = OpenProcessToken(win32api.GetCurrentProcess(),
                                TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY)
     except win32api.error as exc:
-        log.Log("Warning: unable to open Windows process token: %s" % exc, 5)
+        log.Log("Unable to open Windows process token due to "
+                "exception '{ex}'".format(ex=exc), log.INFO)
         return
     try:
         try:
@@ -308,8 +306,8 @@ def init_acls():
                              (lpv(SE_BACKUP_NAME), SE_PRIVILEGE_ENABLED),
                              (lpv(SE_RESTORE_NAME), SE_PRIVILEGE_ENABLED)])
         except win32api.error as exc:
-            log.Log("Warning: unable to enable SE_*_NAME privileges: %s" % exc,
-                    5)
+            log.Log("unable to enable SE_*_NAME privileges due to "
+                    "exception '{ex}'".format(ex=exc), log.INFO)
             return
         for name, enabled in GetTokenInformation(hnd, TokenPrivileges):
             if name == SecurityName and enabled:

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -384,7 +384,7 @@ class BaseAction:
 
         Returns False to propagate potential exception, else True.
         """
-        log.Log("Cleaning up", log.Log.INFO)
+        log.Log("Cleaning up", log.INFO)
         if self.security != "server":
             log.ErrorLog.close()
             log.Log.close_logfile()
@@ -413,18 +413,18 @@ class BaseAction:
         """
         return_code = 0
         if self.values.action != self.name:
-            self.log("Action '{act}' doesn't fit name of action class "
-                     "'{name}'.".format(act=self.values.action, name=self.name),
-                     self.log.ERROR)
+            log.Log("Action value '{av}' doesn't fit name of action class "
+                    "'{ac}'.".format(av=self.values.action, ac=self.name),
+                    log.ERROR)
             return_code |= 1
         if self.values.tempdir and not os.path.isdir(self.values.tempdir):
-            self.log("Temporary directory '{dir}' doesn't exist.".format(
-                     dir=self.values.tempdir), self.log.ERROR)
+            log.Log("Temporary directory '{td}' doesn't exist.".format(
+                    td=self.values.tempdir), log.ERROR)
             return_code |= 1
         if (self.security is None
                 and "locations" in self.values and self.values.locations):
-            self.log("Action '{act}' must have a security class to handle "
-                     "locations".format(act=self.name), self.log.ERROR)
+            log.Log("Action '{ac}' must have a security class to handle "
+                    "locations".format(ac=self.name), log.ERROR)
             return_code |= 1
         return return_code
 
@@ -476,8 +476,8 @@ class BaseAction:
         # if a connection is None, it's an error
         for conn, loc in zip(self.connected_locations, self.values.locations):
             if conn is None:
-                self.log("Location '{loc}' couldn't be connected.".format(
-                    loc=loc), self.log.ERROR)
+                log.Log("Location '{lo}' couldn't be connected.".format(
+                    lo=loc), log.ERROR)
                 return_code |= 1
 
         return return_code
@@ -527,9 +527,9 @@ class BaseAction:
             try:
                 return rp.get_string()
             except OSError as e:
-                self.log.FatalError(
-                    "Error '{err!s}' reading mapping file '{file}'".format(
-                        err=e, file=filename))
+                log.Log.FatalError(
+                    "Error '{er}' reading mapping file '{mf}'".format(
+                        er=e, mf=filename))
 
         user_mapping_string = get_string_from_file(
             self.values.user_mapping_file)
@@ -552,9 +552,8 @@ class BaseAction:
         try:
             return Time.genstrtotime(timestr, rp=ref_rp)
         except Time.TimeException as exc:
-            self.log("Time string '{tstr}' couldn't be parsed "
-                     "due to '{exc}'".format(tstr=timestr, exc=exc),
-                     self.log.ERROR)
+            log.Log("Time string '{ts}' couldn't be parsed "
+                    "due to '{ex}'".format(ts=timestr, ex=exc), log.ERROR)
             return None
 
 

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -29,7 +29,7 @@ import sys
 import tempfile
 import yaml
 from rdiff_backup import (
-    Globals, rpath, Security, SetConnections, Time
+    Globals, log, rpath, Security, SetConnections, Time
 )
 from rdiffbackup.utils.argopts import BooleanOptionalAction, SelectAction
 
@@ -354,16 +354,13 @@ class BaseAction:
             subparsers[sub_name].set_defaults(**{sub_dest: sub_name})
         return subparsers
 
-    def __init__(self, values, log=None, errlog=None):
+    def __init__(self, values):
         """
         Instantiate an action plug-in class.
 
         values is a Namespace as returned by argparse.
-        log is a log.Log object and errlog a log.ErrorLog object.
         """
         self.values = values
-        self.log = log
-        self.errlog = errlog
         if self.values.remote_schema:
             self.remote_schema = os.fsencode(self.values.remote_schema)
         else:
@@ -387,10 +384,10 @@ class BaseAction:
 
         Returns False to propagate potential exception, else True.
         """
-        self.log("Cleaning up", self.log.INFO)
+        log.Log("Cleaning up", log.Log.INFO)
         if self.security != "server":
-            self.errlog.close()
-            self.log.close_logfile()
+            log.ErrorLog.close()
+            log.Log.close_logfile()
             SetConnections.CloseConnections()
 
         return False

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -105,15 +105,15 @@ class BackupAction(actions.BaseAction):
         previous_time = self.target.get_mirror_time()
         if previous_time >= Time.curtime:
             log.Log("The last backup is not in the past. Aborting.",
-                    log.Log.ERROR)
+                    log.ERROR)
             return 1
         if log.Log.verbosity > 0:
             try:  # the target repository must be writable
                 log.Log.open_logfile(
                     self.target.data_dir.append("backup.log"))
             except (log.LoggerError, Security.Violation) as exc:
-                log.Log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), log.Log.ERROR)
+                log.Log("Unable to open logfile due to '{ex}'".format(
+                    ex=exc), log.ERROR)
                 return 1
         # TODO could we get rid of the error log?
         log.ErrorLog.open(Time.curtimestr, compress=self.values.compression)
@@ -136,7 +136,7 @@ class BackupAction(actions.BaseAction):
         if previous_time < 0 or previous_time >= Time.curtime:
             log.Log("Either there is more than one current_mirror or "
                     "the last backup is not in the past. Aborting.",
-                    log.Log.ERROR)
+                    log.ERROR)
             return 1
         elif previous_time:
             Time.setprevtime(previous_time)
@@ -175,12 +175,12 @@ class BackupAction(actions.BaseAction):
         # if not Globals.select_mirror.Select(relative_rpout):
         #     return
 
-        log.Log("The target directory '{trp}' may be contained in the "
-                "source directory '{srp}'. "
+        log.Log("The target directory '{td}' may be contained in the "
+                "source directory '{sd}'. "
                 "This could cause an infinite recursion. "
                 "You may need to use the --exclude option "
                 "(which you might already have done).".format(
-                    trp=rpout, srp=rpin), log.Log.WARNING)
+                    td=rpout, sd=rpin), log.WARNING)
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -24,8 +24,8 @@ A built-in rdiff-backup action plug-in to backup a source to a target directory.
 import time
 
 from rdiff_backup import (
-    log,
     backup,
+    log,
     Security,
     selection,
     SetConnections,
@@ -59,9 +59,9 @@ class BackupAction(actions.BaseAction):
         conn_value = super().connect()
         if conn_value:
             self.source = directory.ReadDir(self.connected_locations[0],
-                                            self.log, self.values.force)
+                                            self.values.force)
             self.target = repository.Repo(
-                self.connected_locations[1], self.log, self.values.force,
+                self.connected_locations[1], self.values.force,
                 must_be_writable=True, must_exist=False,
                 create_full_path=self.values.create_full_path
             )
@@ -104,19 +104,19 @@ class BackupAction(actions.BaseAction):
         self._init_user_group_mapping(self.target.base_dir.conn)
         previous_time = self.target.get_mirror_time()
         if previous_time >= Time.curtime:
-            self.log("The last backup is not in the past. Aborting.",
-                     self.log.ERROR)
+            log.Log("The last backup is not in the past. Aborting.",
+                    log.Log.ERROR)
             return 1
-        if self.log.verbosity > 0:
+        if log.Log.verbosity > 0:
             try:  # the target repository must be writable
-                self.log.open_logfile(
+                log.Log.open_logfile(
                     self.target.data_dir.append("backup.log"))
             except (log.LoggerError, Security.Violation) as exc:
-                self.log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), self.log.ERROR)
+                log.Log("Unable to open logfile due to '{exc}'".format(
+                    exc=exc), log.Log.ERROR)
                 return 1
         # TODO could we get rid of the error log?
-        self.errlog.open(Time.curtimestr, compress=self.values.compression)
+        log.ErrorLog.open(Time.curtimestr, compress=self.values.compression)
 
         (select_opts, select_data) = selection.get_prepared_selections(
             self.values.selections)
@@ -134,9 +134,9 @@ class BackupAction(actions.BaseAction):
                 return ret_code
         previous_time = self.target.get_mirror_time()
         if previous_time < 0 or previous_time >= Time.curtime:
-            self.log("Either there is more than one current_mirror or "
-                     "the last backup is not in the past. Aborting.",
-                     self.log.ERROR)
+            log.Log("Either there is more than one current_mirror or "
+                    "the last backup is not in the past. Aborting.",
+                    log.Log.ERROR)
             return 1
         elif previous_time:
             Time.setprevtime(previous_time)
@@ -175,12 +175,12 @@ class BackupAction(actions.BaseAction):
         # if not Globals.select_mirror.Select(relative_rpout):
         #     return
 
-        self.log("The target directory '{trp}' may be contained in the "
-                 "source directory '{srp}'. "
-                 "This could cause an infinite recursion. "
-                 "You may need to use the --exclude option "
-                 "(which you might already have done).".format(
-                     trp=rpout, srp=rpin), self.log.WARNING)
+        log.Log("The target directory '{trp}' may be contained in the "
+                "source directory '{srp}'. "
+                "This could cause an infinite recursion. "
+                "You may need to use the --exclude option "
+                "(which you might already have done).".format(
+                    trp=rpout, srp=rpin), log.Log.WARNING)
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -56,9 +56,9 @@ class CompareAction(actions.BaseAction):
         conn_value = super().connect()
         if conn_value:
             self.source = directory.ReadDir(self.connected_locations[0],
-                                            self.log, self.values.force)
+                                            self.values.force)
             self.target = repository.Repo(
-                self.connected_locations[1], self.log, self.values.force,
+                self.connected_locations[1], self.values.force,
                 must_be_writable=False, must_exist=True, can_be_sub_path=True
             )
         return conn_value

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -66,7 +66,7 @@ class ListAction(actions.BaseAction):
         conn_value = super().connect()
         if conn_value:
             self.source = repository.Repo(
-                self.connected_locations[0], self.log, self.values.force,
+                self.connected_locations[0], self.values.force,
                 must_be_writable=False, must_exist=True, can_be_sub_path=True
             )
         return conn_value

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -49,7 +49,7 @@ class RegressAction(actions.BaseAction):
         conn_value = super().connect()
         if conn_value:
             self.source = repository.Repo(
-                self.connected_locations[0], self.log, self.values.force,
+                self.connected_locations[0], self.values.force,
                 must_be_writable=True, must_exist=True
             )
         return conn_value
@@ -84,13 +84,13 @@ class RegressAction(actions.BaseAction):
         # TODO validate how much of the following lines and methods
         # should go into the directory/repository modules
         self._init_user_group_mapping(self.source.base_dir.conn)
-        if self.log.verbosity > 0:
+        if log.Log.verbosity > 0:
             try:  # the source repository must be writable
-                self.log.open_logfile(
+                log.Log.open_logfile(
                     self.source.data_dir.append(self.name + ".log"))
             except (log.LoggerError, Security.Violation) as exc:
-                self.log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), self.log.ERROR)
+                log.Log("Unable to open logfile due to '{exc}'".format(
+                    exc=exc), log.Log.ERROR)
                 return 1
 
         return 0
@@ -102,8 +102,8 @@ class RegressAction(actions.BaseAction):
         if self.source.needs_regress():
             return self.source.regress()
         else:
-            self.log("Given repository doesn't need to be regressed",
-                     self.log.NOTE)
+            log.Log("Given repository doesn't need to be regressed",
+                    log.Log.NOTE)
             return 0  # all is good
 
 

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -89,8 +89,8 @@ class RegressAction(actions.BaseAction):
                 log.Log.open_logfile(
                     self.source.data_dir.append(self.name + ".log"))
             except (log.LoggerError, Security.Violation) as exc:
-                log.Log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), log.Log.ERROR)
+                log.Log("Unable to open logfile due to exception '{ex}'".format(
+                    ex=exc), log.ERROR)
                 return 1
 
         return 0
@@ -103,7 +103,7 @@ class RegressAction(actions.BaseAction):
             return self.source.regress()
         else:
             log.Log("Given repository doesn't need to be regressed",
-                    log.Log.NOTE)
+                    log.NOTE)
             return 0  # all is good
 
 

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -51,7 +51,7 @@ class RemoveAction(actions.BaseAction):
         conn_value = super().connect()
         if conn_value:
             self.source = repository.Repo(
-                self.connected_locations[0], self.log, self.values.force,
+                self.connected_locations[0], self.values.force,
                 must_be_writable=True, must_exist=True
             )
         return conn_value
@@ -68,11 +68,11 @@ class RemoveAction(actions.BaseAction):
         # the source directory must directly point at the base directory of
         # the repository
         if self.source.restore_index:
-            self.log("Increments for directory '{orp}' cannot be removed "
-                     "separately.\n"
-                     "Instead run on entire directory '{brp}'.".format(
-                         orp=self.source.orig_path,
-                         brp=self.source.base_dir), self.log.ERROR)
+            log.Log("Increments for directory '{orp}' cannot be removed "
+                    "separately.\n"
+                    "Instead run on entire directory '{brp}'.".format(
+                        orp=self.source.orig_path,
+                        brp=self.source.base_dir), log.Log.ERROR)
             return_code |= 1
 
         return return_code
@@ -95,13 +95,13 @@ class RemoveAction(actions.BaseAction):
 
         # TODO validate how much of the following lines and methods
         # should go into the directory/repository modules
-        if self.log.verbosity > 0:
+        if log.Log.verbosity > 0:
             try:  # the source repository must be writable
-                self.log.open_logfile(
+                log.Log.open_logfile(
                     self.source.data_dir.append(self.name + ".log"))
             except (log.LoggerError, Security.Violation) as exc:
-                self.log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), self.log.ERROR)
+                log.Log("Unable to open logfile due to '{exc}'".format(
+                    exc=exc), log.Log.ERROR)
                 return 1
 
         return 0
@@ -136,27 +136,27 @@ class RemoveAction(actions.BaseAction):
         ]
         times_in_secs = [t for t in times_in_secs if t < action_time]
         if not times_in_secs:
-            self.log("No increments older than {atim} found, exiting.".format(
-                atim=Time.timetopretty(action_time)), self.log.NOTE)
+            log.Log("No increments older than {atim} found, exiting.".format(
+                atim=Time.timetopretty(action_time)), log.Log.NOTE)
             return None
 
         times_in_secs.sort()
         pretty_times = "\n".join(map(Time.timetopretty, times_in_secs))
         if len(times_in_secs) > 1:
             if not self.values.force:
-                self.log(
+                log.Log(
                     "Found {lent} relevant increments, dated:\n{ptim}\n"
                     "If you want to delete multiple increments in this way, "
                     "use the --force option.".format(lent=len(times_in_secs),
                                                      ptim=pretty_times),
-                    self.log.ERROR)
+                    log.Log.ERROR)
                 return None
             else:
-                self.log("Deleting increments at times:\n{ptim}".format(
-                    ptim=pretty_times), self.log.NOTE)
+                log.Log("Deleting increments at times:\n{ptim}".format(
+                    ptim=pretty_times), log.Log.NOTE)
         else:
-            self.log("Deleting increment at time:\n{ptim}".format(
-                ptim=pretty_times), self.log.NOTE)
+            log.Log("Deleting increment at time:\n{ptim}".format(
+                ptim=pretty_times), log.Log.NOTE)
         # make sure we don't delete current increment
         return times_in_secs[-1] + 1
 

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -68,11 +68,11 @@ class RemoveAction(actions.BaseAction):
         # the source directory must directly point at the base directory of
         # the repository
         if self.source.restore_index:
-            log.Log("Increments for directory '{orp}' cannot be removed "
-                    "separately.\n"
-                    "Instead run on entire directory '{brp}'.".format(
-                        orp=self.source.orig_path,
-                        brp=self.source.base_dir), log.Log.ERROR)
+            log.Log("Increments for sub-directory '{sd}' cannot be removed "
+                    "separately. "
+                    "Instead run on entire directory '{ed}'.".format(
+                        sd=self.source.orig_path,
+                        ed=self.source.base_dir), log.ERROR)
             return_code |= 1
 
         return return_code
@@ -100,8 +100,8 @@ class RemoveAction(actions.BaseAction):
                 log.Log.open_logfile(
                     self.source.data_dir.append(self.name + ".log"))
             except (log.LoggerError, Security.Violation) as exc:
-                log.Log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), log.Log.ERROR)
+                log.Log("Unable to open logfile due to exception '{ex}'".format(
+                    ex=exc), log.ERROR)
                 return 1
 
         return 0
@@ -136,8 +136,8 @@ class RemoveAction(actions.BaseAction):
         ]
         times_in_secs = [t for t in times_in_secs if t < action_time]
         if not times_in_secs:
-            log.Log("No increments older than {atim} found, exiting.".format(
-                atim=Time.timetopretty(action_time)), log.Log.NOTE)
+            log.Log("No increments older than {at} found, exiting.".format(
+                at=Time.timetopretty(action_time)), log.NOTE)
             return None
 
         times_in_secs.sort()
@@ -145,18 +145,17 @@ class RemoveAction(actions.BaseAction):
         if len(times_in_secs) > 1:
             if not self.values.force:
                 log.Log(
-                    "Found {lent} relevant increments, dated:\n{ptim}\n"
+                    "Found {ri} relevant increments, dates/times:\n{dt}\n"
                     "If you want to delete multiple increments in this way, "
-                    "use the --force option.".format(lent=len(times_in_secs),
-                                                     ptim=pretty_times),
-                    log.Log.ERROR)
+                    "use the --force option.".format(
+                        ri=len(times_in_secs), dt=pretty_times), log.ERROR)
                 return None
             else:
-                log.Log("Deleting increments at times:\n{ptim}".format(
-                    ptim=pretty_times), log.Log.NOTE)
+                log.Log("Deleting increments at dates/times:\n{dt}".format(
+                    dt=pretty_times), log.NOTE)
         else:
-            log.Log("Deleting increment at time:\n{ptim}".format(
-                ptim=pretty_times), log.Log.NOTE)
+            log.Log("Deleting increment at date/time: {dt}".format(
+                dt=pretty_times), log.NOTE)
         # make sure we don't delete current increment
         return times_in_secs[-1] + 1
 

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -78,14 +78,14 @@ class RestoreAction(actions.BaseAction):
         if self.source.restore_type == "inc":
             if self.values.at:
                 log.Log("You can't give an increment file and a time to "
-                        "restore at the same time.", log.Log.ERROR)
+                        "restore at the same time.", log.ERROR)
                 return_code |= 1
             elif not self.values.increment:
                 self.values.increment = True
         elif self.source.restore_type in ("base", "subdir"):
             if self.values.increment:
                 log.Log("You can't use the --increment option and _not_ "
-                        "give an increment file", log.Log.ERROR)
+                        "give an increment file", log.ERROR)
                 return_code |= 1
             elif not self.values.at:
                 self.values.at = "now"
@@ -117,8 +117,8 @@ class RestoreAction(actions.BaseAction):
             self.target.base_dir.conn.fs_abilities.restore_set_globals(
                 self.target.base_dir)
         except OSError as exc:
-            log.Log("Could not begin restore due to\n{exc}".format(exc=exc),
-                    log.Log.ERROR)
+            log.Log("Could not begin restore due to exception '{ex}'".format(
+                ex=exc), log.ERROR)
             return 1
         self.source.init_quoting(self.values.chars_to_quote)
         self._init_user_group_mapping(self.target.base_dir.conn)
@@ -127,8 +127,9 @@ class RestoreAction(actions.BaseAction):
                 log.Log.open_logfile(
                     self.source.data_dir.append("restore.log"))
             except (log.LoggerError, Security.Violation) as exc:
-                log.Log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), log.Log.WARNING)
+                log.Log(
+                    "Unable to open logfile due to exception '{ex}'".format(
+                        ex=exc), log.WARNING)
 
         # we need now to identify the actual time of restore
         self.inc_rpath = self.source.data_dir.append_path(
@@ -142,7 +143,7 @@ class RestoreAction(actions.BaseAction):
             self.action_time = self.source.orig_path.getinctime()
         else:  # this should have been catched in the check method
             log.Log("This shouldn't happen but neither restore time nor "
-                    "an increment have been identified so far", log.Log.ERROR)
+                    "an increment have been identified so far", log.ERROR)
             return 1
         (select_opts, select_data) = selection.get_prepared_selections(
             self.values.selections)
@@ -163,18 +164,18 @@ class RestoreAction(actions.BaseAction):
             log.Log("Previous backup to {rp} seems to have failed. "
                     "Use rdiff-backup to 'regress' first the failed backup, "
                     "then try again to restore".format(
-                        rp=self.source.base_dir), log.Log.ERROR)
+                        rp=self.source.base_dir), log.ERROR)
             return 1
         try:
             restore.Restore(
                 self.source.base_dir.new_index(self.source.restore_index),
                 self.inc_rpath, self.target.base_dir, self.action_time)
         except OSError as exc:
-            log.Log("Could not complete restore due to '{exc}'".format(
-                exc=exc), log.Log.ERROR)
+            log.Log("Could not complete restore due to exception '{ex}'".format(
+                ex=exc), log.ERROR)
             return 1
         else:
-            log.Log("Restore successfully finished", log.Log.INFO)
+            log.Log("Restore successfully finished", log.INFO)
             return 0
 
 

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -59,11 +59,11 @@ class RestoreAction(actions.BaseAction):
         conn_value = super().connect()
         if conn_value:
             self.source = repository.Repo(
-                self.connected_locations[0], self.log, self.values.force,
+                self.connected_locations[0], self.values.force,
                 must_be_writable=False, must_exist=True, can_be_sub_path=True
             )
             self.target = directory.WriteDir(self.connected_locations[1],
-                                             self.log, self.values.force,
+                                             self.values.force,
                                              self.values.create_full_path)
         return conn_value
 
@@ -77,15 +77,15 @@ class RestoreAction(actions.BaseAction):
         # fit together
         if self.source.restore_type == "inc":
             if self.values.at:
-                self.log("You can't give an increment file and a time to restore "
-                         "at the same time.", self.log.ERROR)
+                log.Log("You can't give an increment file and a time to "
+                        "restore at the same time.", log.Log.ERROR)
                 return_code |= 1
             elif not self.values.increment:
                 self.values.increment = True
         elif self.source.restore_type in ("base", "subdir"):
             if self.values.increment:
-                self.log("You can't use the --increment option and _not_ "
-                         "give an increment file", self.log.ERROR)
+                log.Log("You can't use the --increment option and _not_ "
+                        "give an increment file", log.Log.ERROR)
                 return_code |= 1
             elif not self.values.at:
                 self.values.at = "now"
@@ -117,18 +117,18 @@ class RestoreAction(actions.BaseAction):
             self.target.base_dir.conn.fs_abilities.restore_set_globals(
                 self.target.base_dir)
         except OSError as exc:
-            self.log("Could not begin restore due to\n{exc}".format(exc=exc),
-                     self.log.ERROR)
+            log.Log("Could not begin restore due to\n{exc}".format(exc=exc),
+                    log.Log.ERROR)
             return 1
         self.source.init_quoting(self.values.chars_to_quote)
         self._init_user_group_mapping(self.target.base_dir.conn)
-        if self.log.verbosity > 0:
+        if log.Log.verbosity > 0:
             try:  # the source repository could be read-only
-                self.log.open_logfile(
+                log.Log.open_logfile(
                     self.source.data_dir.append("restore.log"))
             except (log.LoggerError, Security.Violation) as exc:
-                self.log("Unable to open logfile due to '{exc}'".format(
-                    exc=exc), self.log.WARNING)
+                log.Log("Unable to open logfile due to '{exc}'".format(
+                    exc=exc), log.Log.WARNING)
 
         # we need now to identify the actual time of restore
         self.inc_rpath = self.source.data_dir.append_path(
@@ -141,8 +141,8 @@ class RestoreAction(actions.BaseAction):
         elif self.values.increment:
             self.action_time = self.source.orig_path.getinctime()
         else:  # this should have been catched in the check method
-            self.log("This shouldn't happen but neither restore time nor "
-                     "an increment have been identified so far", self.log.ERROR)
+            log.Log("This shouldn't happen but neither restore time nor "
+                    "an increment have been identified so far", log.Log.ERROR)
             return 1
         (select_opts, select_data) = selection.get_prepared_selections(
             self.values.selections)
@@ -160,21 +160,21 @@ class RestoreAction(actions.BaseAction):
         # the regress in the run section, we also do the check here...
         if self.source.needs_regress():
             # source could be read-only, so we don't try to regress it
-            self.log("Previous backup to {rp} seems to have failed. "
-                     "Use rdiff-backup to 'regress' first the failed backup, "
-                     "then try again to restore".format(
-                         rp=self.source.base_dir), self.log.ERROR)
+            log.Log("Previous backup to {rp} seems to have failed. "
+                    "Use rdiff-backup to 'regress' first the failed backup, "
+                    "then try again to restore".format(
+                        rp=self.source.base_dir), log.Log.ERROR)
             return 1
         try:
             restore.Restore(
                 self.source.base_dir.new_index(self.source.restore_index),
                 self.inc_rpath, self.target.base_dir, self.action_time)
         except OSError as exc:
-            self.log("Could not complete restore due to '{exc}'".format(
-                exc=exc), self.log.ERROR)
+            log.Log("Could not complete restore due to '{exc}'".format(
+                exc=exc), log.Log.ERROR)
             return 1
         else:
-            self.log("Restore successfully finished", self.log.INFO)
+            log.Log("Restore successfully finished", log.Log.INFO)
             return 0
 
 

--- a/src/rdiffbackup/actions/test.py
+++ b/src/rdiffbackup/actions/test.py
@@ -49,11 +49,11 @@ class TestAction(actions.BaseAction):
         for location in self.values.locations:
             (file_host, file_path, err) = SetConnections.parse_location(location)
             if err:
-                log.Log(err, log.Log.ERROR)
+                log.Log(err, log.ERROR)
                 return_code |= 1  # binary 'or' to always get 1
             elif not file_host:
-                log.Log("Only remote locations can be tested but '{loc}' "
-                        "isn't remote.".format(loc=location), log.Log.ERROR)
+                log.Log("Only remote locations can be tested but location "
+                        "'{lo}' isn't remote".format(lo=location), log.ERROR)
                 return_code |= 1  # binary 'or' to always get 1
 
         return return_code

--- a/src/rdiffbackup/actions/test.py
+++ b/src/rdiffbackup/actions/test.py
@@ -25,7 +25,7 @@ usable for a back-up.
 """
 
 from rdiffbackup import actions
-from rdiff_backup import SetConnections
+from rdiff_backup import log, SetConnections
 
 
 class TestAction(actions.BaseAction):
@@ -49,11 +49,11 @@ class TestAction(actions.BaseAction):
         for location in self.values.locations:
             (file_host, file_path, err) = SetConnections.parse_location(location)
             if err:
-                self.log(err, self.log.ERROR)
+                log.Log(err, log.Log.ERROR)
                 return_code |= 1  # binary 'or' to always get 1
             elif not file_host:
-                self.log("Only remote locations can be tested but '{loc}' "
-                         "isn't remote.".format(loc=location), self.log.ERROR)
+                log.Log("Only remote locations can be tested but '{loc}' "
+                        "isn't remote.".format(loc=location), log.Log.ERROR)
                 return_code |= 1  # binary 'or' to always get 1
 
         return return_code

--- a/src/rdiffbackup/actions/verify.py
+++ b/src/rdiffbackup/actions/verify.py
@@ -51,7 +51,7 @@ class VerifyAction(actions.BaseAction):
         conn_value = super().connect()
         if conn_value:
             self.source = repository.Repo(
-                self.connected_locations[0], self.log, self.values.force,
+                self.connected_locations[0], self.values.force,
                 must_be_writable=False, must_exist=True, can_be_sub_path=True
             )
         return conn_value

--- a/src/rdiffbackup/locations/__init__.py
+++ b/src/rdiffbackup/locations/__init__.py
@@ -24,6 +24,7 @@ All those classes should be considered abstract and not instantiated directly.
 """
 
 import os
+from rdiff_backup import log
 
 
 class Location():
@@ -31,9 +32,8 @@ class Location():
     Abstract location class representing a user@hostname::/dir location
     """
 
-    def __init__(self, base_dir, log, force):
+    def __init__(self, base_dir, force):
         self.base_dir = base_dir
-        self.log = log
         self.force = force
 
     def _is_existing(self):
@@ -41,12 +41,12 @@ class Location():
         check that the location exists and is a directory
         """
         if not self.base_dir.lstat():
-            self.log("Source path {rp} does not exist".format(
-                rp=self.base_dir), self.log.ERROR)
+            log.Log("Source path {rp} does not exist".format(
+                rp=self.base_dir), log.Log.ERROR)
             return False
         elif not self.base_dir.isdir():
-            self.log("Source path {rp} is not a directory".format(
-                rp=self.base_dir), self.log.ERROR)
+            log.Log("Source path {rp} is not a directory".format(
+                rp=self.base_dir), log.Log.ERROR)
             return False
         return True
 
@@ -57,13 +57,13 @@ class Location():
         # TODO The writable aspect hasn't yet been implemented
         if (self.base_dir.lstat() and not self.base_dir.isdir()):
             if self.force:
-                self.log("Target {rp} exists but isn't a directory, "
-                         "and will be force deleted".format(
-                             rp=self.base_dir), self.log.WARNING)
+                log.Log("Target {rp} exists but isn't a directory, "
+                        "and will be force deleted".format(
+                            rp=self.base_dir), log.Log.WARNING)
             else:
-                self.log("Target {rp} exists and is not a directory, "
-                         "call with '--force' to overwrite".format(
-                             rp=self.base_dir), self.log.ERROR)
+                log.Log("Target {rp} exists and is not a directory, "
+                        "call with '--force' to overwrite".format(
+                            rp=self.base_dir), log.Log.ERROR)
                 return False
         return True
 
@@ -85,8 +85,8 @@ class Location():
                     self.base_dir.mkdir()
                 self.base_dir.chmod(0o700)  # only read-writable by its owner
         except os.error:
-            self.log("Unable to delete and/or create directory {rp}".format(
-                rp=self.base_dir), self.log.ERROR)
+            log.Log("Unable to delete and/or create directory {rp}".format(
+                rp=self.base_dir), log.Log.ERROR)
             return False
 
         return True  # all is good
@@ -112,8 +112,8 @@ class WriteLocation(Location):
     Abstract writable location class, possibly not pre-existing
     """
 
-    def __init__(self, base_dir, log, force, create_full_path):
-        super().__init__(base_dir, log, force)
+    def __init__(self, base_dir, force, create_full_path):
+        super().__init__(base_dir, force)
         self.create_full_path = create_full_path
 
     def check(self):

--- a/src/rdiffbackup/locations/__init__.py
+++ b/src/rdiffbackup/locations/__init__.py
@@ -41,12 +41,12 @@ class Location():
         check that the location exists and is a directory
         """
         if not self.base_dir.lstat():
-            log.Log("Source path {rp} does not exist".format(
-                rp=self.base_dir), log.Log.ERROR)
+            log.Log("Source path {sp} does not exist".format(
+                sp=self.base_dir), log.ERROR)
             return False
         elif not self.base_dir.isdir():
-            log.Log("Source path {rp} is not a directory".format(
-                rp=self.base_dir), log.Log.ERROR)
+            log.Log("Source path {sp} is not a directory".format(
+                sp=self.base_dir), log.ERROR)
             return False
         return True
 
@@ -57,13 +57,13 @@ class Location():
         # TODO The writable aspect hasn't yet been implemented
         if (self.base_dir.lstat() and not self.base_dir.isdir()):
             if self.force:
-                log.Log("Target {rp} exists but isn't a directory, "
+                log.Log("Target path {tp} exists but isn't a directory, "
                         "and will be force deleted".format(
-                            rp=self.base_dir), log.Log.WARNING)
+                            tp=self.base_dir), log.WARNING)
             else:
-                log.Log("Target {rp} exists and is not a directory, "
+                log.Log("Target path {tp} exists and is not a directory, "
                         "call with '--force' to overwrite".format(
-                            rp=self.base_dir), log.Log.ERROR)
+                            tp=self.base_dir), log.ERROR)
                 return False
         return True
 
@@ -85,8 +85,8 @@ class Location():
                     self.base_dir.mkdir()
                 self.base_dir.chmod(0o700)  # only read-writable by its owner
         except os.error:
-            log.Log("Unable to delete and/or create directory {rp}".format(
-                rp=self.base_dir), log.Log.ERROR)
+            log.Log("Unable to delete and/or create directory {di}".format(
+                di=self.base_dir), log.ERROR)
             return False
 
         return True  # all is good

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -52,7 +52,7 @@ class ReadDir(Dir, locations.ReadLocation):
         # FIXME not sure we couldn't support symbolic links nowadays on Windows
         if self.base_dir.conn.os.name == 'nt':
             log.Log("Symbolic links excluded by default on Windows",
-                    log.Log.NOTE)
+                    log.NOTE)
             select_opts.append(("--exclude-symbolic-links", None))
         # FIXME we're retransforming bytes into a file pointer
         self.base_dir.conn.backup.SourceStruct.set_source_select(

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -69,13 +69,13 @@ class WriteDir(Dir, locations.WriteLocation):
                 and self.base_dir.isdir()
                 and self.base_dir.listdir()):
             if self.force:
-                log.Log("Target {rp} exists and isn't empty, content might "
-                        "be force overwritten by restore".format(
-                            rp=self.base_dir), log.Log.WARNING)
+                log.Log("Target path {tp} exists and isn't empty, content "
+                        "might be force overwritten by restore".format(
+                            tp=self.base_dir), log.WARNING)
             else:
-                log.Log("Target {rp} exists and isn't empty, "
+                log.Log("Target path {tp} exists and isn't empty, "
                         "call with '--force' to overwrite".format(
-                            rp=self.base_dir), log.Log.ERROR)
+                            tp=self.base_dir), log.ERROR)
                 ret_code |= 1
 
         return ret_code

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -26,6 +26,7 @@ usable for a back-up.
 
 import io
 from rdiffbackup import locations
+from rdiff_backup import log
 
 
 class Dir():
@@ -50,8 +51,8 @@ class ReadDir(Dir, locations.ReadLocation):
 
         # FIXME not sure we couldn't support symbolic links nowadays on Windows
         if self.base_dir.conn.os.name == 'nt':
-            self.log("Symbolic links excluded by default on Windows",
-                     self.log.NOTE)
+            log.Log("Symbolic links excluded by default on Windows",
+                    log.Log.NOTE)
             select_opts.append(("--exclude-symbolic-links", None))
         # FIXME we're retransforming bytes into a file pointer
         self.base_dir.conn.backup.SourceStruct.set_source_select(
@@ -68,13 +69,13 @@ class WriteDir(Dir, locations.WriteLocation):
                 and self.base_dir.isdir()
                 and self.base_dir.listdir()):
             if self.force:
-                self.log("Target {rp} exists and isn't empty, content might "
-                         "be force overwritten by restore".format(
-                             rp=self.base_dir), self.log.WARNING)
+                log.Log("Target {rp} exists and isn't empty, content might "
+                        "be force overwritten by restore".format(
+                            rp=self.base_dir), log.Log.WARNING)
             else:
-                self.log("Target {rp} exists and isn't empty, "
-                         "call with '--force' to overwrite".format(
-                             rp=self.base_dir), self.log.ERROR)
+                log.Log("Target {rp} exists and isn't empty, "
+                        "call with '--force' to overwrite".format(
+                            rp=self.base_dir), log.Log.ERROR)
                 ret_code |= 1
 
         return ret_code

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -76,8 +76,8 @@ class Repo(locations.Location):
             # there is nothing to save, the user must first give a correct path
             return 1
         else:
-            log.Log("Using repository '{rp}'".format(rp=self.base_dir),
-                    log.Log.INFO)
+            log.Log("Using repository '{re}'".format(re=self.base_dir),
+                    log.INFO)
         ret_code = 0
 
         if self.must_exist and not self._is_existing():
@@ -166,7 +166,7 @@ class Repo(locations.Location):
                 """Bad rdiff-backup-data dir on destination side
 
 The rdiff-backup data directory
-{drp}
+{dd}
 exists, but we cannot find a valid current_mirror marker.  You can
 avoid this message by removing the rdiff-backup-data directory;
 however any data in it will be lost.
@@ -176,7 +176,7 @@ into a new directory failed.  If this is the case it is safe to delete
 the rdiff-backup-data directory because there is no important
 information in it.
 
-""".format(drp=self.data_dir))
+""".format(dd=self.data_dir))
         elif len(curmir_incs) == 1:
             return False
         else:
@@ -186,10 +186,10 @@ information in it.
                 except OSError as exc:
                     log.Log.FatalError(
                         "Could not check if rdiff-backup is currently"
-                        "running due to\n{exc}".format(exc=exc))
+                        "running due to exception {ex}".format(ex=exc))
             assert len(curmir_incs) == 2, (
-                "Found more than 2 current_mirror incs in '{rp}'.".format(
-                    rp=self.data_dir))
+                "Found more than 2 current_mirror incs in '{ci}'.".format(
+                    ci=self.data_dir))
             return True
 
     def regress(self):
@@ -199,9 +199,8 @@ information in it.
         This can/should be run before any action on the repository to start
         with a clean state.
         """
-        log.Log(
-            "Previous backup seems to have failed, regressing "
-            "destination now.", log.Log.WARNING)
+        log.Log("Previous backup seems to have failed, regressing "
+                "destination now", log.WARNING)
         try:
             self.base_dir.conn.regress.Regress(self.base_dir)
             return 0
@@ -209,7 +208,7 @@ information in it.
             log.Log(
                 "Security violation while attempting to regress destination, "
                 "perhaps due to --restrict-read-only or "
-                "--restrict-update-only.", log.Log.ERROR)
+                "--restrict-update-only", log.ERROR)
             return 1
 
     def set_select(self, select_opts, select_data, target_rp):
@@ -236,13 +235,13 @@ information in it.
             return False
 
         if not self.data_dir.isdir():
-            log.Log("Source '{rp}' doesn't have an 'rdiff-backup-data' "
-                    "sub-directory".format(rp=self.base_dir), log.Log.ERROR)
+            log.Log("Source directory '{sd}' doesn't have a sub-directory "
+                    "'rdiff-backup-data'".format(sd=self.base_dir), log.ERROR)
             return False
         elif not self.incs_dir.isdir():
-            log.Log("Data directory '{rp}' doesn't have an 'increments' "
-                    "sub-directory".format(rp=self.data_dir),
-                    log.Log.WARNING)  # used to be normal  # compat200
+            log.Log("Data directory '{dd}' doesn't have an 'increments' "
+                    "sub-directory".format(dd=self.data_dir),
+                    log.WARNING)  # used to be normal  # compat200
             # return False # compat200
         return True
 
@@ -258,13 +257,13 @@ information in it.
                 and self.base_dir.listdir()
                 and not self.data_dir.lstat()):
             if self.force:
-                log.Log("Target '{rp}' does not look like a rdiff-backup "
+                log.Log("Target path '{tp}' does not look like a rdiff-backup "
                         "repository but will be force overwritten".format(
-                            rp=self.base_dir), log.Log.WARNING)
+                            tp=self.base_dir), log.WARNING)
             else:
-                log.Log("Target '{rp}' does not look like a rdiff-backup "
+                log.Log("Target path '{tp}' does not look like a rdiff-backup "
                         "repository, call with '--force' to overwrite".format(
-                            rp=self.base_dir), log.Log.ERROR)
+                            tp=self.base_dir), log.ERROR)
                 return False
         return True
 
@@ -279,9 +278,9 @@ information in it.
                 self.data_dir.mkdir()
             except OSError as exc:
                 log.Log("Could not create 'rdiff-backup-data' sub-directory "
-                        "in '{rp}' due to '{exc}'. "
+                        "in base directory '{bd}' due to exception '{ex}'. "
                         "Please fix the access rights and retry.".format(
-                            rp=self.base_dir, exc=exc), log.Log.ERROR)
+                            bd=self.base_dir, ex=exc), log.ERROR)
                 return False
         elif self._is_failed_initial_backup():
             self._fix_failed_initial_backup()
@@ -290,9 +289,9 @@ information in it.
                 self.incs_dir.mkdir()
             except OSError as exc:
                 log.Log("Could not create 'increments' sub-directory "
-                        "in '{rp}' due to '{exc}'. "
+                        "in data directory '{dd}' due to exception '{ex}'. "
                         "Please fix the access rights and retry.".format(
-                            rp=self.data_dir, exc=exc), log.Log.ERROR)
+                            dd=self.data_dir, ex=exc), log.ERROR)
                 return False
 
         return True
@@ -322,8 +321,8 @@ information in it.
         Clear the given rdiff-backup-data if possible, it's faster than
         trying to do a regression, which would probably anyway fail.
         """
-        log.Log("Found interrupted initial backup in {rp}. "
-                "Removing...".format(rp=self.data_dir), log.Log.NOTE)
+        log.Log("Found interrupted initial backup in data directory {dd}. "
+                "Removing...".format(dd=self.data_dir), log.NOTE)
         rbdir_files = self.data_dir.listdir()
 
         # Try to delete the increments dir first
@@ -336,10 +335,10 @@ information in it.
             try:
                 rp.conn.rpath.delete_dir_no_files(rp)
             except rpath.RPathException:
-                log.Log("Increments dir contains files.", log.Log.INFO)
+                log.Log("Increments dir contains files", log.INFO)
                 return
             except Security.Violation:
-                log.Log("Server doesn't support resuming.", log.Log.WARNING)
+                log.Log("Server doesn't support resuming", log.WARNING)
                 return
 
         # then delete all remaining files

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -186,7 +186,7 @@ information in it.
                 except OSError as exc:
                     log.Log.FatalError(
                         "Could not check if rdiff-backup is currently"
-                        "running due to exception {ex}".format(ex=exc))
+                        "running due to exception '{ex}'".format(ex=exc))
             assert len(curmir_incs) == 2, (
                 "Found more than 2 current_mirror incs in '{ci}'.".format(
                     ci=self.data_dir))

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -5,10 +5,10 @@ import sys
 import code
 import shutil
 import subprocess
-# Avoid circularities
-from rdiff_backup.log import Log
-from rdiff_backup import Globals, Hardlink, Security, SetConnections, Main, \
-    selection, rpath, eas_acls, rorpiter, hash
+from rdiff_backup import (
+    Globals, Hardlink, log, Main, rpath, eas_acls, rorpiter, hash,
+    Security, SetConnections, selection
+)
 from rdiffbackup import actions
 
 RBBin = os.fsencode(shutil.which("rdiff-backup") or "rdiff-backup")
@@ -308,39 +308,39 @@ def _hardlink_rorp_eq(src_rorp, dest_rorp):
     rorp_eq = Hardlink.rorp_eq(src_rorp, dest_rorp)
     if not src_rorp.isreg() or not dest_rorp.isreg() or src_rorp.getnumlinks() == dest_rorp.getnumlinks() == 1:
         if not rorp_eq:
-            Log("Hardlink compare error with when no links exist", 3)
-            Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
-            Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
+            log.Log("Hardlink compare error with when no links exist", 3)
+            log.Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
+            log.Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
             return False
     elif src_rorp.getnumlinks() > 1 and not Hardlink.is_linked(src_rorp):
         if rorp_eq:
-            Log("Hardlink compare error with first linked src_rorp and no dest_rorp sha1", 3)
-            Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
-            Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
+            log.Log("Hardlink compare error with first linked src_rorp and no dest_rorp sha1", 3)
+            log.Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
+            log.Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
             return False
         hash.compute_sha1(dest_rorp)
         rorp_eq = Hardlink.rorp_eq(src_rorp, dest_rorp)
         if src_rorp.getnumlinks() != dest_rorp.getnumlinks():
             if rorp_eq:
-                Log("Hardlink compare error with first linked src_rorp, with dest_rorp sha1, and with differing link counts", 3)
-                Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
-                Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
+                log.Log("Hardlink compare error with first linked src_rorp, with dest_rorp sha1, and with differing link counts", 3)
+                log.Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
+                log.Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
                 return False
         elif not rorp_eq:
-            Log("Hardlink compare error with first linked src_rorp, with dest_rorp sha1, and with equal link counts", 3)
-            Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
-            Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
+            log.Log("Hardlink compare error with first linked src_rorp, with dest_rorp sha1, and with equal link counts", 3)
+            log.Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
+            log.Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
             return False
     elif src_rorp.getnumlinks() != dest_rorp.getnumlinks():
         if rorp_eq:
-            Log("Hardlink compare error with non-first linked src_rorp and with differing link counts", 3)
-            Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
-            Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
+            log.Log("Hardlink compare error with non-first linked src_rorp and with differing link counts", 3)
+            log.Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
+            log.Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
             return False
     elif not rorp_eq:
-        Log("Hardlink compare error with non-first linked src_rorp and with equal link counts", 3)
-        Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
-        Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
+        log.Log("Hardlink compare error with non-first linked src_rorp and with equal link counts", 3)
+        log.Log("%s: %s" % (src_rorp.index, Hardlink._get_inode_key(src_rorp)), 3)
+        log.Log("%s: %s" % (dest_rorp.index, Hardlink._get_inode_key(dest_rorp)), 3)
         return False
     Hardlink.del_rorp(src_rorp)
     Hardlink.del_rorp(dest_rorp)
@@ -372,10 +372,10 @@ def _files_rorp_eq(src_rorp, dest_rorp,
                    compare_acls=False):
     """Combined eq func returns true if two files compare same"""
     if not src_rorp:
-        Log("Source rorp missing: %s" % str(dest_rorp), 3)
+        log.Log("Source rorp missing: %s" % str(dest_rorp), 3)
         return False
     if not dest_rorp:
-        Log("Dest rorp missing: %s" % str(src_rorp), 3)
+        log.Log("Dest rorp missing: %s" % str(src_rorp), 3)
         return False
     if not src_rorp._equal_verbose(dest_rorp,
                                    compare_ownership=compare_ownership):
@@ -383,12 +383,12 @@ def _files_rorp_eq(src_rorp, dest_rorp,
     if compare_hardlinks and not _hardlink_rorp_eq(src_rorp, dest_rorp):
         return False
     if compare_eas and not _ea_compare_rps(src_rorp, dest_rorp):
-        Log(
+        log.Log(
             "Different EAs in files %s and %s" %
             (src_rorp.get_indexpath(), dest_rorp.get_indexpath()), 3)
         return False
     if compare_acls and not _acl_compare_rps(src_rorp, dest_rorp):
-        Log(
+        log.Log(
             "Different ACLs in files %s and %s" %
             (src_rorp.get_indexpath(), dest_rorp.get_indexpath()), 3)
         return False
@@ -435,7 +435,8 @@ def compare_recursive(src_rp, dest_rp,
 
     """
 
-    Log("Comparing {srp} and {drp}, hardlinks {chl}, "
+    log.Log(
+        "Comparing {srp} and {drp}, hardlinks {chl}, "
         "eas {cea}, acls {cacl}".format(
             srp=src_rp, drp=dest_rp, chl=compare_hardlinks,
             cea=compare_eas, cacl=compare_acls), 3)


### PR DESCRIPTION
- revert changes to have the log object passed as parameter to actions and locations, it'll remain a singleton, as it is usual actually.
- make sure log.Log is used everywhere instead of Log
- Use names for log levels and format messages
- Improve further formatting and adapt docs, also ErrorLog (I noticed that its methods were called remotely using backup_writer instead of the usual `conn`)

CHG: all messages have a proper prefix corresponding to their severity (ERROR, WARNING, etc...)

Still TODO adapt CODING docs to changes made