### PR TITLE
Add test for the action test

### DIFF
--- a/testing/action_test_test.py
+++ b/testing/action_test_test.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import unittest
+import yaml
+import commontest as comtst
+from rdiff_backup import Globals
+
+
+class ActionTestTest(unittest.TestCase):
+    """Test api versioning functionality"""
+
+    def test_action_test(self):
+        """test the "test" action"""
+        # the test action works with one or two locations (or more)
+        self.assertEqual(
+            comtst.rdiff_backup_action(False, False, b"/dummy1", b"/dummy2",
+                                       (), b"test", ()),
+            0)
+        self.assertEqual(
+            comtst.rdiff_backup_action(False, True, b"/dummy1", None,
+                                       (), b"test", ()),
+            0)
+        # but it doesn't work with a local one
+        self.assertNotEqual(
+            comtst.rdiff_backup_action(False, True, b"/dummy1", b"/dummy2",
+                                       (), b"test", ()),
+            0)
+        # and it doesn't work without any location
+        self.assertNotEqual(
+            comtst.rdiff_backup_action(True, True, None, None,
+                                       (), b"test", ()),
+            0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/action_test_test.py
+++ b/testing/action_test_test.py
@@ -1,9 +1,5 @@
-import os
-import subprocess
 import unittest
-import yaml
 import commontest as comtst
-from rdiff_backup import Globals
 
 
 class ActionTestTest(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands_pre =
 # also for sub-processes, like for "client/server" rdiff-backup
 	python -c 'with open("{envsitepackagesdir}/coverage.pth","w") as fd: fd.write("import coverage; coverage.process_startup()\n")'
 commands =
+	coverage run testing/action_test_test.py
 	coverage run testing/api_test.py
 	coverage run testing/ctest.py
 	coverage run testing/timetest.py


### PR DESCRIPTION
The source code for actions/test.py was only covered at ~50%, it is now up to 90%.
I used the chance to add a new generic test function using the new CLI.

DEV: new test function commontest.rdiff_backup_action using the new CLI interface