### PR TITLE
Move get_inclist from restore to rpath

### DIFF
--- a/src/rdiff-backup-statistics
+++ b/src/rdiff-backup-statistics
@@ -30,7 +30,6 @@ from rdiff_backup import (
     FilenameMapping,
     robust,
     rpath,
-    restore,
 )
 
 begin_time = None  # Parse statistics at or after this time...
@@ -116,7 +115,7 @@ class StatisticsRPaths:
 
     def get_sorted_inc_rps(self, prefix):
         """Return list of sorted rps with given prefix"""
-        incs = restore.get_inclist(self.rbdir.append(prefix))
+        incs = self.rbdir.append(prefix).get_incfiles_list()
         if begin_time:
             incs = filter(lambda i: i.getinctime() >= begin_time, incs)
         if end_time:

--- a/src/rdiff_backup/FilenameMapping.py
+++ b/src/rdiff_backup/FilenameMapping.py
@@ -92,7 +92,7 @@ class QuotedRPath(rpath.RPath):
         """Return true if path indicates increment, sets various variables"""
         if not self.index:  # consider the last component as quoted
             dirname, basename = self.dirsplit()
-            temp_rp = rpath.RPath(self.conn, dirname, (unquote(basename), ))
+            temp_rp = rpath.RPath(self.conn, dirname, (basename, ))
             result = temp_rp.isincfile()
             if result:
                 self.inc_basestr = unquote(temp_rp.inc_basestr)
@@ -100,6 +100,13 @@ class QuotedRPath(rpath.RPath):
         else:
             result = rpath.RPath.isincfile(self)
         return result
+
+    def dirsplit(self):
+        """
+        Same as rpath.dirsplit but unquotes the basename
+        """
+        dirname, basename = super().dirsplit()
+        return (dirname, unquote(basename))
 
     def __fspath__(self):
         """

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -21,7 +21,7 @@
 import os
 import sys
 from rdiff_backup import (
-    C, Globals, log, restore, statistics, Time,
+    C, Globals, log, statistics, Time,
 )
 from rdiffbackup import arguments, actions_mgr, actions
 
@@ -139,7 +139,7 @@ def backup_remove_curmirror_local():
     assert Globals.rbdir.conn is Globals.local_connection, (
         "Function can only be called locally and not over '{conn}'.".format(
             conn=Globals.rbdir.conn))
-    curmir_incs = restore.get_inclist(Globals.rbdir.append(b"current_mirror"))
+    curmir_incs = Globals.rbdir.append(b"current_mirror").get_incfiles_list()
     assert len(curmir_incs) == 2, (
         "There must be two current mirrors not '{ilen}'.".format(
             ilen=len(curmir_incs)))

--- a/src/rdiff_backup/manage.py
+++ b/src/rdiff_backup/manage.py
@@ -19,9 +19,7 @@
 """list, delete, and otherwise manage increments"""
 
 import os
-from . import (
-    FilenameMapping, Globals, log, restore, selection, statistics, Time
-)
+from . import Globals, log, selection, statistics, Time
 
 
 class ManageException(Exception):
@@ -54,16 +52,10 @@ def describe_incs_human(incs, mirror_time, mirrorrp):
     incpairs.sort()
 
     result = ["Found %d increments:" % len(incpairs)]
-    if Globals.chars_to_quote:
-        for time, inc in incpairs:
-            result.append("    %s   %s" % (
-                os.fsdecode(FilenameMapping.unquote(inc.dirsplit()[1])),
-                Time.timetopretty(time)))
-    else:
-        for time, inc in incpairs:
-            result.append("    %s   %s" % (
-                os.fsdecode(inc.dirsplit()[1]),
-                Time.timetopretty(time)))
+    for time, inc in incpairs:
+        result.append("    %s   %s" % (
+            os.fsdecode(inc.dirsplit()[1]),
+            Time.timetopretty(time)))
     result.append("Current mirror: %s" % Time.timetopretty(mirror_time))
     return "\n".join(result)
 
@@ -134,7 +126,7 @@ def list_increment_sizes(mirror_root, index):
     def get_inc_select():
         """Return iterator of increment rpaths"""
         inc_base = Globals.rbdir.append_path(b'increments', index)
-        for base_inc in restore.get_inclist(inc_base):
+        for base_inc in inc_base.get_incfiles_list():
             yield base_inc
         if inc_base.isdir():
             inc_select = selection.Select(inc_base).set_iter()
@@ -146,7 +138,7 @@ def list_increment_sizes(mirror_root, index):
         triples = []
 
         cur_mir_base = Globals.rbdir.append(b'current_mirror')
-        mirror_time = restore.get_inclist(cur_mir_base)[0].getinctime()
+        mirror_time = (cur_mir_base.get_incfiles_list())[0].getinctime()
         triples.append((mirror_time, mirror_total, mirror_total))
 
         inc_times = list(time_dict.keys())

--- a/src/rdiff_backup/regress.py
+++ b/src/rdiff_backup/regress.py
@@ -403,7 +403,8 @@ def _iterate_raw_rfs(mirror_rp, inc_rp):
     change them back later because regress will do that for us.
 
     """
