### PR TITLE
Add runtime info in debug mode

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -370,7 +370,7 @@ def get_api_version():
     return api_version["actual"] or api_version["default"]
 
 
-def get_runtime_info():
+def get_runtime_info(parsed=None):
     """Return a structure containing all relevant runtime information about
     the executable, Python and the operating system.
     Beware that additional information might be added at any time."""
@@ -379,6 +379,7 @@ def get_runtime_info():
             'version': version,
             'api_version': api_version,
             'argv': sys.argv,
+            'parsed': parsed,
         },
         'python': {
             'name': sys.implementation.name,

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -69,6 +69,9 @@ def _main_run(arglist, security_override=False):
     # parsed arguments
     action = discovered_actions[parsed_args.action](parsed_args)
 
+    log.Log("Runtime information =>{ri}<=".format(
+        ri=Globals.get_runtime_info(parsed=vars(parsed_args))), log.DEBUG)
+
     # validate that everything looks good before really starting
     ret_val = action.pre_check()
     if ret_val != 0:

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -30,7 +30,7 @@ from . import Globals
 
 LOGFILE_ENCODING = 'utf-8'
 
-# we need to define constants before the imports to avoid circular dependencies
+# we need to define constants
 ERROR = 1
 WARNING = 2
 NOTE = 3


### PR DESCRIPTION
NEW: output runtime information with parsed arguments in debug mode, to help support

Note that the info action doesn't output the parsed arguments because they're generally of no help and would only clutter the screen.

Outputs something like the following in DEBUG mode:

```
DEBUG:   Runtime information =>{'exec': {'version': '2.0.5', 'api_version':
         {'default': 200, 'min': 200, 'max': 201, 'actual': 201}, 'argv':
         ['/home/ericl/Comp/rdiff-backup/build/scripts-3.9/rdiff-backup', '-v',
         '8', '--api-version', '201', 'info'], 'parsed': {'api_version': 201,
         'current_time': None, 'force': False, 'fsync': True, 'null_separator':
         False, 'new': False, 'chars_to_quote': None, 'parsable_output': False,
         'remote_schema': None, 'remote_tempdir': None, 'ssh_compression':
         True, 'tempdir': None, 'terminal_verbosity': None,
         'use_compatible_timestamps': False, 'verbosity': 8, 'action':
         'info'}}, 'python': {'name': 'cpython', 'executable':
         '/usr/bin/python3', 'version': '3.9.5'}, 'system': {'platform':
         'Linux-5.12.8-300.fc34.x86_64-x86_64-with-glibc2.33', 'fs_encoding':
         'utf-8'}}<=
```