### PR TITLE
Fix bad file descriptor error

### DIFF
--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -28,7 +28,7 @@ from . import librsync, C, rpath, Globals, log, connection
 # impacting only a single file, especially on remote file systems.
 # We list first only the POSIX conform signals, present on all platforms.
 _robust_errno_list = [errno.EPERM, errno.ENOENT, errno.EACCES, errno.EBUSY,
-                      errno.EEXIST, errno.ENOTDIR, errno.EILSEQ,
+                      errno.EEXIST, errno.ENOTDIR, errno.EILSEQ, errno.EBADF,
                       errno.ENAMETOOLONG, errno.EINTR, errno.ESTALE,
                       errno.ENOTEMPTY, errno.EIO, errno.ETXTBSY,
                       errno.ESRCH, errno.EINVAL, errno.EDEADLK,


### PR DESCRIPTION
FIX: ignore bad file descriptor (errno 9/EBADF) error impacting a single file, closes #611

I couldn't test the issue but the change is innocuous enough.