-    root_rf = RegressFile(mirror_rp, inc_rp, restore.get_inclist(inc_rp))
+    root_rf = RegressFile(mirror_rp, inc_rp,
+                          inc_rp.get_incfiles_list())
 
     def helper(rf):
         mirror_rp = rf.mirror_rp

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1032,6 +1032,25 @@ class RPath(RORPath):
                     log.ERROR)
             return (self, [], None)
 
+    def get_incfiles_list(self):
+        """
+        Returns list of increments whose name starts like the current file
+        """
+        dirname, basename = self.dirsplit()
+        parent_dir = self.__class__(self.conn, dirname, ())
+        if not parent_dir.isdir():
+            return []  # inc directory not created yet
+
+        inc_list = []
+        for filename in parent_dir.listdir():
+            inc_info = get_incfile_info(filename)
+            if inc_info and inc_info[3] == basename:
+                inc = parent_dir.append(filename)
+                assert inc.isincfile(), (
+                    "Path '{irp!r}' must be an increment file".format(irp=inc))
+                inc_list.append(inc)
+        return inc_list
+
     def newpath(self, newpath, index=()):
         """Return new RPath with the same connection but different path"""
         return self.__class__(self.conn, newpath, index)

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -137,7 +137,7 @@ class ListAction(actions.BaseAction):
 
     def _list_increments(self):
         """Print out a summary of the increments and their times"""
