### PR TITLE
Deprecate remote functions in Main and backup

### DIFF
--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -10,15 +10,17 @@
 
 === Internal
 
-* `backup.DestinationStruct`
-* `backup.SourceStruct`
-* `backup.SourceStruct.set_source_select`
+==== rdiff_backup
+
+* `backup.DestinationStruct` **deprecated**
+* `backup.SourceStruct` **deprecated**
+* `backup.SourceStruct.set_source_select` **deprecated**
 * `compare.DataSide`
 * `compare.RepoSide`
 * `compare.Verify`
-* `conn_number`
-* `quit`
-* `reval`
+* `connection.conn_number`
+* `connection.quit`
+* `connection.reval`
 * `eas_acls.get_acl_lists_from_rp`
 * `eas_acls.set_rp_acl`
 * `FilenameMapping.set_init_quote_vals`
@@ -44,9 +46,9 @@
 * `log.Log.open_logfile_local`
 * `log.Log.setterm_verbosity`
 * `log.Log.setverbosity`
-* `Main.backup_close_statistics`
-* `Main.backup_remove_curmirror_local`
-* `Main.backup_touch_curmirror_local`
+* `Main.backup_close_statistics` **deprecated**
+* `Main.backup_remove_curmirror_local` **deprecated**
+* `Main.backup_touch_curmirror_local` **deprecated**
 * `manage.delete_earlier_than_local`
 * `regress.check_pids`
 * `regress.Regress`
@@ -73,6 +75,21 @@
 * `user_group.init_group_mapping`
 * `user_group.init_user_mapping`
 * `user_group.map_rpath`
+
+==== rdiffbackup
+
+* `locations._dir_shadow.ShadowReadDir`  **new**
+** `.set_select`
+** `.get_select`
+** `.get_diffs`
+* `locations._repo_shadow.ShadowRepo`  **new**
+** `.set_rorp_cache`
+** `.get_sigs`
+** `.patch`
+** `.patch_and_increment`
+** `.touch_current_mirror`
+** `.remove_current_mirror`
+** `.close_statistics`
 
 === External
 

--- a/docs/arch/locations.adoc
+++ b/docs/arch/locations.adoc
@@ -25,6 +25,24 @@ The `set_select` method is also common to directories and repositories but is st
 * Repository.set_select: restore.MirrorStruct.set_mirror_select
 ====
 
