### PR TITLE
Get rid of most manage functions

### DIFF
--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -55,7 +55,7 @@
 * `Main.backup_close_statistics` **deprecated**
 * `Main.backup_remove_curmirror_local` **deprecated**
 * `Main.backup_touch_curmirror_local` **deprecated**
-* `manage.delete_earlier_than_local`
+* `manage.delete_earlier_than_local` **deprecated**
 * `regress.check_pids`
 * `regress.Regress`
 * `restore.ListAtTime` **deprecated**
@@ -102,6 +102,7 @@
 * `locations._repo_shadow.ShadowRepo`  **new**
 ** `.close_rf_cache`
 ** `.close_statistics`
+** `.delete_increments_older_than`
 ** `.get_diffs`
 ** `.get_increment_times`
 ** `.get_mirror_time`

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -290,14 +290,15 @@ def _set_allowed_requests(sec_class, sec_level):
             "rpath.delete_dir_no_files",
             "fs_abilities.restore_set_globals",
             "fs_abilities.single_set_globals", "regress.Regress",
-            "manage.delete_earlier_than_local",
             # API < 201
             "backup.DestinationStruct.patch",
+            "manage.delete_earlier_than_local",
             "restore.TargetStruct.get_initial_iter",
             "restore.TargetStruct.patch",
             "restore.TargetStruct.set_target_select",
             # API >= 201
             "_repo_shadow.ShadowRepo.patch",
+            "_repo_shadow.ShadowRepo.remove_increments_older_than",
             "_dir_shadow.ShadowWriteDir.get_initial_iter",
             "_dir_shadow.ShadowWriteDir.patch",
             "_dir_shadow.ShadowWriteDir.set_select",

--- a/src/rdiff_backup/manage.py
+++ b/src/rdiff_backup/manage.py
@@ -18,49 +18,10 @@
 # 02110-1301, USA
 """list, delete, and otherwise manage increments"""
 
