### PR TITLE
Placeholder for version is a capital V

### DIFF
--- a/docs/migration.adoc
+++ b/docs/migration.adoc
@@ -189,7 +189,7 @@ rdiff-backup --remote-schema 'ssh -C %s rdiff-backup-2.0 --server' \
 Starting with rdiff-backup 2.1+, the command would look like this and wouldn't need to be changed with each update of the client, as the version would automatically follow:
 
 ----
-rdiff-backup --remote-schema 'ssh -C {h} rdiff-backup-{vx}.{vy} server' \
+rdiff-backup --remote-schema 'ssh -C {h} rdiff-backup-{Vx}.{Vy} server' \
 	backup /sourcedir user@serverhost::/backup-repo
 ----
 

--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -453,11 +453,11 @@ Similarly, if you want to refer to a local file whose filename contains two cons
 Because the backslash is a quote character in these circumstances, it too must be quoted to get a literal backslash, so '[.code]``foo\::\\bar``' evaluates to '[.code]``foo::\bar``'.
 To make things more complicated, because the backslash is also a common shell quoting character, you may need to type in '[.code]``\\\\``' at the shell prompt to get a literal backslash.
 
-You may also use the placehoders '[.code]``{vx}``', '[.code]``{vy}``' and '[.code]``{vz}``' for the '[.code]``x.y.z``' version of rdiff-backup, so that you can have multiple versions of rdiff-backup installed on the server, and automatically targeted from the client.
+You may also use the placehoders '[.code]``{Vx}``', '[.code]``{Vy}``' and '[.code]``{Vz}``' for the '[.code]``x.y.z``' version of rdiff-backup, so that you can have multiple versions of rdiff-backup installed on the server, and automatically targeted from the client.
 
 For example, if you have rdiff-backup 2.1.5 and 2.2.1 installed in virtual environments on the server, respectively under '[.code]``/usr/local/lib/rdiff-backup-2.0``' and '[.code]``/usr/local/lib/rdiff-backup-2.1``' (we assume that the z-Version isn't relevant to any kind of compatibility), then the client may be called with the following remote schema:
 
- ssh -C {h} /usr/local/lib/rdiff-backup-{vx}.{vy} --server
+ ssh -C {h} /usr/local/lib/rdiff-backup-{Vx}.{Vy} --server
 
 The client will then use the correct version of rdiff-backup based on its own version '[.code]``x.y.z``'.
 You'll find more explanations in the *migration* file in the documentation.

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -269,10 +269,10 @@ def _fill_schema(host_info, cmd_schema):
             thi=type(host_info)))
     try:
         # for security reasons, we accept only specific format placeholders
-        # h for host_info, vx,vy,vz for version x.y.z
+        # h for host_info, Vx,Vy,Vz for version x.y.z
         # and the host placeholder is mandatory
         if ((re.findall(b"{[^}]*}", cmd_schema)
-             != re.findall(b"{h}|{v[xyz]}", cmd_schema))
+             != re.findall(b"{h}|{V[xyz]}", cmd_schema))
                 or (b"{h}" not in cmd_schema
                     and b"%s" not in cmd_schema)):  # compat200
             raise KeyError
@@ -281,7 +281,7 @@ def _fill_schema(host_info, cmd_schema):
             # bytes doesn't have a format method, hence the conversions
             return os.fsencode(os.fsdecode(cmd_schema).format(
                 h=os.fsdecode(host_info),
-                vx=ver_split[0], vy=ver_split[1], vz=ver_split[2]))
+                Vx=ver_split[0], Vy=ver_split[1], Vz=ver_split[2]))
         else:  # compat200: accepts "%s" as host place-holder
             return cmd_schema % host_info
     except (TypeError, KeyError):


### PR DESCRIPTION
CHG: placeholder for version parts in remote schema are Vx, Vy and Vz to align with -V for --version (and reserve small v for verbosity)