+== Shadows
+
+Each Location class has a "shadow" class, which it uses to communicate remotely.
+Those shadow classes are called so because they do only what their "real" class does but haven't an existence of their own.
+
+The shadow classes hence have only class methods and can't be called directly, but only through their real class, which must offer corresponding methods to interact with the remote side.
+This is why those shadow classes are prefixed with an underscore, they are considered private to the location namespace.
+
+The aim is to bundle the communication with the remote side (and hence the API definition) through those shadow classes.
+
+Internally, each location class defines a _private_ `_shadow` variable which points to the corresponding shadow class (either locally or remotely, through the connection of the basis directory).
+It is set in the `setup()` method (so it can't be used earlier).
+This variable can be used by the interfacing methods to interact with the class methods of the shadow class.
+
+CAUTION: the fact that the shadow classes can't be instantiated make them some kind of singleton, so that only one type of each can be handled locally.
+This isn't an issue currently, but needs to be considered should an extension require this feature.
+This said, it isn't an issue remotely, because each location has its own instance running in a different rdiff-backup process.
+
 == Directories
 
 A directory is either:

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -109,7 +109,7 @@ def _main_run(arglist, security_override=False):
     return ret_val
 
 
-# @API(backup_touch_curmirror_local, 200)
+# @API(backup_touch_curmirror_local, 200, 200)
 def backup_touch_curmirror_local(rpin, rpout):
     """Make a file like current_mirror.time.data to record time
 
@@ -133,7 +133,7 @@ def backup_touch_curmirror_local(rpin, rpout):
     mirrorrp.fsync_with_dir()
 
 
-# @API(backup_remove_curmirror_local, 200)
+# @API(backup_remove_curmirror_local, 200, 200)
 def backup_remove_curmirror_local():
     """Remove the older of the current_mirror files.  Use at end of session"""
     assert Globals.rbdir.conn is Globals.local_connection, (
@@ -152,7 +152,7 @@ def backup_remove_curmirror_local():
     older_inc.delete()
 
 
-# @API(backup_close_statistics, 200)
+# @API(backup_close_statistics, 200, 200)
 def backup_close_statistics(end_time):
     """Close out the tracking of the backup statistics.
 

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -237,47 +237,63 @@ def _set_allowed_requests(sec_class, sec_level):
             "restore.MirrorStruct.initialize_rf_cache",
             "restore.MirrorStruct.close_rf_cache",
             "restore.MirrorStruct.get_diffs", "restore.ListChangedSince",
-            "restore.ListAtTime", "backup.SourceStruct.get_source_select",
-            "backup.SourceStruct.set_source_select",
-            "backup.SourceStruct.get_diffs",
+            "restore.ListAtTime",
             "compare.RepoSide.init_and_get_iter",
             "compare.RepoSide.close_rf_cache", "compare.RepoSide.attach_files",
             "compare.DataSide.get_source_select",
             "compare.DataSide.compare_fast", "compare.DataSide.compare_hash",
-            "compare.DataSide.compare_full", "compare.Verify"
+            "compare.DataSide.compare_full", "compare.Verify",
+            # API < 201
+            "backup.SourceStruct.get_source_select",
+            "backup.SourceStruct.set_source_select",
+            "backup.SourceStruct.get_diffs",
+            # API >= 201
+            "_dir_shadow.ShadowReadDir.get_select",
+            "_dir_shadow.ShadowReadDir.set_select",
+            "_dir_shadow.ShadowReadDir.get_diffs",
         ])
     if sec_level == "update-only" or sec_level == "read-write":
         requests.update([
             "log.Log.open_logfile_local", "log.Log.close_logfile_local",
             "log.ErrorLog.open", "log.ErrorLog.isopen", "log.ErrorLog.close",
+            "regress.check_pids", "statistics.record_error",
+            "log.ErrorLog.write_if_open", "fs_abilities.backup_set_globals",
+            # API < 201
             "backup.DestinationStruct.set_rorp_cache",
             "backup.DestinationStruct.get_sigs",
             "backup.DestinationStruct.patch_and_increment",
             "Main.backup_touch_curmirror_local",
             "Main.backup_remove_curmirror_local",
-            "Main.backup_close_statistics", "regress.check_pids",
-            "statistics.record_error",
-            "log.ErrorLog.write_if_open", "fs_abilities.backup_set_globals"
+            "Main.backup_close_statistics",
+            # API >= 201
+            "_repo_shadow.ShadowRepo.set_rorp_cache",
+            "_repo_shadow.ShadowRepo.get_sigs",
+            "_repo_shadow.ShadowRepo.patch_and_increment",
+            "_repo_shadow.ShadowRepo.touch_current_mirror",
+            "_repo_shadow.ShadowRepo.remove_current_mirror",
+            "_repo_shadow.ShadowRepo.close_statistics",
         ])
     if sec_level == "read-write":
         requests.update([
             "os.mkdir", "os.chown", "os.lchown", "os.rename", "os.unlink",
             "os.remove", "os.chmod", "os.makedirs",
-            "rpath.delete_dir_no_files", "backup.DestinationStruct.patch",
+            "rpath.delete_dir_no_files",
             "restore.TargetStruct.get_initial_iter",
             "restore.TargetStruct.patch",
             "restore.TargetStruct.set_target_select",
             "fs_abilities.restore_set_globals",
             "fs_abilities.single_set_globals", "regress.Regress",
-            "manage.delete_earlier_than_local"
+            "manage.delete_earlier_than_local",
+            # API < 201
+            "backup.DestinationStruct.patch",
+            # API >= 201
+            "_repo_shadow.ShadowRepo.patch",
         ])
     if sec_class == "server":
         requests.update([
             "SetConnections.init_connection_remote", "log.Log.setverbosity",
             "log.Log.setterm_verbosity", "Time.setprevtime_local",
             "Globals.postset_regexp_local",
-            "backup.SourceStruct.set_session_info",
-            "backup.DestinationStruct.set_session_info",
             "user_group.init_user_mapping", "user_group.init_group_mapping"
         ])
     return requests

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -658,6 +658,7 @@ from . import (  # noqa: E402,F401
     SetConnections, librsync, log, regress, fs_abilities,
     eas_acls, user_group, compare
 )