-        incs = restore.get_inclist(self.inc_rpath)
+        incs = self.inc_rpath.get_incfiles_list()
         mirror_time = restore.MirrorStruct.get_mirror_time()
         if self.values.parsable_output:
             print(manage.describe_incs_parsable(incs, mirror_time,

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -22,7 +22,7 @@ A built-in rdiff-backup action plug-in to remove increments from a back-up
 repository.
 """
 
-from rdiff_backup import (log, manage, restore, Security, Time)
+from rdiff_backup import (log, manage, Security, Time)
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
 
@@ -131,8 +131,7 @@ class RemoveAction(actions.BaseAction):
             return None
 
         times_in_secs = [
-            inc.getinctime() for inc in restore.get_inclist(
-                self.source.incs_dir)
+            inc.getinctime() for inc in self.source.incs_dir.get_incfiles_list()
         ]
         times_in_secs = [t for t in times_in_secs if t < action_time]
         if not times_in_secs:

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -29,7 +29,6 @@ from rdiff_backup import (
     FilenameMapping,
     Globals,
     log,
-    restore,  # FIXME shouldn't be necessary!
     rpath,
     Security,
     SetConnections,
@@ -108,7 +107,7 @@ class Repo(locations.Location):
         or 0 if there is no backup yet.
         """
         incbase = self.data_dir.append_path(b"current_mirror")
-        mirror_rps = restore.get_inclist(incbase)  # FIXME is probably better here
+        mirror_rps = incbase.get_incfiles_list()
         if mirror_rps:
             if len(mirror_rps) == 1:
                 return mirror_rps[0].getinctime()
@@ -160,7 +159,7 @@ class Repo(locations.Location):
             if not self.incs_dir.isdir() or not self.incs_dir.listdir():
                 return None
         curmirroot = self.data_dir.append(b"current_mirror")
-        curmir_incs = restore.get_inclist(curmirroot)  # FIXME belongs here
+        curmir_incs = curmirroot.get_incfiles_list()
         if not curmir_incs:
             log.Log.FatalError(
                 """Bad rdiff-backup-data dir on destination side

--- a/testing/hardlinktest.py
+++ b/testing/hardlinktest.py
@@ -4,7 +4,7 @@ import time
 from commontest import abs_test_dir, abs_output_dir, old_test_dir, re_init_rpath_dir, \
     compare_recursive, BackupRestoreSeries, InternalBackup, InternalRestore, \
     MakeOutputDir, reset_hardlink_dicts, xcopytree
-from rdiff_backup import Globals, Hardlink, selection, rpath, restore, metadata
+from rdiff_backup import Globals, Hardlink, selection, rpath, metadata
 
 
 class HardlinkTest(unittest.TestCase):
@@ -208,7 +208,7 @@ class HardlinkTest(unittest.TestCase):
             Globals.local_connection,
             os.path.join(abs_output_dir, b"rdiff-backup-data",
                          b"mirror_metadata"))
-        incs = restore.get_inclist(meta_prefix)
+        incs = meta_prefix.get_incfiles_list()
         self.assertEqual(len(incs), 1)
         metadata_rp = incs[0]
         hashes, link_counts = self.extract_metadata(metadata_rp)
@@ -229,7 +229,7 @@ class HardlinkTest(unittest.TestCase):
                          out_subdir.append("hardlink3").getinode())
 
         # validate that hashes and link counts are correctly saved in metadata
-        incs = restore.get_inclist(meta_prefix)
+        incs = meta_prefix.get_incfiles_list()
         self.assertEqual(len(incs), 2)
         if incs[0].getinctype() == b'snapshot':
             metadata_rp = incs[0]
@@ -307,7 +307,7 @@ class HardlinkTest(unittest.TestCase):
             Globals.local_connection,
             os.path.join(abs_output_dir, b"rdiff-backup-data",
                          b"mirror_metadata"))
-        incs = restore.get_inclist(meta_prefix)
+        incs = meta_prefix.get_incfiles_list()
         self.assertEqual(len(incs), 1)
         metadata_rp = incs[0]
         hashes, link_counts = self.extract_metadata(metadata_rp)
@@ -326,7 +326,7 @@ class HardlinkTest(unittest.TestCase):
                          out_subdir.append("hardlink3").getinode())
 
         # validate that hashes and link counts are correctly saved in metadata
-        incs = restore.get_inclist(meta_prefix)
+        incs = meta_prefix.get_incfiles_list()
         self.assertEqual(len(incs), 2)
         if incs[0].getinctype() == b'snapshot':
             metadata_rp = incs[0]

--- a/testing/hashtest.py
+++ b/testing/hashtest.py
@@ -6,7 +6,7 @@ import sys
 import os
 from commontest import abs_test_dir, re_init_rpath_dir, Myrm, \
     abs_output_dir, rdiff_backup, abs_testing_dir, MakeOutputDir
-from rdiff_backup import hash, rpath, restore, metadata, Globals, Security, SetConnections
+from rdiff_backup import hash, rpath, metadata, Globals, Security, SetConnections
 
 
 class HashTest(unittest.TestCase):
@@ -99,14 +99,14 @@ class HashTest(unittest.TestCase):
             Globals.local_connection,
             os.path.join(abs_output_dir, b"rdiff-backup-data",
                          b"mirror_metadata"))
-        incs = restore.get_inclist(meta_prefix)
+        incs = meta_prefix.get_incfiles_list()
         self.assertEqual(len(incs), 1)
         metadata_rp = incs[0]
         hashlist = self.extract_hashs(metadata_rp)
         self.assertEqual(hashlist, hashlist1)
 
         rdiff_backup(1, 1, in_rp2.path, abs_output_dir, 20000)
-        incs = restore.get_inclist(meta_prefix)
+        incs = meta_prefix.get_incfiles_list()
         self.assertEqual(len(incs), 2)
         if incs[0].getinctype() == 'snapshot':
             inc = incs[0]

--- a/testing/killtest.py
+++ b/testing/killtest.py
@@ -6,7 +6,7 @@ import random
 import time
 from commontest import abs_test_dir, old_test_dir, compare_recursive, RBBin, \
     xcopytree
-from rdiff_backup import Globals, restore, rpath, Time
+from rdiff_backup import Globals, rpath, Time
 """Test consistency by killing rdiff-backup as it is backing up"""
 
 
@@ -178,7 +178,7 @@ class KillTest(ProcessFuncs):
 
         """
         rbdir = rp.append_path("rdiff-backup-data")
-        inclist = restore.get_inclist(rbdir.append("current_mirror"))
+        inclist = rbdir.append("current_mirror").get_incfiles_list()
         self.assertIn(
             len(inclist), (1, 2),
             "There must be 1 or 2 elements in '{paths_list}'.".format(

--- a/testing/statisticstest.py
+++ b/testing/statisticstest.py
@@ -2,7 +2,7 @@ import unittest
 import time
 import os
 from commontest import abs_test_dir, Myrm, InternalBackup, old_test_dir, abs_output_dir
-from rdiff_backup import Globals, statistics, rpath, restore
+from rdiff_backup import Globals, statistics, rpath
 
 
 class StatsObjTest(unittest.TestCase):
@@ -202,7 +202,7 @@ class IncStatTest(unittest.TestCase):
         rbdir = rpath.RPath(Globals.local_connection,
                             os.path.join(abs_output_dir, b"rdiff-backup-data"))
 
-        incs = sorti(restore.get_inclist(rbdir.append("session_statistics")))
+        incs = sorti(rbdir.append("session_statistics").get_incfiles_list())
         self.assertEqual(len(incs), 2)
         s2 = statistics.StatsObj().read_stats_from_rp(incs[0])
         self.assertEqual(s2.SourceFiles, 7)


### PR DESCRIPTION
- move restore.get_inclist to rpath.get_incfiles_list to clean-up the code
- avoid recursive import between FilenameMapping and rpath by overloading the QuotedRpath.dirsplit method, making also the code easier