### PR TITLE
Make rdiff-backup not notice regress not needed

### DIFF
--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -558,10 +558,14 @@ class BaseAction:
                     "due to '{ex}'".format(ts=timestr, ex=exc), log.ERROR)
             return None
 
-    def _operate_regress(self, try_regress=True):
+    def _operate_regress(self, try_regress=True, noticeable=False):
         """
         Check the given repository and regress it if necessary
         """
+        if noticeable:
+            regress_verbosity = log.NOTE
+        else:
+            regress_verbosity = log.INFO
         if Globals.get_api_version() < 201:  # compat200
             if self.repo.needs_regress_compat200():
                 if not try_regress:
@@ -579,7 +583,7 @@ class BaseAction:
                     return 1
             else:
                 log.Log("Given repository doesn't need to be regressed",
-                        log.NOTE)
+                        regress_verbosity)
                 return 0  # all is good
         else:
             if self.repo.needs_regress():
@@ -590,7 +594,7 @@ class BaseAction:
                 return self.repo.regress()
             else:
                 log.Log("Given repository doesn't need to be regressed",
-                        log.NOTE)
+                        regress_verbosity)
                 return 0  # all is good
 
 

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -100,7 +100,7 @@ class RegressAction(actions.BaseAction):
         """
         Check the given repository and regress it if necessary
         """
-        return self._operate_regress()
+        return self._operate_regress(noticeable=True)
 
 
 def get_action_class():


### PR DESCRIPTION
It's only noticeable if regress is explicitly asked, else it's only info.

Very small PR to review.