### PR TITLE
Fix server calls to new schema

### DIFF
--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -94,7 +94,8 @@ COMMON_PARSER.add_argument(
     "--use-compatible-timestamps", action="store_true",
     help="[opt] use hyphen '-' instead of colon ':' to represent time")
 COMMON_PARSER.add_argument(
-    "-v", "--verbosity", type=int, choices=range(0, 10), default=3,
+    "-v", "--verbosity", type=int, choices=range(0, 10),
+    default=int(os.getenv('RDIFF_BACKUP_VERBOSITY', '3')),
     help="[opt] overall verbosity on terminal and in logfiles (default is 3)")
 
 
@@ -446,7 +447,8 @@ class BaseAction:
                 self.values.locations,
                 remote_schema=self.remote_schema,
                 ssh_compression=self.values.ssh_compression,
-                remote_tempdir=self.remote_tempdir
+                remote_tempdir=self.remote_tempdir,
+                term_verbosity=log.Log.term_verbosity
             )
             Security.initialize(self.get_security_class(), cmdpairs)
             self.connected_locations = list(

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -109,10 +109,10 @@ def rdiff_backup(source_local,
 
     """
     if not source_local:
-        src_dir = (b'"cd %s; %s --server::%s"' %
+        src_dir = (b'"cd %s; %s server::%s"' %
                    (abs_remote1_dir, RBBin, src_dir))
     if dest_dir and not dest_local:
-        dest_dir = (b'"cd %s; %s --server::%s"' %
+        dest_dir = (b'"cd %s; %s server::%s"' %
                     (abs_remote2_dir, RBBin, dest_dir))
 
     cmdargs = [RBBin, extra_options]
@@ -157,10 +157,10 @@ def rdiff_backup_action(source_local, dest_local,
     rdiff-backup with pre-defined input.
     """
     if src_dir and not source_local:
-        src_dir = (b"cd %s; %s --server::%s" %
+        src_dir = (b"cd %s; %s server::%s" %
                    (abs_remote1_dir, RBBin, src_dir))
     if dest_dir and not dest_local:
-        dest_dir = (b"cd %s; %s --server::%s" %
+        dest_dir = (b"cd %s; %s server::%s" %
                     (abs_remote2_dir, RBBin, dest_dir))
 
     if not (source_local and dest_local):

--- a/testing/roottest.py
+++ b/testing/roottest.py
@@ -278,7 +278,7 @@ class HalfRoot(BaseRootTest):
         in_rp1, in_rp2 = self.make_dirs()
         outrp = rpath.RPath(Globals.local_connection, abs_output_dir)
         re_init_rpath_dir(outrp, userid)
-        remote_schema = b'su -c "%s --server" %s' % (RBBin, user.encode())
+        remote_schema = b'su -c "%s server" %s' % (RBBin, user.encode())
         cmd_schema = (RBBin + b" --current-time %i --remote-schema '{h}' %b '%b'::%b")
 
         cmd1 = cmd_schema % (10000, in_rp1.path, remote_schema, outrp.path)


### PR DESCRIPTION
It avoids too many warnings about deprecation, some remain to still test old interface
FIX: handling of RDIFF_BACKUP_VERBOSITY was broken after recent changes