+from rdiffbackup.locations import _dir_shadow, _repo_shadow  # noqa: E402,F401
 try:
     from . import win_acls  # noqa: F401
 except ImportError:

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -1,0 +1,123 @@
+# Copyright 2002, 2003 Ben Escoto
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+
+"""
+A shadow directory is called like this because like a shadow it does
+what the local representation of the directory is telling it to do, but
+it has no real life of itself, i.e. it has only class methods and can't
+be instantiated.
+"""
+
+from rdiff_backup import (
+    Globals, hash, iterfile, Rdiff, robust, rorpiter, rpath, selection
+)
+
+# ### COPIED FROM BACKUP ####
+
+
+# @API(ShadowReadDir, 201)
+class ShadowReadDir:
+    """
+    Shadow read directory for the local directory representation
+    """
+    _select = None  # will be set to source Select iterator
+
+    @classmethod
+    def set_select(cls, rp, tuplelist, *filelists):
+        """
+        Initialize select object using tuplelist
+
+        Note that each list in filelists must each be passed as
+        separate arguments, so each is recognized as a file by the
+        connection.  Otherwise we will get an error because a list
+        containing files can't be pickled.
+
+        Also, cls._select needs to be cached so get_diffs below
+        can retrieve the necessary rps.
+        """
+        sel = selection.Select(rp)
+        sel.parse_selection_args(tuplelist, filelists)
+        sel_iter = sel.set_iter()
+        cache_size = Globals.pipeline_max_length * 3  # to and from+leeway
+        cls._select = rorpiter.CacheIndexable(sel_iter, cache_size)
+        Globals.set('select_mirror', sel_iter)
+
+    @classmethod
+    def get_select(cls):
+        """
+        Return source select iterator, set by set_select
+        """
+        return cls._select
+
+    @classmethod
+    def get_diffs(cls, dest_sigiter):
+        """
+        Return diffs of any files with signature in dest_sigiter
+        """
+        source_rps = cls._select
+        error_handler = robust.get_error_handler("ListError")
+
+        def attach_snapshot(diff_rorp, src_rp):
+            """Attach file of snapshot to diff_rorp, w/ error checking"""
+            fileobj = robust.check_common_error(
+                error_handler, rpath.RPath.open, (src_rp, "rb"))
+            if fileobj:
+                diff_rorp.setfile(hash.FileWrapper(fileobj))
+            else:
+                diff_rorp.zero()
+            diff_rorp.set_attached_filetype('snapshot')
+
+        def attach_diff(diff_rorp, src_rp, dest_sig):
+            """Attach file of diff to diff_rorp, w/ error checking"""
+            fileobj = robust.check_common_error(
+                error_handler, Rdiff.get_delta_sigrp_hash, (dest_sig, src_rp))
+            if fileobj:
+                diff_rorp.setfile(fileobj)
+                diff_rorp.set_attached_filetype('diff')
+            else:
+                diff_rorp.zero()
+                diff_rorp.set_attached_filetype('snapshot')
+
+        for dest_sig in dest_sigiter:
+            if dest_sig is iterfile.MiscIterFlushRepeat:
+                yield iterfile.MiscIterFlush  # Flush buffer when get_sigs does
+                continue
+            src_rp = (source_rps.get(dest_sig.index)
+                      or rpath.RORPath(dest_sig.index))
+            diff_rorp = src_rp.getRORPath()
+            if dest_sig.isflaglinked():
+                diff_rorp.flaglinked(dest_sig.get_link_flag())
+            elif src_rp.isreg():
+                reset_perms = False
+                if (Globals.process_uid != 0 and not src_rp.readable()
+                        and src_rp.isowner()):
+                    reset_perms = True
+                    src_rp.chmod(0o400 | src_rp.getperms())
+
+                if dest_sig.isreg():
+                    attach_diff(diff_rorp, src_rp, dest_sig)
+                else:
+                    attach_snapshot(diff_rorp, src_rp)
+
+                if reset_perms:
+                    src_rp.chmod(src_rp.getperms() & ~0o400)
+            else:
+                dest_sig.close_if_necessary()
+                diff_rorp.set_attached_filetype('snapshot')
+            yield diff_rorp

