### PR TITLE
Move remote restore commands to shadow dir/repo

### DIFF
--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -231,12 +231,7 @@ def _set_allowed_requests(sec_class, sec_level):
     if sec_level == "read-only" or sec_level == "read-write":
         requests.update([
             "fs_abilities.get_readonly_fsa",
-            "restore.MirrorStruct.get_increment_times",
-            "restore.MirrorStruct.set_mirror_and_rest_times",
-            "restore.MirrorStruct.set_mirror_select",
-            "restore.MirrorStruct.initialize_rf_cache",
-            "restore.MirrorStruct.close_rf_cache",
-            "restore.MirrorStruct.get_diffs", "restore.ListChangedSince",
+            "restore.ListChangedSince",
             "restore.ListAtTime",
             "compare.RepoSide.init_and_get_iter",
             "compare.RepoSide.close_rf_cache", "compare.RepoSide.attach_files",
@@ -247,10 +242,23 @@ def _set_allowed_requests(sec_class, sec_level):
             "backup.SourceStruct.get_source_select",
             "backup.SourceStruct.set_source_select",
             "backup.SourceStruct.get_diffs",
+            "restore.MirrorStruct.get_increment_times",
+            "restore.MirrorStruct.set_mirror_and_rest_times",
+            "restore.MirrorStruct.set_mirror_select",
+            "restore.MirrorStruct.initialize_rf_cache",
+            "restore.MirrorStruct.close_rf_cache",
+            "restore.MirrorStruct.get_diffs",
             # API >= 201
             "_dir_shadow.ShadowReadDir.get_select",
             "_dir_shadow.ShadowReadDir.set_select",
             "_dir_shadow.ShadowReadDir.get_diffs",
+            "_repo_shadow.ShadowRepo.initialize_restore",
+            "_repo_shadow.ShadowRepo.get_mirror_time",
+            "_repo_shadow.ShadowRepo.get_increment_times",
+            "_repo_shadow.ShadowRepo.set_select",
+            "_repo_shadow.ShadowRepo.initialize_rf_cache",
+            "_repo_shadow.ShadowRepo.close_rf_cache",
+            "_repo_shadow.ShadowRepo.get_diffs",
         ])
     if sec_level == "update-only" or sec_level == "read-write":
         requests.update([
@@ -278,16 +286,19 @@ def _set_allowed_requests(sec_class, sec_level):
             "os.mkdir", "os.chown", "os.lchown", "os.rename", "os.unlink",
             "os.remove", "os.chmod", "os.makedirs",
             "rpath.delete_dir_no_files",
-            "restore.TargetStruct.get_initial_iter",
-            "restore.TargetStruct.patch",
-            "restore.TargetStruct.set_target_select",
             "fs_abilities.restore_set_globals",
             "fs_abilities.single_set_globals", "regress.Regress",
             "manage.delete_earlier_than_local",
             # API < 201
             "backup.DestinationStruct.patch",
+            "restore.TargetStruct.get_initial_iter",
+            "restore.TargetStruct.patch",
+            "restore.TargetStruct.set_target_select",
             # API >= 201
             "_repo_shadow.ShadowRepo.patch",
+            "_dir_shadow.ShadowWriteDir.get_initial_iter",
+            "_dir_shadow.ShadowWriteDir.patch",
+            "_dir_shadow.ShadowWriteDir.set_select",
         ])
     if sec_class == "server":
         requests.update([

--- a/src/rdiff_backup/regress.py
+++ b/src/rdiff_backup/regress.py
@@ -433,7 +433,8 @@ def _iterate_meta_rfs(mirror_rp, inc_rp):
     raw_rfs = _iterate_raw_rfs(mirror_rp, inc_rp)
     collated = rorpiter.Collate2Iters(raw_rfs, _yield_metadata())
     for raw_rf, metadata_rorp in collated:
-        raw_rf = longname.update_regressfile(raw_rf, metadata_rorp, mirror_rp)
+        raw_rf = longname.update_rf(raw_rf, metadata_rorp, mirror_rp,
+                                    RegressFile)
         if not raw_rf:
             log.Log("Warning, metadata file has entry for path {pa}, "
                     "but there are no associated files.".format(

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -294,7 +294,8 @@ class CachedRF:
     def get_fp(self, index, mir_rorp):
         """Return the file object (for reading) of given index"""
         rf = longname.update_rf(
-            self._get_rf(index, mir_rorp), mir_rorp, self.root_rf.mirror_rp)
+            self._get_rf(index, mir_rorp), mir_rorp, self.root_rf.mirror_rp,
+            RestoreFile)
         if not rf:
             log.Log(
                 "Unable to retrieve data for file {fi}! The cause is "

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -25,7 +25,7 @@ The module is named with an underscore at the end to avoid overwriting the
 builtin 'list' class.
 """
 
-from rdiff_backup import (manage, restore)
+from rdiff_backup import manage
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
 from rdiffbackup.utils.argopts import BooleanOptionalAction
@@ -138,7 +138,8 @@ class ListAction(actions.BaseAction):
     def _list_increments(self):
         """Print out a summary of the increments and their times"""
         incs = self.inc_rpath.get_incfiles_list()
-        mirror_time = restore.MirrorStruct.get_mirror_time()
+        mirror_time = self.source.get_mirror_time()
+        # TODO return error if mirror_time <= 0 !!!
         if self.values.parsable_output:
             print(manage.describe_incs_parsable(incs, mirror_time,
                                                 self.mirror_rpath))

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -25,7 +25,8 @@ be instantiated.
 """
 
 from rdiff_backup import (
-    Globals, hash, iterfile, Rdiff, robust, rorpiter, rpath, selection
+    Globals, Hardlink, hash, iterfile, log,
+    Rdiff, robust, rorpiter, rpath, selection
 )
 
 # ### COPIED FROM BACKUP ####
@@ -121,3 +122,163 @@ class ShadowReadDir:
                 dest_sig.close_if_necessary()
                 diff_rorp.set_attached_filetype('snapshot')
             yield diff_rorp
+
+
+# @API(ShadowWriteDir, 201)
+class ShadowWriteDir:
+    """Hold functions to be run on the target side when restoring"""
+    _select = None
+
+    @classmethod
+    def set_select(cls, target, select_opts, *filelists):
+        """Return a selection object iterating the rorpaths in target"""
+        if not select_opts:
+            return  # nothing to do...
+        cls._select = selection.Select(target)
+        cls._select.parse_selection_args(select_opts, filelists)
+
+    @classmethod
+    def get_initial_iter(cls, target):
+        """Return selector previously set with set_initial_iter"""
+        if cls._select:
+            return cls._select.set_iter()
+        else:
+            return selection.Select(target).set_iter()
+
+    @classmethod
+    def patch(cls, target, diff_iter):
+        """
+        Patch target with the diffs from the mirror side
+
+        This function and the associated ITRB is similar to the
+        patching code in backup.py, but they have different error
+        correction requirements, so it seemed easier to just repeat it
+        all in this module.
+        """
+        ITR = rorpiter.IterTreeReducer(_DirPatchITRB, [target])
+        for diff in rorpiter.FillInIter(diff_iter, target):
+            log.Log("Processing changed file {cf}".format(cf=diff), log.INFO)
+            ITR(diff.index, diff)
+        ITR.finish_processing()
+        target.setdata()
+
+
+class _DirPatchITRB(rorpiter.ITRBranch):
+    """Patch an rpath with the given diff iters (use with IterTreeReducer)
+
+    The main complication here involves directories.  We have to
+    finish processing the directory after what's in the directory, as
+    the directory may have inappropriate permissions to alter the
+    contents or the dir's mtime could change as we change the
+    contents.
+
+    This code was originally taken from backup.py.  However, because
+    of different error correction requirements, it is repeated here.
+    """
+
+    def __init__(self, basis_root_rp):
+        """Set basis_root_rp, the base of the tree to be incremented"""
+        assert basis_root_rp.conn is Globals.local_connection, (
+            "Function shall be called only locally.")
+        self.basis_root_rp = basis_root_rp
+        self.dir_replacement, self.dir_update = None, None
+        self.cached_rp = None
+
+    def can_fast_process(self, index, diff_rorp):
+        """True if diff_rorp and mirror are not directories"""
+        rp = self._get_rp_from_root(index)
+        return not diff_rorp.isdir() and not rp.isdir()
+
+    def fast_process_file(self, index, diff_rorp):
+        """Patch base_rp with diff_rorp (case where neither is directory)"""
+        rp = self._get_rp_from_root(index)
+        tf = rp.get_temp_rpath(sibling=True)
+        self._patch_to_temp(rp, diff_rorp, tf)
+        rpath.rename(tf, rp)
+
+    def start_process_directory(self, index, diff_rorp):
+        """Start processing directory - record information for later"""
+        base_rp = self.base_rp = self._get_rp_from_root(index)
+        assert diff_rorp.isdir() or base_rp.isdir() or not base_rp.index, (
+            "Either difference '{drp}' or base '{brp}' path must be a "
+            "directory or the index of the base be empty.".format(
+                drp=diff_rorp, brp=base_rp))
+        if diff_rorp.isdir():
+            self._prepare_dir(diff_rorp, base_rp)
+        else:
+            self._set_dir_replacement(diff_rorp, base_rp)
+
+    def end_process_directory(self):
+        """Finish processing directory"""
+        if self.dir_update:
+            assert self.base_rp.isdir(), (
+                "Base path '{brp}' must be a directory.".format(
+                    brp=self.base_rp))
+            rpath.copy_attribs(self.dir_update, self.base_rp)
+        else:
+            assert self.dir_replacement, (
+                "Replacement directory must be defined.")
+            self.base_rp.rmdir()
+            if self.dir_replacement.lstat():
+                rpath.rename(self.dir_replacement, self.base_rp)
+
+    def _get_rp_from_root(self, index):
+        """Return RPath by adding index to self.basis_root_rp"""
+        if not self.cached_rp or self.cached_rp.index != index:
+            self.cached_rp = self.basis_root_rp.new_index(index)
+        return self.cached_rp
+
+    def _patch_to_temp(self, basis_rp, diff_rorp, new):
+        """Patch basis_rp, writing output in new, which doesn't exist yet"""
+        if diff_rorp.isflaglinked():
+            Hardlink.link_rp(diff_rorp, new, self.basis_root_rp)
+            return
+        if diff_rorp.get_attached_filetype() == 'snapshot':
+            copy_report = rpath.copy(diff_rorp, new)
+        else:
+            assert diff_rorp.get_attached_filetype() == 'diff', (
+                "File '{drp}' must be of type '{dtype}'.".format(
+                    drp=diff_rorp, dtype='diff'))
+            copy_report = Rdiff.patch_local(basis_rp, diff_rorp, new)
+        self._check_hash(copy_report, diff_rorp)
+        if new.lstat():
+            rpath.copy_attribs(diff_rorp, new)
+
+    def _check_hash(self, copy_report, diff_rorp):
+        """Check the hash in the copy_report with hash in diff_rorp"""
+        if not diff_rorp.isreg():
+            return
+        if not diff_rorp.has_sha1():
+            log.Log("Hash for file {fi} missing, cannot check".format(
+                fi=diff_rorp), log.WARNING)
+        elif copy_report.sha1_digest == diff_rorp.get_sha1():
+            log.Log("Hash {ha} of file {fi} verified".format(
+                ha=diff_rorp.get_sha1(), fi=diff_rorp), log.DEBUG)
+        else:
+            log.Log("Calculated hash {ch} of file {fi} "
+                    "doesn't match recorded hash {rh}".format(
+                        ch=copy_report.sha1_digest, fi=diff_rorp,
+                        rh=diff_rorp.get_sha1()), log.WARNING)
+
+    def _prepare_dir(self, diff_rorp, base_rp):
+        """Prepare base_rp to turn into a directory"""
+        self.dir_update = diff_rorp.getRORPath()  # make copy in case changes
+        if not base_rp.isdir():
+            if base_rp.lstat():
+                base_rp.delete()
+            base_rp.mkdir()
+        base_rp.chmod(0o700)
+
+    def _set_dir_replacement(self, diff_rorp, base_rp):
+        """Set self.dir_replacement, which holds data until done with dir
+
+        This is used when base_rp is a dir, and diff_rorp is not.
+
+        """
+        assert diff_rorp.get_attached_filetype() == 'snapshot', (
+            "File '{drp!r}' must be of type '{dtype}'.".format(
+                drp=diff_rorp, dtype='snapshot'))
+        self.dir_replacement = base_rp.get_temp_rpath(sibling=True)
+        rpath.copy_with_attribs(diff_rorp, self.dir_replacement)
+        if base_rp.isdir():
+            base_rp.chmod(0o700)

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -89,6 +89,21 @@ class ReadDir(Dir, locations.ReadLocation):
 
 class WriteDir(Dir, locations.WriteLocation):
 
+    def setup(self):
+        ret_code = super().setup()
+        if ret_code != 0:
+            return ret_code
+
+        if Globals.get_api_version() >= 201:  # compat200
+            if self.base_dir.conn is Globals.local_connection:
+                # should be more efficient than going through the connection
+                from rdiffbackup.locations import _dir_shadow
+                self._shadow = _dir_shadow.ShadowWriteDir
+            else:
+                self._shadow = self.base_dir.conn._dir_shadow.ShadowWriteDir
+
+        return 0  # all is good
+
     def check(self):
         ret_code = super().check()
 
@@ -122,5 +137,22 @@ class WriteDir(Dir, locations.WriteLocation):
 
         # FIXME we're retransforming bytes into a file pointer
         if select_opts:
-            self.base_dir.conn.restore.TargetStruct.set_target_select(
-                self.base_dir, select_opts, *list(map(io.BytesIO, select_data)))
+            if Globals.get_api_version() >= 201:  # compat200
+                self._shadow.set_select(self.base_dir, select_opts,
+                                        *list(map(io.BytesIO, select_data)))
+            else:
+                self.base_dir.conn.restore.TargetStruct.set_target_select(
+                    self.base_dir, select_opts,
+                    *list(map(io.BytesIO, select_data)))
+
+    def get_initial_iter(self):
+        """
+        Shadow function for ShadowWriteDir.get_initial_iter
+        """
+        return self._shadow.get_initial_iter(self.base_dir)
+
+    def patch(self, source_diff_iter):
+        """
+        Shadow function for ShadowWriteDir.patch
+        """
+        return self._shadow.patch(self.base_dir, source_diff_iter)


### PR DESCRIPTION
Same thing as for backup but for restore now, the other commands follow once this branch is merged.

It's even more complex than the backup one because some of the other commands (e.g. regress) use some of the restore functions for their own purpose (which justifies moving those functions to the locations classes).