### PR TITLE
Don't count coverage for server action breakpoint

### DIFF
--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -61,7 +61,7 @@ class ServerAction(actions.BaseAction):
         return connection.PipeConnection(sys.stdin.buffer,
                                          sys.stdout.buffer).Server()
 
-    def _set_breakpoint(self):
+    def _set_breakpoint(self):  # pragma: no cover
         """
         Set a breakpoint for remote debugging
 


### PR DESCRIPTION
It's unnecessary as it's only a debug function

Very small PR...