--- a/testing/fileset.py
+++ b/testing/fileset.py
@@ -1,0 +1,256 @@
+# Copyright (C) 2021 Eric Lavarde <ewl+rdiffbackup@lavar.de>
+#
+# This program is licensed under the GNU General Public License (GPL).
+# you can redistribute it and/or modify it under the terms of the GNU
+# General Public License as published by the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA;
+# either version 2 of the License, or (at your option) any later version.
+# Distributions of rdiff-backup should include a copy of the GPL in a
+# file called COPYING.  The GPL is also available online at
+# https://www.gnu.org/copyleft/gpl.html.
+
+"""
+This library allows to create a set of files (and directories), using a
+structure of dictionaries.
+
+The name of the files and directories in the base directory are used as keys
+in a dictionary of dictionaries.
+
+A directory has the type "dir" or a "subs" key to contain sub-directories or
+files.
+
+Both directories and files can have the following keys:
+* a "mode" to define the chmod to apply
+
+Files can also have the following keys:
+* "content" which is written to the file.
+* "open" flag, "t" or "b" for the write mode to the file
+
+Example:
+{
+    "a_dir": {"subs": {"fileA": {"content": "initial"}, "fileB": {}}},
+    "empty_dir": {"type": "dir", "mode": 0o777},
+    "a_bin_file": {"content": b"some_binary_content", "open": "b"},
+}
+"""
+
+import os
+import shutil
+import stat
+
+DEFAULT_DIR_MODE = 0o755
+DEFAULT_FILE_MODE = 0o644
+DEFAULT_FILE_OPEN = "t"  # or "b"
+DEFAULT_FILE_CONTENT = ""
+
+
+def create_fileset(base_dir, structure):
+    """
+    Create the file set as represented by the structure in the base directory
+
+    base_dir can be path-like, str or bytes,
+    structure contains names as str
+    """
+    _create_directory(base_dir)
+    for name in structure:
+        _create_fileset(os.path.join(os.fsdecode(base_dir), name),
+                        structure[name])
+
+
+def remove_fileset(base_dir, structure):
+    """
+    Remove the file set as represented by the strucutre in the base directory
+
+    The base directory itself isn't removed unless it's empty
+    """
+    for name in structure:
+        fullname = os.path.join(os.fsdecode(base_dir), name)
+        struct = structure[name]
+        try:
+            if struct.get("type") == "dir" or "subs" in struct:
+                shutil.rmtree(fullname)
+            else:
+                os.remove(fullname)
+        except FileNotFoundError:
+            pass  # if the file doesn't exist, we don't need to remove it
+        except IsADirectoryError:
+            shutil.rmtree(fullname)
+        except NotADirectoryError:
+            os.remove(fullname)
+
+    # at the end we try to remove the base directory, if it's empty
+    try:
+        os.removedirs(base_dir)
+    except OSError:
+        pass  # directory isn't empty, we don't really care
+
+
+def compare_paths(path1, path2):
+    """
+    Compare two paths, possibly created by this library
+
+    Comparaison is made recursively according to the names of the files and
+    sub-directories.
+    If there are commonalities, those common files/dirs are then compared for
+    type, link numbers, size and/or content, access mode, uid, gid.
+
+    The result is a list of explained differences, empty if there are no
+    differences. None is returned if the two paths happen to point at the
+    same directory.
+    """
+    differences = []
+    # if the paths are pointing to the same file, no need to compare
+    if os.path.samefile(path1, path2):
+        return None
+
+    # compare first the paths as normal files
+    stat1 = os.lstat(path1)
+    stat2 = os.lstat(path2)
+
+    differences += _compare_files(path1, stat1, path2, stat2)
+
+    # stop the comparaison here if the paths don't both point to directories
+    if not (stat.S_ISDIR(stat1.st_mode) and stat.S_ISDIR(stat2.st_mode)):
+        return differences
+
+    # then compare them as directories
+    files1 = set(os.listdir(os.fsdecode(path1)))
+    files2 = set(os.listdir(os.fsdecode(path2)))
+    if len(files1 - files2):
+        differences.append(
+            "Files {fi} are in base dir {bd1} but not in {bd2}".format(
+                fi=files1 - files2, bd1=path1, bd2=path2))
+    if len(files2 - files1):
+        differences.append(
+            "Files {fi} are not in base dir {bd1} but in {bd2}".format(
+                fi=files2 - files1, bd1=path1, bd2=path2))
+    if files1.isdisjoint(files2):
+        return differences  # there are no files in common
+
+    for file in files1 & files2:
+        next_path1 = os.path.join(os.fsdecode(path1), file)
+        next_path2 = os.path.join(os.fsdecode(path2), file)
+        differences += compare_paths(next_path1, next_path2)
+
+    return differences
+
+
+def _create_fileset(fullname, struct):
+    """
+    Recursive part of the fileset creation
+    """
+    if struct.get("type") == "dir" or "subs" in struct:
+        _create_directory(fullname, settings=struct, always_delete=True)
+        for name in struct.get("subs", {}):
+            _create_fileset(os.path.join(fullname, name), struct["subs"][name])
+    else:
+        _create_file(fullname, settings=struct)
+    # other types of items are ignored for now
+
+
+def _create_directory(dir_name, settings={}, always_delete=False):
+    """
+    Create a directory according to settings.
+
+    The directory is created according to "mode". It is first destroyed if
+    requested. It is currently the recommended approach to make sure the
+    structure is exactly as expected (a delta mechanism could be added).
+    """
+    if os.path.exists(dir_name):
+        if always_delete or not os.path.isdir(dir_name):
+            shutil.rmtree(dir_name)
+        else:
+            return
+    os.makedirs(dir_name, mode=settings.get("mode", DEFAULT_DIR_MODE))
+
+
+def _create_file(file_name, settings):
+    """
+    Creates a file according to settings
+
+    The file will have the access rights according to "mode", and the "content"
+    from the corresponding key, written in binary mode if "open" is set to "b",
+    else "t".
+    """
+    with open(file_name, "w" + settings.get("open", DEFAULT_FILE_OPEN)) as fd:
+        fd.write(settings.get("content", DEFAULT_FILE_CONTENT))
+    os.chmod(file_name, mode=settings.get("mode", DEFAULT_FILE_MODE))
+
+
+def _compare_files(file1, stat1, file2, stat2):
+    """
+    Compares two files and their file stats.
+
+    Those files are compared for type, link numbers, size and/or content,
+    access mode, uid, gid.
+
+    The result is a list of explained differences, empty if there are no
+    differences.
+    """
+    differences = []
+
+    if stat.S_IFMT(stat1.st_mode) != stat.S_IFMT(stat2.st_mode):
+        differences.append(
+            "Paths {pa1} and {pa2} have different types {ft1} vs. {ft2}".format(
+                pa1=file1, pa2=file2,
+                ft1=stat.S_IFMT(stat1.st_mode),
+                ft2=stat.S_IFMT(stat2.st_mode)))
+        # if the files don't have the same type, there is no point comparing
+        # them further...
+        return differences
+
+    if stat.S_IMODE(stat1.st_mode) != stat.S_IMODE(stat2.st_mode):
+        differences.append(
+            "Paths {pa1} and {pa2} have different "
+            "access rights {ar1} vs. {ar2}".format(
+                pa1=file1, pa2=file2,
+                ar1=stat.S_IMODE(stat1.st_mode),
+                ar2=stat.S_IMODE(stat2.st_mode)))
+
+    if stat1.st_nlink != stat2.st_nlink:
+        differences.append(
+            "Paths {pa1} and {pa2} have different "
+            "link numbers {ln1} vs. {ln2}".format(
+                pa1=file1, pa2=file2, ln1=stat1.st_nlink, ln2=stat2.st_nlink))
+
+    if stat1.st_size != stat2.st_size:
+        differences.append(
+            "Paths {pa1} and {pa2} have different "
+            "file sizes {fs1} vs. {fs2}".format(
+                pa1=file1, pa2=file2, fs1=stat1.st_size, fs2=stat2.st_size))
+    elif stat.S_ISREG(stat1.st_mode) and stat.S_ISREG(stat2.st_mode):
+        with open(file1) as fd1, open(file2) as fd2:
+            content1 = fd1.read()
+            content2 = fd2.read()
+        if content1 != content2:
+            if len(content1) > 75:
+                content1 = content1[:36] + "..." + content1[-36:]
+            if len(content2) > 75:
+                content2 = content2[:36] + "..." + content2[-36:]
+            differences.append(
+                "Paths {pa1} and {pa2} have different "
+                "regular file' contents '{rc1}' vs. '{rc2}'".format(
+                    pa1=file1, pa2=file2, rc1=content1, rc2=content2))
+
+    # we compare only the modification seconds, because rdiff-backup doesn't
+    # save milliseconds.
+    if int(stat1.st_mtime) != int(stat2.st_mtime):
+        differences.append(
+            "Paths {pa1} and {pa2} have different "
+            "modification times {mt1} vs. {mt2}".format(
+                pa1=file1, pa2=file2,
+                mt1=int(stat1.st_mtime), mt2=int(stat2.st_mtime)))
+
+    if stat1.st_uid != stat2.st_uid:
+        differences.append(
+            "Paths {pa1} and {pa2} have different "
+            "user owners {uo1} vs. {uo2}".format(
+                pa1=file1, pa2=file2, uo1=stat1.st_uid, uo2=stat2.st_uid))
+
+    if stat1.st_gid != stat2.st_gid:
+        differences.append(
+            "Paths {pa1} and {pa2} have different "
+            "group owners {go1} vs. {go2}".format(
+                pa1=file1, pa2=file2, go1=stat1.st_uid, go2=stat2.st_uid))
+
+    return differences

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands_pre =
 	python -c 'with open("{envsitepackagesdir}/coverage.pth","w") as fd: fd.write("import coverage; coverage.process_startup()\n")'
 commands =
 	coverage run testing/action_test_test.py
+	coverage run testing/action_backuprestore_test.py
 	coverage run testing/api_test.py
 	coverage run testing/ctest.py
 	coverage run testing/timetest.py


### PR DESCRIPTION
DEV: remote functions in Main and backup are deprecated from the API and replaced by class methods in _repo_shadow and _dir_shadow

Architecture documentation has been extended to explain the shadow classes.

Further PRs will follow to do the same for other actions, and probably more. Check the docs/arch/locations.adoc changes in this PR for the idea behind those changes.