### PR TITLE
Add remote debug feature to the server process

### DIFF
--- a/docs/CODING.adoc
+++ b/docs/CODING.adoc
@@ -2,7 +2,7 @@
 :sectnums:
 :toc:
 
-We follow the latest flake8 enforced guidelines, but certain aspects of coding can't be enforced through automated checks, hence to be followed by humans and reviewers.
+We follow the latest  https://www.python.org/dev/peps/pep-0008/[PEP 8 coding standard] as enforced by flake8 within our CI pipeline, but certain aspects of coding can't be enforced through automated checks, hence to be followed by humans and reviewers.
 This document lists such coding conventions.
 
 == QUOTING

--- a/docs/DEVELOP.adoc
+++ b/docs/DEVELOP.adoc
@@ -85,10 +85,6 @@ They are meant mostly to test the deployment itself (use alpha versions to relea
 
 NOTE: the GitHub releases are created as draft, meaning that a maintainer must review them and publish them before they become visible.
 
-== Releases
-
-There is no prior release schedule -- they are made when deemed fit.
-
 == BUILD AND INSTALL
 
 === Pre-requisites
@@ -373,7 +369,9 @@ print s.getvalue()
 
 == RELEASING
 
-We use https://travis-ci.org[Travis CI] to release automatically, as setup in the link:../.travis.yml[Travis configuration file].
+There is no prior release schedule -- they are made when deemed fit.
+
+We use https://docs.github.com/en/actions[GitHub Actions] to release automatically, as setup in the link:../.github/workflows[GitHub Workflows].
 
 The following rules apply:
 
@@ -395,8 +393,8 @@ Given the above rules, a release cycle looks roughly as follows:
 . Make sure you have the latest master commits with `git checkout master && git pull --prune`.
 . Tag the last commit with `git tag vX.Y.ZbN` (beta) or `git tag vX.y.Z" (stable).
 . Push the tag to GitHub with `git push --tags`.
-. You won't see anything in GitHub at first and need to go directly to https://travis-ci.org/rdiff-backup/rdiff-backup/builds[Travis builds] to verify that the pipeline has started.
-. If everything goes well, you should see the https://github.com/rdiff-backup/rdiff-backup/releases[new draft release] with all assets (aka packages) attached to it after all jobs have finished in Travis.
+. You can go to https://github.com/rdiff-backup/rdiff-backup/actions[Actions] to verify that the pipeline has started.
+. If everything goes well, you should see the https://github.com/rdiff-backup/rdiff-backup/releases[new draft release] with all assets (aka packages) attached to it after all jobs have finished.
 . Give the release a title and description and save it to make it visible to everybody.
 . You'll get a notification e-mail telling you that rdiff-backup-admin has released a new version.
 . Use this e-mail to inform the link:rdiff-backup-users@nongnu.org[rdiff-backup users].

--- a/docs/DEVELOP.adoc
+++ b/docs/DEVELOP.adoc
@@ -2,9 +2,7 @@
 :sectnums:
 :toc:
 
-____
-Suggest https://github.com/rdiff-backup/rdiff-backup/issues/new?title=Docs%20feedback:%20/docs/DEVELOP.md[improvements to this documentation]!
-____
+NOTE: Suggest https://github.com/rdiff-backup/rdiff-backup/issues/new?title=Docs%20feedback:%20/docs/DEVELOP.md[improvements to this documentation]!
 
 == GETTING THE SOURCE
 
@@ -12,10 +10,8 @@ Simply clone the source with:
 
  git clone https://github.com/rdiff-backup/rdiff-backup.git
 
-____
-*NOTE:* If you plan to provide your own code, you should first fork our repo and clone your own forked repo (probably using ssh not https).
+NOTE: If you plan to provide your own code, you should first fork our repo and clone your own forked repo (probably using ssh not https).
 How is described at https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks
-____
 
 == GENERAL GUIDELINES
 
@@ -25,6 +21,7 @@ Eventually it will be much easier to merge your change request if the idea and d
 It might provide useful insight why the current state is as it is.
 * Changes can be submitted using the typical Github workflow: clone this repository, make your changes, test and verify, and submit a Pull Request (PR).
 * For all code changes, please remember also to include inline comments and update tests where needed.
+* Follow of course our xref:CODING.adoc[coding guidelines].
 
 === License
 
@@ -71,10 +68,6 @@ To get write access, the person mush exhibit commitment to high standards and ha
 
 It is the responsibility of the merging developer to make sure that the PR is _squashed_ and that the squash commit message helps the release process with the right description and 3-capital-letters prefix (it is still the obligation of the PR author to provide enough information in their commit messages).
 
-=== Coding style
-
-This project is written in Python, and must follow the official https://www.python.org/dev/peps/pep-0008/[PEP 8 coding standard] as enforced via the CI system.
-
 === Versioning
 
 In versioning we utilize git tags as understood by https://github.com/pypa/setuptools_scm/#default-versioning-scheme[setuptools_scm].
@@ -90,13 +83,7 @@ the ones looking like: vX.Y.ZaN (alpha), vX.Y.ZbN (beta), vX.Y.ZrcN (release can
 like previously with an additional `.devM` at the end, are released to  https://test.pypi.org/project/rdiff-backup/#history[Test PyPI].
 They are meant mostly to test the deployment itself (use alpha versions to release development code).
 
-____
-*NOTE:* the GitHub releases are created as draft, meaning that a maintainer 	must review them and publish them before they become visible.
-____
-
-____
-*CAUTION:* due to a bug in Travis CI, the Windows wheel can't currently be 	published to PyPI and needs to be downloaded from GitHub and manually 	uploaded to PyPI.
-____
+NOTE: the GitHub releases are created as draft, meaning that a maintainer must review them and publish them before they become visible.
 
 == Releases
 
@@ -121,6 +108,7 @@ Additionally following pre-requisites are needed:
 * libacl-devel (for sys/acl.h)
 * rdiff (for testing)
 * asciidoctor (for documentation generation)
+* rpdb and netcat/ncat/nc (for remote debugging of server processes)
 
 All of those should come packaged with your system or available from https://pypi.org/ but if you need them otherwise, here are some sources:
 
@@ -138,7 +126,7 @@ Using the `Makefile` is the easiest way to quickly build and test the source cod
 
 By default the `Makefile` runs all of it's command in a clean Docker container, thus making sure all the build dependencies are correctly defined and also protecting the host system from having to install them.
 
-The https://travis-ci.org/rdiff-backup/rdiff-backup[Travis-CI] integration also uses the `Makefile`, so if all commands in the `Makefile` succeed locally, the CI is most likely to pass as well.
+The CI pipeline also uses the `Makefile`, so if all commands in the `Makefile` succeed locally, the CI is most likely to pass as well.
 
 === Build and install with setup.py
 
@@ -164,14 +152,10 @@ Additional help is displayed by the command:
 
 More information about using setup.py and how rdiff-backup is installed is available from the Python guide, Installing Python Modules for System Administrators, located at https://docs.python.org/3/install/index.html
 
-____
-*NOTE:* There is no uninstall command provided by the Python distutils/setuptools system.
+NOTE: There is no uninstall command provided by the Python distutils/setuptools system.
 One strategy is to use the `python3 setup.py install --record <file>` option to save a list of the files installed to `<file>`, another is to created a wheel package with `python3 setup.py bdist_wheel`, as it can be installed and deinstalled.
-____
 
-____
-*NOTE:* if you plan to use `./setup.py bdist_rpm` to create an RPM, you would need rpm-build but be aware that it will currently fail due to a https://github.com/pypa/setuptools/issues/1277[known bug in setuptools with compressed man pages].
-____
+NOTE: if you plan to use `./setup.py bdist_rpm` to create an RPM, you would need rpm-build but be aware that it will currently fail due to a https://github.com/pypa/setuptools/issues/1277[known bug in setuptools with compressed man pages].
 
 To build from source on Windows, check the link:../tools/windows[Windows tools] to build a single executable file which contains Python, librsync, and all required modules.
 
@@ -202,9 +186,7 @@ References:
 * Debugging dynamically loaded extensions: https://www.oreilly.com/library/view/python-cookbook/0596001673/ch16s08.html
 * Debugging Memory Problems: https://www.oreilly.com/library/view/python-cookbook/0596001673/ch16s09.html
 
-____
-*NOTE:* This assumes gdb was already installed.
-____
+NOTE: This assumes gdb was already installed.
 
 . First install:
 
@@ -225,9 +207,7 @@ ____
   [...]
   Segmentation fault (core dumped)
 
-____
-*NOTE:* The CFLAGS avoids optimizations making debugging too complicated
-____
+NOTE: The CFLAGS avoids optimizations making debugging too complicated
 
 At this stage `coredumpctl list` shows that coredump is the last one, so that one can call `coredumpctl gdb`, which itself tells (in multiple steps) that we missing some more debug information, hence the above `debuginfo-install` statements (assuming guess you could install the packages without version information if you're sure they fit the installed package versions).
 
@@ -273,9 +253,7 @@ If you get something looking like a `ResourceWarning: Enable tracemalloc to get 
 
 This tells you indeed where the file was opened: `Object allocated at (most recent call last)` but it still requires deeper analysis to understand the reason.
 
-____
-*Reference:* https://docs.python.org/3/library/tracemalloc.html
-____
+NOTE: See https://docs.python.org/3/library/tracemalloc.html for more information.
 
 === Debug client / server mode
 
@@ -285,6 +263,32 @@ The result command line might look as follows:
  rdiff-backup -v9 localhost::/sourcedir /backupdir 2>&1 | awk \
  	'/^2019-09-16/ { if (line) print line; line = $0 } ! /^2019-09-16/ { line = line " ## " $0 }' \
  	| sort | sed 's/ ## /\n/g'
+
+Since version 2.1+, you can use the server's `--debug` option to debug remotely the server process.
+Make sure first that you've installed rpdb (remote pdb) and netcat (also called nc or ncat).
+
+If you make sure that you run the latest code version, and set all the environment variables correctly, you can then connect remotely to the spawned server process:
+
+----
+./setup.py build
+PATH=$PWD/build/scripts-3.9:$PATH PYTHONPATH=$PWD/build/lib.linux-x86_64-3.9 \
+	python -m pdb build/scripts-3.9/rdiff-backup --remote-schema \
+		"ssh -C {h}  # <1>
+		RDIFF_BACKUP_DEBUG=0.0.0.0:4445  # <2>
+		PATH=$PWD/build/scripts-3.9:$PATH
+		PYTHONPATH=$PWD/build/lib.linux-x86_64-3.9
+		rdiff-backup server --debug" \  # <3>
+	backup source_dir localhost::/target_dir
+pdb is running on 0.0.0.0:4445  # <4>
+----
+<1> the double quotes are important to make sure that the PATH variable is resolved locally
+<2> this variable is optional and only required if you want another address/port
+<3> note the `--debug` option necessary to set a breakpoint early in the process
+<4> here the address:port where the debug process is listening, the default is 127.0.0.1:4444
+
+Once you've done this, in another terminal, you can call `ncat localhost 4445` (or 4444 by default) and you'll arrive in the pdb command line. You're one or two `n(ext)` steps away from the pre-check method, so you can start to debug the server process relatively early (not the argument parsing step though).
+
+TIP: rpdb is just a wrapper around pdb so it acts very similarly.
 
 === Debug iterators
 
@@ -324,10 +328,8 @@ PATH=$PWD/build/scripts-3.8:$PATH PYTHONPATH=$PWD/build/lib.linux-x86_64-3.8 \
 The `-s tottime` option _sorts_ by total time spent in the function.
 More information can be found in the https://docs.python.org/3/library/profile.html[profile documentation].
 
-____
-*TIP:* if you're into graphical tools and overviews, have a look e.g.
+TIP: if you're into graphical tools and overviews, have a look e.g.
 at  https://pythonhosted.org//ProfileEye/ ?
-____
 
 You may also do memory profiling using the https://pypi.org/project/memory-profiler/[memory-profiler], though more detailed information requires changes to the code by adding the `@profile` decorator to functions:
 
@@ -340,14 +342,10 @@ mprof plot
 mprof clean
 ----
 
-____
-*NOTE:* sometimes calling rdiff-backup this way fails, it's due to the 	script having a wrong interpreter (because of wheel building).
+NOTE: sometimes calling rdiff-backup this way fails, it's due to the script having a wrong interpreter (because of wheel building).
 Call `./setup.sh clean --all && ./setup.py build` to fix it.
-____
 
-____
-*TIP:* there is also a 	https://pypi.org/project/line-profiler/[line-profiler], 	but I didn't try it because it requires changes to the code 	(again the `@profile` decorator).
-____
+TIP: there is also a https://pypi.org/project/line-profiler/[line-profiler], but I didn't try it because it requires changes to the code (again the `@profile` decorator).
 
 ==== More profiling with code changes
 
@@ -390,11 +388,6 @@ Just make sure that you remove such tags, and potential draft releases, after us
 * If you want, again for test purposes, to trigger a PyPI deployment towards test.pypi.org, tag the commit before you push it with a development release tag, like `vA.B.CbD.devN`, then explicitly push the tag and the branch at the same time e.g.
 with `git push origin vA.B.CbD.devN myname-mybranch`.
 
-____
-*TIP:* Travis will not trigger again on a commit which has already gone            through the pipeline, even if you add a tag.
-This applies especially            to PR commits merged to master without squashing.
-____
-
 Given the above rules, a release cycle looks roughly as follows:
 
 . Call `./tools/get_changelog_since.sh PREVIOUSTAG` to get a list of changes (see above) since the last release and a sorted and unique list of authors, on which basis you can extend the xref:../CHANGELOG.adoc[CHANGELOG] for the new release.
@@ -408,33 +401,12 @@ Given the above rules, a release cycle looks roughly as follows:
 . You'll get a notification e-mail telling you that rdiff-backup-admin has released a new version.
 . Use this e-mail to inform the link:rdiff-backup-users@nongnu.org[rdiff-backup users].
 
-____
-*IMPORTANT:* if not everything goes well, remove the tag both locally with                  `git tag -d TAG` and remotely with `git push -d origin TAG`.
+IMPORTANT: if not everything goes well, remove the tag both locally with `git tag -d TAG` and remotely with `git push -d origin TAG`.
 Then fix the issue with a new PR and start from the beginning.
-____
 
-____
-*TIP:* the PyPI deploy pipeline is for now broken under Windows on Travis-CI.
-You may download the Windows wheel(s) from GitHub and upload them to            PyPI from the command line using twine:            `+twine upload [--repository-url https://test.pypi.org/legacy/] dist/rdiff\_backup-*-win32.whl+`
-____
+TIP: if the PyPI deploy pipeline is broken, you may download the impacted wheel(s) from GitHub and upload them to PyPI from the command line using twine: `twine upload [--repository-url https://test.pypi.org/legacy/] dist/rdiff\_backup-*.whl`
 
 The following sub-chapters list some learnings and specifities in case you need to modify the pipeline.
-
-=== Install the Travis client locally
-
-See https://github.com/travis-ci/travis.rb for details, here only the gist of it:
-
-----
-ruby -v               # version >= 2
-dnf install rubygems  # or zipper, apt, yum...
-gem install travis    # as non-root keeps everybody more happy
-travis version        # 1.8.10 -> all OK
-----
-
-____
-*NOTE:* installing travis gem also pulls the dependencies multipart-post, faraday, faraday_middleware, highline, backports, net-http-pipeline, net-http-persistent, addressable, multi_json, gh, launchy, ethon, typhoeus, websocket, pusher-client.
-You might want to install some of them via your preferred package manager instead.
-____
 
 === Create an OAuth key
 
@@ -471,7 +443,5 @@ hub release --include-drafts -f '%U %S %cr%n' | \
 
 the `2` compared to `$3` is the number of days, so that you get one tab opened in firefox for each draft release, so that you only need 2 clicks and one Ctrl+W (close the tab) to delete those releases.
 
-____
-*NOTE:* deletion directly using hub isn't possible as it only supports tags and not release IDs.
+NOTE: deletion directly using hub isn't possible as it only supports tags and not release IDs.
 Drafts do NOT have tags...
-____

--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -63,7 +63,7 @@ in case rdiff-backup doesn't recognize a case-insensitive file system, you need 
 _chars_ is a string of characters fit to be used in regexp square brackets (e.g.
 '[.code]``A-Z``' as in '[.code]``[A-Z]``').
 +
-*CAUTION:* do NOT change the chars to quote within the same repository!
+CAUTION: do NOT change the chars to quote within the same repository!
 Actually, you only need to set this parameter when creating a new backup repository.
 Do also NOT quote any character used by rdiff-backup in *rdiff-backup-data* (any of '[.code]``a-z0-9._-``')!
 
@@ -76,14 +76,14 @@ The argument is the number of seconds since the epoch.
 Authorize a more drastic modification of a directory than usual (for instance, when overwriting of a destination path, or when removing multiple sessions with *remove*).
 rdiff-backup will generally tell you if it needs this.
 +
-*CAUTION:* You can cause data loss if you mis-use this option.
+CAUTION: You can cause data loss if you mis-use this option.
 Furthermore, do NOT use this option when doing a restore, as it will DELETE files, unless you absolutely know what you are doing.
 
 --fsync, --no-fsync::
 This will enable/disable issuing fsync from rdiff-backup altogether.
 This option is designed to optimize performance on busy backup systems.
 +
-*CAUTION:* This may render your backup unusable in case of filesystem failure.
+CAUTION: This may render your backup unusable in case of filesystem failure.
 Default is hence for fsync to be enabled.
 
 --new, --no-new::
@@ -107,9 +107,9 @@ See the <<remote-operation,REMOTE OPERATION>> section for details.
 
 --restrict-path _dirpath_::
 Require that all file access be inside the given path.
-This switch, and *--restrict-mode*, are intended to be used with the *--server* switch to provide a bit more protection when doing automated remote backups.
+This switch, and *--restrict-mode*, are intended to be used with the *server* action to provide a bit more protection when doing automated remote backups.
 +
-*CAUTION:* Those options are _not_ intended as your only line of defense so please don't do something silly like allow public access to an rdiff-backup server run with *--restrict-mode read-only*.
+CAUTION: Those options are _not_ intended as your only line of defense so please don't do something silly like allow public access to an rdiff-backup server run with *--restrict-mode read-only*.
 
 --restrict-mode {*read-write*,*read-only*,*update-only*}:: restriction mode for the directory given by *--restrict-path*, either full access (aka read-write), read-only, or only to update incrementally an already existing back-up (default is *read-write*).
 
@@ -216,13 +216,19 @@ See <<time-formats,TIME FORMATS>> for details.
 the _source_ parameter is expected to be an increment within a
 back-up repository, to be restored into the given target directory.
 
-server:: Enter server mode (not to be invoked directly, but instead used by another rdiff-backup process on a remote computer).
+server [**--debug**]::
+Enter server mode (not to be invoked directly, but instead used by another rdiff-backup process on a remote computer).
+
+--debug;;
+Start the server in debug mode so that it stops on an early breakpoint and can be remotely debugged using https://github.com/tamentis/rpdb[rpdb].
+See the https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#debug-client-server-mode[developer's documentation] for details.
 
 test _remote_location_1_ [_remote_location_2_ ...]::
 Test for the presence of a compatible rdiff-backup server as specified in the following remote location argument(s) (of which the filename section will be ignored).
 See the <<remote-operation,REMOTE OPERATION>> section for details.
 
-verify *--at* _time_ _location_:: Check all the data in the repository at the given time by computing the SHA1 hash of all the regular files and comparing them with the hashes stored in the metadata file.
+verify [*--at* _time_] _location_::
+Check all the data in the repository at the given time by computing the SHA1 hash of all the regular files and comparing them with the hashes stored in the metadata file.
 
 --at _time_;;
 the time of the data which needs to be verified.
@@ -302,7 +308,7 @@ This is a best fit for an automatically generated list of files, else use globbi
 
 === Special files selection
 
-*NOTE:* All special files are included by default, so that including them explicitly isn't generally required.
+NOTE: All special files are included by default, so that including them explicitly isn't generally required.
 Exceptions are described.
 
 --include-device-files,--exclude-device-files::
@@ -482,7 +488,7 @@ If you just want to learn the basics, first look at the selection examples in th
 rdiff-backup's selection system was originally inspired by *rsync*(1), but there are many differences.
 For instance, trailing backslashes have no special significance.
 
-*IMPORTANT:* include and exclude patterns under Windows solely support slashes '[.code]``/``' as file separators, given that backslashes '[.code]``\``' have a special meaning in regex/glob patterns.
+IMPORTANT: include and exclude patterns under Windows solely support slashes '[.code]``/``' as file separators, given that backslashes '[.code]``\``' have a special meaning in regex/glob patterns.
 
 All the available file selection conditions are listed under <<selection-options,SELECTION OPTIONS>>.
 
@@ -681,7 +687,11 @@ The log files are not compressed and can become quite large if rdiff-backup is r
 [[environment]]
 == ENVIRONMENT
 
-*RDIFF_BACKUP_VERBOSITY*=_[0-9]_:: the default verbosity for log file and terminal, can be overwritten by the corresponding options *-v/--verbosity* and *--terminal-verbosity*.
+RDIFF_BACKUP_VERBOSITY=_[0-9]_:: the default verbosity for log file and terminal, can be overwritten by the corresponding options *-v/--verbosity* and *--terminal-verbosity*.
+
+RDIFF_BACKUP_DEBUG=[_address_][:__port__]::
+set a non-default listening address and/or port (default is `127.0.0.1:4444`) for  rpdb.
+Valid values are _address_, _address:port_ or _:port_.
 
 [[bugs]]
 == BUGS

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -46,7 +46,7 @@ class ServerAction(actions.BaseAction):
 
     def __init__(self, values):
         super().__init__(values)
-        if self.values.debug:
+        if 'debug' in self.values and self.values.debug:
             self._set_breakpoint()
 
     def connect(self):

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -25,7 +25,7 @@ import os
 import sys
 
 from rdiffbackup import actions
-from rdiff_backup import (connection, Security)
+from rdiff_backup import (connection, log, Security)
 
 
 class ServerAction(actions.BaseAction):
@@ -44,8 +44,8 @@ class ServerAction(actions.BaseAction):
             help="Allow for remote python debugging (rpdb) using netcat")
         return subparser
 