-import os
-from . import Globals, log, selection, statistics, Time
+from . import Globals, log
 
 
-class ManageException(Exception):
-    pass
-
-
-def describe_incs_parsable(incs, mirror_time, mirrorrp):
-    """Return a string parsable by computer describing the increments
-
-    Each line is a time in seconds of the increment, and then the
-    type of the file.  It will be sorted oldest to newest.  For example:
-
-    10000 regular
-    20000 directory
-    30000 special
-    40000 missing
-    50000 regular    <- last will be the current mirror
-
-    """
-    incpairs = [(inc.getinctime(), inc) for inc in incs]
-    incpairs.sort()
-    result = ["%s %s" % (time, _get_inc_type(inc)) for time, inc in incpairs]
-    result.append("%s %s" % (mirror_time, _get_file_type(mirrorrp)))
-    return "\n".join(result)
-
-
-def describe_incs_human(incs, mirror_time, mirrorrp):
-    """Return a string describing all the the root increments"""
-    incpairs = [(inc.getinctime(), inc) for inc in incs]
-    incpairs.sort()
-
-    result = ["Found %d increments:" % len(incpairs)]
-    for time, inc in incpairs:
-        result.append("    %s   %s" % (
-            os.fsdecode(inc.dirsplit()[1]),
-            Time.timetopretty(time)))
-    result.append("Current mirror: %s" % Time.timetopretty(mirror_time))
-    return "\n".join(result)
-
-
-def delete_earlier_than(baserp, time):
+def delete_earlier_than(baserp, time):  # compat200
     """Deleting increments older than time in directory baserp
 
     time is in seconds.  It will then delete any empty directories
@@ -71,7 +32,7 @@ def delete_earlier_than(baserp, time):
     baserp.conn.manage.delete_earlier_than_local(baserp, time)
 
 
-# @API(delete_earlier_than_local, 200)
+# @API(delete_earlier_than_local, 200, 200)
 def delete_earlier_than_local(baserp, time):
     """Like delete_earlier_than, but run on local connection for speed"""
     assert baserp.conn is Globals.local_connection, (
@@ -90,114 +51,3 @@ def delete_earlier_than_local(baserp, time):
                 or (rp.isdir() and not rp.listdir())):
             log.Log("Deleting increment file {fi}".format(fi=rp), log.INFO)
             rp.delete()
-
-
-def list_increment_sizes(mirror_root, index):
-    """Return string summarizing the size of all the increments"""
-    stat_obj = statistics.StatsObj()  # used for byte summary string
-
-    def get_total(rp_iter):
-        """Return the total size of everything in rp_iter"""
-        total = 0
-        for rp in rp_iter:
-            total += rp.getsize()
-        return total
-
-    def get_time_dict(inc_iter):
-        """Return dictionary pairing times to total size of incs"""
-        time_dict = {}
-        for inc in inc_iter:
-            if not inc.isincfile():
-                continue
-            t = inc.getinctime()
-            if t not in time_dict:
-                time_dict[t] = 0
-            time_dict[t] += inc.getsize()
-        return time_dict
-
-    def get_mirror_select():
-        """Return iterator of mirror rpaths"""
-        mirror_base = mirror_root.new_index(index)
-        mirror_select = selection.Select(mirror_base)
-        if not index:  # must exclude rdiff-backup-directory
-            mirror_select.parse_rbdir_exclude()
-        return mirror_select.set_iter()
-
-    def get_inc_select():
-        """Return iterator of increment rpaths"""
-        inc_base = Globals.rbdir.append_path(b'increments', index)
-        for base_inc in inc_base.get_incfiles_list():
-            yield base_inc
-        if inc_base.isdir():
-            inc_select = selection.Select(inc_base).set_iter()
-            for inc in inc_select:
-                yield inc
-
-    def get_summary_triples(mirror_total, time_dict):
-        """Return list of triples (time, size, cumulative size)"""
-        triples = []
-
-        cur_mir_base = Globals.rbdir.append(b'current_mirror')
-        mirror_time = (cur_mir_base.get_incfiles_list())[0].getinctime()
-        triples.append((mirror_time, mirror_total, mirror_total))
-
-        inc_times = list(time_dict.keys())
-        inc_times.sort()
-        inc_times.reverse()
-        cumulative_size = mirror_total
-        for inc_time in inc_times:
-            size = time_dict[inc_time]
-            cumulative_size += size
-            triples.append((inc_time, size, cumulative_size))
-        return triples
-
-    def triple_to_line(triple):
-        """Convert triple to display string"""
-        time, size, cum_size = triple
-        return "%24s   %13s   %15s" % \
-            (Time.timetopretty(time),
-             stat_obj.get_byte_summary_string(size),
-             stat_obj.get_byte_summary_string(cum_size))
-
-    mirror_total = get_total(get_mirror_select())
-    time_dict = get_time_dict(get_inc_select())
-    triples = get_summary_triples(mirror_total, time_dict)
-
-    sizes = [
-        '%12s %9s  %15s   %20s' % ('Time', '', 'Size', 'Cumulative size'),
-        '-' * 77,
-        triple_to_line(triples[0]) + '   (current mirror)'
-    ]
-    for triple in triples[1:]:
-        sizes.append(triple_to_line(triple))
-    return '\n'.join(sizes)
-
-
-def _get_inc_type(inc):
-    """Return file type increment represents"""
-    assert inc.isincfile(), (
-        "File '{inc!s}' must be an increment.".format(inc=inc))
-    inc_type = inc.getinctype()
-    if inc_type == b"dir":
-        return "directory"
-    elif inc_type == b"diff":
-        return "regular"
-    elif inc_type == b"missing":
-        return "missing"
-    elif inc_type == b"snapshot":
-        return _get_file_type(inc)
-    else:
-        log.Log.FatalError("Unknown type '{ut}' of increment '{ic}'".format(
-            ut=inc_type, ic=inc))
-
-
-def _get_file_type(rp):
-    """Returns one of "regular", "directory", "missing", or "special"."""
-    if not rp.lstat():
-        return "missing"
-    elif rp.isdir():
-        return "directory"
-    elif rp.isreg():
-        return "regular"
-    else:
-        return "special"

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -25,7 +25,6 @@ The module is named with an underscore at the end to avoid overwriting the
 builtin 'list' class.
 """
 
-import os
 import yaml
 from rdiff_backup import Globals, statistics, Time
 from rdiffbackup import actions

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -511,6 +511,31 @@ class ShadowRepo:
             yield rorp
         cls.close_rf_cache()
 
+# ### COPIED FROM MANAGE ####
+
+    # @API(remove_increments_older_than, 201)
+    @classmethod
+    def remove_increments_older_than(cls, baserp, time):
+        """
+        Remove increments older than the given time
+        """
+        assert baserp.conn is Globals.local_connection, (
+            "Function should be called only locally "
+            "and not over '{co}'.".format(co=baserp.conn))
+
+        def yield_files(rp):
+            if rp.isdir():
+                for filename in rp.listdir():
+                    for sub_rp in yield_files(rp.append(filename)):
+                        yield sub_rp
+            yield rp
+
+        for rp in yield_files(baserp):
+            if ((rp.isincfile() and rp.getinctime() < time)
+                    or (rp.isdir() and not rp.listdir())):
+                log.Log("Deleting increment file {fi}".format(fi=rp), log.INFO)
+                rp.delete()
+
 
 class _CacheCollatedPostProcess:
     """

--- a/testing/action_list_test.py
+++ b/testing/action_list_test.py
@@ -127,12 +127,13 @@ deleted fileOld
 
     def test_action_listincrements(self):
         """test the list increments action, without and with size"""
-        self.assertEqual(comtst.rdiff_backup_action(
+        # we need to use a regex for different timezones
+        self.assertRegex(comtst.rdiff_backup_action(
             False, None, self.bak_path, None,
             ("--api-version", "201", "--parsable"),
             b"list", ("increments", ), return_stdout=True),
             b"""---
-- base: increments.1970-01-01T03:46:40+01:00.dir
+- base: increments.1970-01-0[12]T[0-9][0-9]:[14]6:40.*.dir
   time: 10000
   type: directory
 - base: bak

--- a/testing/action_list_test.py
+++ b/testing/action_list_test.py
@@ -8,7 +8,7 @@ import commontest as comtst
 import fileset
 
 
-class ActionListFilesTest(unittest.TestCase):
+class ActionListTest(unittest.TestCase):
     """
     Test that rdiff-backup really restores what has been backed-up
     """
@@ -120,6 +120,40 @@ deleted fileOld
             b"""changed fileChanged
 new     fileNew
 deleted fileOld
+""")
+
+        # all tests were successful
+        self.success = True
+
+    def test_action_listincrements(self):
+        """test the list increments action, without and with size"""
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--parsable"),
+            b"list", ("increments", ), return_stdout=True),
+            b"""---
+- base: increments.1970-01-01T03:46:40+01:00.dir
+  time: 10000
+  type: directory
+- base: bak
+  time: 20000
+  type: directory
+...
+
+""")
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--parsable"),
+            b"list", ("increments", "--size"), return_stdout=True),
+            b"""---
+- size: 139
+  time: 10000
+  total_size: 242
+- size: 103
+  time: 20000
+  total_size: 103
+...
+
 """)
 
         # all tests were successful

--- a/testing/action_list_test.py
+++ b/testing/action_list_test.py
@@ -142,17 +142,19 @@ deleted fileOld
 ...
 
 """)
-        self.assertEqual(comtst.rdiff_backup_action(
+        # we need to use a regex for different filesystem types
+        # especially directories can have any kind of size
+        self.assertRegex(comtst.rdiff_backup_action(
             False, None, self.bak_path, None,
             ("--api-version", "201", "--parsable"),
             b"list", ("increments", "--size"), return_stdout=True),
             b"""---