-    def __init__(self, values, log=None, errlog=None):  # TODO remove logs
-        super().__init__(values, log, errlog)
+    def __init__(self, values):
+        super().__init__(values)
         if self.values.debug:
             self._set_breakpoint()
 
@@ -86,8 +86,8 @@ class ServerAction(actions.BaseAction):
                 # connect to the default 127.0.0.1:4444
                 rpdb.set_trace()
         except ImportError:
-            self.log("Remote debugging impossible, please install rpdb",
-                     self.log.WARNING)
+            log.Log("Remote debugging impossible, please install rpdb",
+                    log.Log.WARNING)
 
 
 def get_action_class():

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -89,5 +89,6 @@ class ServerAction(actions.BaseAction):
             self.log("Remote debugging impossible, please install rpdb",
                      self.log.WARNING)
 
+
 def get_action_class():
     return ServerAction

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -21,6 +21,7 @@
 A built-in rdiff-backup action plug-in to start a remote server process.
 """
 
+import os
 import sys
 
 from rdiffbackup import actions
@@ -35,6 +36,19 @@ class ServerAction(actions.BaseAction):
     security = "server"
     parent_parsers = [actions.RESTRICT_PARSER]
 
+    @classmethod
+    def add_action_subparser(cls, sub_handler):
+        subparser = super().add_action_subparser(sub_handler)
+        subparser.add_argument(
+            "--debug", action="store_true",
+            help="Allow for remote python debugging (rpdb) using netcat")
+        return subparser
+
+    def __init__(self, values, log=None, errlog=None):  # TODO remove logs
+        super().__init__(values, log, errlog)
+        if self.values.debug:
+            self._set_breakpoint()
+
     def connect(self):
         conn_value = super().connect()
         if conn_value:
@@ -47,6 +61,33 @@ class ServerAction(actions.BaseAction):
         return connection.PipeConnection(sys.stdin.buffer,
                                          sys.stdout.buffer).Server()
 
+    def _set_breakpoint(self):
+        """
+        Set a breakpoint for remote debugging
+
+        Use the environment variable RDIFF_BACKUP_DEBUG to set a non-default
+        listening address and/or port (default is 127.0.0.1:4444).
+        Valid values are 'addr', 'addr:port' or ':port'.
+        """
+        try:
+            import rpdb
+            debug_values = os.getenv("RDIFF_BACKUP_DEBUG", "").split(":")
+            if debug_values != [""]:
+                if debug_values[0]:
+                    debug_addr = debug_values[0]
+                else:
+                    debug_addr = "127.0.0.1"
+                if len(debug_values) > 1:
+                    debug_port = int(debug_values[1])
+                else:
+                    debug_port = 4444
+                rpdb.set_trace(addr=debug_addr, port=debug_port)
+            else:
+                # connect to the default 127.0.0.1:4444
+                rpdb.set_trace()
+        except ImportError:
+            self.log("Remote debugging impossible, please install rpdb",
+                     self.log.WARNING)
 
 def get_action_class():
     return ServerAction


### PR DESCRIPTION
As the subject says. Basically you can use this option as part of the `--remote-schema` definition and remotely debug the server process using rpdb (more details in the man page and in the developer documentation).

That's something I needed for a long time, so cool thing.