-- size: 139
+- size: [0-9]+
   time: 10000
-  total_size: 242
-- size: 103
+  total_size: [0-9]+
+- size: [0-9]+
   time: 20000
-  total_size: 103
+  total_size: [0-9]+
 ...
 
 """)

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -84,12 +84,12 @@ class ActionRemoveTest(unittest.TestCase):
             ("--api-version", "201", "--force"),  # now forcing!
             b"remove", ("increments", "--older-than", "1B")), 0)
         # then check that only one increment and mirror remain
-        self.assertEqual(comtst.rdiff_backup_action(
+        self.assertRegex(comtst.rdiff_backup_action(
             False, None, self.bak_path, None,
             ("--api-version", "201", "--parsable"),
             b"list", ("increments", ), return_stdout=True),
             b"""---
-- base: increments.1970-01-01T09:20:00+01:00.dir
+- base: increments.1970-01-0[12]T[0-9][0-9]:[25]0:00.*.dir
   time: 30000
   type: directory
 - base: bak
@@ -104,12 +104,12 @@ class ActionRemoveTest(unittest.TestCase):
             False, None, self.bak_path, None,
             ("--api-version", "201", "--force"),
             b"remove", ("increments", "--older-than", "30000")), 0)
-        self.assertEqual(comtst.rdiff_backup_action(
+        self.assertRegex(comtst.rdiff_backup_action(
             False, None, self.bak_path, None,
             ("--api-version", "201", "--parsable"),
             b"list", ("increments", ), return_stdout=True),
             b"""---
-- base: increments.1970-01-01T09:20:00+01:00.dir
+- base: increments.1970-01-0[12]T[0-9][0-9]:[25]0:00.*.dir
   time: 30000
   type: directory
 - base: bak

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -1,0 +1,168 @@
+"""
+Test the remove action with api version >= 201
+"""
+import os
+import unittest
+
+import commontest as comtst
+import fileset
+
+
+class ActionRemoveTest(unittest.TestCase):
+    """
+    Test that rdiff-backup really restores what has been backed-up
+    """
+
+    def setUp(self):
+        self.base_dir = os.path.join(comtst.abs_test_dir, b"listfiles")
+        self.from1_struct = {
+            "from1": {"subs": {
+                "fileChanged": {"content": "initial"},
+                "fileOld": {},
+                "fileUnchanged": {"content": "unchanged"},
+            }}
+        }
+        self.from1_path = os.path.join(self.base_dir, b"from1")
+        self.from2_struct = {
+            "from2": {"subs": {
+                "fileChanged": {"content": "modified"},
+                "fileNew": {},
+                "fileUnchanged": {"content": "unchanged"},
+            }}
+        }
+        self.from2_path = os.path.join(self.base_dir, b"from2")
+        self.from3_struct = {
+            "from3": {"subs": {
+                "fileChanged": {"content": "modified again"},
+                "fileNew": {},
+                "fileUnchanged": {"content": "unchanged"},
+            }}
+        }
+        self.from3_path = os.path.join(self.base_dir, b"from3")
+        self.from4_struct = {
+            "from4": {"subs": {
+                "fileChanged": {"content": "modified again"},
+                "fileEvenNewer": {},
+                "fileUnchanged": {"content": "unchanged"},
+            }}
+        }
+        self.from4_path = os.path.join(self.base_dir, b"from4")
+        fileset.create_fileset(self.base_dir, self.from1_struct)
+        fileset.create_fileset(self.base_dir, self.from2_struct)
+        fileset.create_fileset(self.base_dir, self.from3_struct)
+        fileset.create_fileset(self.base_dir, self.from4_struct)
+        fileset.remove_fileset(self.base_dir, {"bak": {}})
+        self.bak_path = os.path.join(self.base_dir, b"bak")
+        self.success = False
+        # we backup to the same backup repository at different times
+        comtst.rdiff_backup_action(
+            True, True, self.from1_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "10000"),
+            b"backup", ())
+        comtst.rdiff_backup_action(
+            True, True, self.from2_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "20000"),
+            b"backup", ())
+        comtst.rdiff_backup_action(
+            True, True, self.from3_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "30000"),
+            b"backup", ())
+        comtst.rdiff_backup_action(
+            True, True, self.from4_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "40000"),
+            b"backup", ())
+
+    def test_action_removeincsolderthan(self):
+        """test different ways of removing increments"""
+        # removing multiple increments fails without --force
+        self.assertNotEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201"),
+            b"remove", ("increments", "--older-than", "1B")), 0)
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--force"),  # now forcing!
+            b"remove", ("increments", "--older-than", "1B")), 0)
+        # then check that only one increment and mirror remain
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--parsable"),
+            b"list", ("increments", ), return_stdout=True),
+            b"""---
+- base: increments.1970-01-01T09:20:00+01:00.dir
+  time: 30000
+  type: directory
+- base: bak
+  time: 40000
+  type: directory
+...
+
+""")
+
+        # check that nothing happens if no increment is old enough issue #616
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--force"),
+            b"remove", ("increments", "--older-than", "30000")), 0)
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--parsable"),
+            b"list", ("increments", ), return_stdout=True),
+            b"""---
+- base: increments.1970-01-01T09:20:00+01:00.dir
+  time: 30000
+  type: directory
+- base: bak
+  time: 40000
+  type: directory
+...
+
+""")
+        # then remove the last increment
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", ),
+            b"remove", ("increments", "--older-than", "30001")), 0)
+        # and check that only the mirror is left
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--parsable"),
+            b"list", ("increments", ), return_stdout=True),
+            b"""---
+- base: bak
+  time: 40000
+  type: directory
+...
+
+""")
+        # then try to remove the mirror
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", ),
+            b"remove", ("increments", "--older-than", "now")), 0)
+        # and check that it is still there
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, None, self.bak_path, None,
+            ("--api-version", "201", "--parsable"),
+            b"list", ("increments", ), return_stdout=True),
+            b"""---
+- base: bak
+  time: 40000
+  type: directory
+...
+
+""")
+
+        # all tests were successful
+        self.success = True
+
+    def tearDown(self):
+        # we clean-up only if the test was successful
+        if self.success:
+            fileset.remove_fileset(self.base_dir, self.from1_struct)
+            fileset.remove_fileset(self.base_dir, self.from2_struct)
+            fileset.remove_fileset(self.base_dir, {"bak": {}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,10 @@ commands_pre =
 # also for sub-processes, like for "client/server" rdiff-backup
 	python -c 'with open("{envsitepackagesdir}/coverage.pth","w") as fd: fd.write("import coverage; coverage.process_startup()\n")'
 commands =
-	coverage run testing/action_test_test.py
 	coverage run testing/action_backuprestore_test.py
+	coverage run testing/action_list_test.py
+	coverage run testing/action_remove_test.py
+	coverage run testing/action_test_test.py
 	coverage run testing/api_test.py
 	coverage run testing/ctest.py
 	coverage run testing/timetest.py


### PR DESCRIPTION
- the list increments have been moved to repository and list_
- the delete/remove function has been copied to repository and remove
  action (and the old one deprecated)
- add list and remove test cases for API >= 201

Note that the delete_earlier_than(_local) functions remain for
compatibility reasons.

NEW: parsable list of increments is in YAML format for easier parsing
CHG: human readable list of increments with size has slightly changed and is in the same order as the list _without_ size for consistency
FIX: do not return an error if no increment is old enough to be removed, closes #616