### PR TITLE
refactor connection and correct API docs

### DIFF
--- a/docs/api/v200.adoc
+++ b/docs/api/v200.adoc
@@ -30,11 +30,13 @@ bytes).
 ** `.close_rf_cache` (inherited from MirrorStruct)
 ** `.init_and_get_iter`
 * `compare.Verify`
-* `conn_number`
-* `quit`
-* `reval`
-* `eas_acls.get_acl_lists_from_rp`
-* `eas_acls.set_rp_acl`
+* `connection.RedirectedRun`
+* `connection.VirtualFile`
+** `.closebyid`
+** `.readfromid`
+** `.writetoid`
+* `eas_acls.get_acl_lists_from_rp`  **unused**
+* `eas_acls.set_rp_acl`  **unused**
 * `FilenameMapping.set_init_quote_vals_local`
 * `fs_abilities.backup_set_globals`
 * `fs_abilities.get_readonly_fsa`
@@ -48,7 +50,6 @@ bytes).
 * `log.ErrorLog.close`
 * `log.ErrorLog.isopen`
 * `log.ErrorLog.open`
-* `log.ErrorLog.write`
 * `log.ErrorLog.write_if_open`
 * `log.Log.close_logfile_allconn`
 * `log.Log.close_logfile_local`
@@ -95,8 +96,8 @@ bytes).
 
 === External
 
-* `gzip.GzipFile`
-* `open`
+* `gzip.GzipFile` **???**  // perhaps covered by VirtualFile
+* `open` **???**  // perhaps covered by VirtualFile
 * `os.chmod`
 * `os.chown`
 * `os.getuid`
@@ -116,14 +117,14 @@ bytes).
 * `os.utime`
 * `shutil.rmtree`
 * `sys.stdout.write`
-* `win32security.ConvertSecurityDescriptorToStringSecurityDescriptor`
-* `win32security.ConvertStringSecurityDescriptorToSecurityDescriptor`
-* `win32security.GetNamedSecurityInfo`
-* `win32security.SetNamedSecurityInfo`
-* `xattr.get`
-* `xattr.list`
-* `xattr.remove`
-* `xattr.set`
+* `win32security.ConvertSecurityDescriptorToStringSecurityDescriptor`  **unused**
+* `win32security.ConvertStringSecurityDescriptorToSecurityDescriptor`  **unused**
+* `win32security.GetNamedSecurityInfo`  **unused**
+* `win32security.SetNamedSecurityInfo`  **unused**
+* `xattr.get`  **unused**
+* `xattr.list`  **unused**
+* `xattr.remove`  **unused**
+* `xattr.set`  **unused**
 
 == Testing
 

--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -31,11 +31,13 @@
 ** `.close_rf_cache` (inherited from MirrorStruct)
 ** `.init_and_get_iter`
 * `compare.Verify`  **deprecated**
-* `connection.conn_number`
-* `connection.quit`
-* `connection.reval`
-* `eas_acls.get_acl_lists_from_rp`
-* `eas_acls.set_rp_acl`
+* `connection.RedirectedRun`
+* `connection.VirtualFile`
+** `.closebyid`
+** `.readfromid`
+** `.writetoid`
+* `eas_acls.get_acl_lists_from_rp` **unused**
+* `eas_acls.set_rp_acl` **unused**
 * `FilenameMapping.set_init_quote_vals_local`  **deprecated**
 * `fs_abilities.backup_set_globals` **deprecated**
 * `fs_abilities.get_readonly_fsa` **deprecated**
@@ -50,7 +52,6 @@
 * `log.ErrorLog.close`
 * `log.ErrorLog.isopen`
 * `log.ErrorLog.open`
-* `log.ErrorLog.write`
 * `log.ErrorLog.write_if_open`
 * `log.Log.close_logfile_allconn`
 * `log.Log.close_logfile_local`
@@ -102,9 +103,11 @@
 ** `.compare_hash`
 ** `.compare_meta`
 ** `.get_diffs`
+** `.get_fs_abilities`
 ** `.get_select`
 ** `.set_select`
 * `locations._dir_shadow.WriteDirShadow`  **new**
+** `.get_fs_abilities`
 ** `.get_initial_iter`
 ** `.init_owners_mapping`
 ** `.patch`
@@ -113,9 +116,11 @@
 ** `.attach_files`
 ** `.close_rf_cache`
 ** `.close_statistics`
-** `.delete_increments_older_than`
+** `.remove_increments_older_than`
 ** `.get_config`
 ** `.get_diffs`
+** `.get_fs_abilities_readonly`
+** `.get_fs_abilities_readwrite`
 ** `.get_increment_times`
 ** `.get_mirror_time`
 ** `.get_sigs`
@@ -139,8 +144,8 @@
 
 === External
 
-* `gzip.GzipFile`
-* `open`
+* `gzip.GzipFile` **???**  // perhaps covered by VirtualFile
+* `open` **???**  // perhaps covered by VirtualFile
 * `os.chmod`
 * `os.chown`
 * `os.getuid`
@@ -160,14 +165,14 @@
 * `os.utime`
 * `shutil.rmtree`
 * `sys.stdout.write`
-* `win32security.ConvertSecurityDescriptorToStringSecurityDescriptor`
-* `win32security.ConvertStringSecurityDescriptorToSecurityDescriptor`
-* `win32security.GetNamedSecurityInfo`
-* `win32security.SetNamedSecurityInfo`
-* `xattr.get`
-* `xattr.list`
-* `xattr.remove`
-* `xattr.set`
+* `win32security.ConvertSecurityDescriptorToStringSecurityDescriptor`  **unused**
+* `win32security.ConvertStringSecurityDescriptorToSecurityDescriptor`  **unused**
+* `win32security.GetNamedSecurityInfo`  **unused**
+* `win32security.SetNamedSecurityInfo`  **unused**
+* `xattr.get`  **unused**
+* `xattr.list`  **unused**
+* `xattr.remove`  **unused**
+* `xattr.set`  **unused**
 
 == Testing
 

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -291,11 +291,6 @@ def get(name):
     return globals()[name]
 
 
-def is_not_None(name):
-    """Returns true if value is not None"""
-    return globals()[name] is not None
-
-
 # @API(set, 200)
 def set(name, val):
     """Set the value of something in this module
@@ -324,16 +319,6 @@ def set_integer(name, val):
         log.Log.FatalError("Variable {vr} must be set to an integer, received "
                            "value '{vl}' instead".format(vr=name, vl=val))
     set(name, intval)
-
-
-def get_dict_val(name, key):
-    """Return val from dictionary in this class"""
-    return globals()[name][key]
-
-
-def set_dict_val(name, key, val):
-    """Set value for dictionary in this class"""
-    globals()[name][key] = val
 
 
 def postset_regexp(name, re_string, flags=None):

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -56,23 +56,29 @@ _disallowed_server_globals = ["server"]
 # The keys are files request, the value is the index of the argument
 # taking a file.
 _file_requests = {
-    'os.listdir': 0,
-    'rpath.make_file_dict': 0,
-    'os.chmod': 0,
-    'os.chown': 0,
-    'os.remove': 0,
-    'os.removedirs': 0,
-    'os.rename': 0,
-    'os.renames': 0,
-    'os.rmdir': 0,
-    'os.unlink': 0,
-    'os.utime': 0,
-    'os.lchown': 0,
-    'os.link': 1,
-    'os.symlink': 1,
-    'os.mkdir': 0,
-    'os.makedirs': 0,
-    'rpath.delete_dir_no_files': 0
+    "os.chmod": 0,
+    "os.chown": 0,
+    "os.lchown": 0,
+    "os.link": 1,
+    "os.listdir": 0,
+    "os.makedirs": 0,
+    "os.mkdir": 0,
+    "os.mkfifo": 0,
+    "os.mknod": 0,
+    "os.remove": 0,
+    "os.rename": 0,
+    "os.rmdir": 0,
+    "os.symlink": 1,
+    "os.unlink": 0,
+    "os.utime": 0,
+    "rpath.make_file_dict": 0,
+    "rpath.delete_dir_no_files": 0
+}
+
+# functions to set global values
+_globals_requests = {
+    "Globals.set",
+    "Globals.set_local"
 }
 
 
@@ -121,7 +127,7 @@ def vet_request(request, arglist):
             _vet_filename(request, arglist)
     if request.function_string in _allowed_requests:
         return
-    if request.function_string in ("Globals.set", "Globals.set_local"):
+    if request.function_string in _globals_requests:
         if arglist[0] not in _disallowed_server_globals:
             return
     _raise_violation("invalid request", request, arglist)
@@ -212,22 +218,34 @@ def _set_allowed_requests(sec_class, sec_level):
     Set the allowed requests list using the security level
     """
     requests = {  # minimal set of requests
-        "VirtualFile.readfromid", "VirtualFile.closebyid", "Globals.get",
-        "Globals.is_not_None", "Globals.get_dict_val",
-        "log.Log.open_logfile_allconn", "log.Log.close_logfile_allconn",
+        "RedirectedRun",  # connection.RedirectedRun
+        "VirtualFile.readfromid",  # connection.VirtualFile.readfromid
+        "VirtualFile.closebyid",  # connection.VirtualFile.closebyid
+        "Globals.get",
+        "log.Log.open_logfile_allconn",
+        "log.Log.close_logfile_allconn",
         "log.Log.log_to_file",
+        "robust.install_signal_handlers",
+        "SetConnections.add_redirected_conn",
         "Time.setcurtime_local",
-        "SetConnections.add_redirected_conn", "RedirectedRun",
-        "sys.stdout.write", "robust.install_signal_handlers",
+        # System
+        # "gzip.GzipFile",  # ??? perhaps covered by VirtualFile
+        # "open",  # ??? perhaps covered by VirtualFile
+        "sys.stdout.write",
         # API < 201
         "FilenameMapping.set_init_quote_vals_local",
     }
     if (sec_level == "read-only" or sec_level == "update-only"
             or sec_level == "read-write"):
         requests.update([
-            "rpath.make_file_dict", "os.listdir", "rpath.ea_get",
-            "rpath.acl_get", "rpath.setdata_local", "log.Log.log_to_file",
-            "os.getuid", "rpath.gzip_open_local_read", "rpath.open_local_read",
+            "rpath.gzip_open_local_read",
+            "rpath.make_file_dict",
+            "rpath.open_local_read",
+            "rpath.setdata_local",
+            # System
+            "os.getuid",
+            "os.listdir",
+            "os.name",
             # API < 201
             "Hardlink.initialize_dictionaries",
         ])
@@ -237,12 +255,12 @@ def _set_allowed_requests(sec_class, sec_level):
             "backup.SourceStruct.get_source_select",
             "backup.SourceStruct.set_source_select",
             "backup.SourceStruct.get_diffs",
-            "compare.DataSide.get_source_select",
+            "compare.DataSide.get_source_select",  # inherited from SourceStruct
             "compare.DataSide.compare_fast",
             "compare.DataSide.compare_hash",
             "compare.DataSide.compare_full",
             "compare.RepoSide.init_and_get_iter",
-            "compare.RepoSide.close_rf_cache",
+            "compare.RepoSide.close_rf_cache",  # inherited from MirrorStruct
             "compare.RepoSide.attach_files",
             "compare.Verify",
             "fs_abilities.get_readonly_fsa",
@@ -279,10 +297,14 @@ def _set_allowed_requests(sec_class, sec_level):
         ])
     if sec_level == "update-only" or sec_level == "read-write":
         requests.update([
-            "log.Log.open_logfile_local", "log.Log.close_logfile_local",
-            "log.ErrorLog.open", "log.ErrorLog.isopen", "log.ErrorLog.close",
-            "statistics.record_error",
+            "VirtualFile.writetoid",  # connection.VirtualFile.writetoid
+            "log.ErrorLog.close",
+            "log.ErrorLog.isopen",
+            "log.ErrorLog.open",
             "log.ErrorLog.write_if_open",
+            "log.Log.close_logfile_local",
+            "log.Log.open_logfile_local",
+            "statistics.record_error",
             # API < 201
             "backup.DestinationStruct.set_rorp_cache",
             "backup.DestinationStruct.get_sigs",
@@ -306,9 +328,27 @@ def _set_allowed_requests(sec_class, sec_level):
         ])
     if sec_level == "read-write":
         requests.update([
-            "os.mkdir", "os.chown", "os.lchown", "os.rename", "os.unlink",
-            "os.remove", "os.chmod", "os.makedirs",
             "rpath.delete_dir_no_files",
+            "rpath.copy_reg_file",  # FIXME really needed?
+            "rpath.make_socket_local",  # FIXME really needed?
+            "rpath.RPath.fsync_local",  # FIXME really needed?
+            # System
+            "os.chmod",
+            "os.chown",
+            "os.lchown",
+            "os.link",
+            "os.makedev",
+            "os.makedirs",
+            "os.mkdir",
+            "os.mkfifo",
+            "os.mknod",
+            "os.remove",
+            "os.rename",
+            "os.rmdir",
+            "os.symlink",
+            "os.unlink",
+            "os.utime",
+            "shutil.rmtree",
             # API < 201
             "backup.DestinationStruct.patch",
             "manage.delete_earlier_than_local",
@@ -329,9 +369,11 @@ def _set_allowed_requests(sec_class, sec_level):
         ])
     if sec_class == "server":
         requests.update([
-            "SetConnections.init_connection_remote", "log.Log.setverbosity",
-            "log.Log.setterm_verbosity", "Time.setprevtime_local",
             "Globals.postset_regexp_local",
+            "log.Log.setverbosity",
+            "log.Log.setterm_verbosity",
+            "SetConnections.init_connection_remote",
+            "Time.setprevtime_local",
             # API < 201
             "user_group.init_user_mapping",
             "user_group.init_group_mapping",

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -30,18 +30,18 @@ import tempfile  # noqa: F401
 import types  # noqa: F401
 
 # The following EA and ACL modules may be used if available
-try:
+try:  # compat200
     import xattr.pyxattr_compat as xattr  # noqa: F401
 except ImportError:
     try:
         import xattr  # noqa: F401
     except ImportError:
         pass
-try:
+try:  # compat200
     import posix1e  # noqa: F401
 except ImportError:
     pass
-try:
+try:  # compat200
     import win32security  # noqa: F401
 except ImportError:
     pass
@@ -376,9 +376,6 @@ class PipeConnection(LowLevelPipeConnection):
 
     """
 
-    # @API(conn_number, 200)
-    # conn_number is defined in the __init__ function
-
     def __init__(self, inpipe, outpipe, conn_number=0):
         """Init PipeConnection
 
@@ -407,14 +404,13 @@ class PipeConnection(LowLevelPipeConnection):
         self._get_response(-1)
         return 0  # all is well...
 
-    # @API(reval, 200)
     def reval(self, function_string, *args):
-        """Execute command on remote side
+        """
+        Execute command on remote side
 
         The first argument should be a string that evaluates to a
         function, like "pow", and the remaining are arguments to that
         function.
-
         """
         req_num = self._get_new_req_num()
         self._put(ConnectionRequest(function_string, len(args)), req_num)
@@ -431,7 +427,6 @@ class PipeConnection(LowLevelPipeConnection):
         else:
             return result
 
-    # @API(quit, 200)
     def quit(self):
         """Close the associated pipes and tell server side to quit"""
         assert not Globals.server, "This function shouldn't run as server."
@@ -577,60 +572,43 @@ class VirtualFile:
 
     """
     # The following are used by the server
-    vfiles = {}
-    counter = 0
+    _vfiles = {}
+    _counter = -1
 
-    @classmethod
-    def getbyid(cls, id):
-        return cls.vfiles[id]
-
+    # @API(VirtualFile.readfromid, 200)
     @classmethod
     def readfromid(cls, id, length):
         if length is None:
-            return cls.vfiles[id].read()
+            return cls._vfiles[id].read()
         else:
-            return cls.vfiles[id].read(length)
+            return cls._vfiles[id].read(length)
 
-    @classmethod
-    def readlinefromid(cls, id):
-        return cls.vfiles[id].readline()
-
+    # @API(VirtualFile.writetoid, 200)
     @classmethod
     def writetoid(cls, id, buffer):
-        return cls.vfiles[id].write(buffer)
+        return cls._vfiles[id].write(buffer)
 
+    # @API(VirtualFile.closebyid, 200)
     @classmethod
     def closebyid(cls, id):
-        fp = cls.vfiles[id]
-        del cls.vfiles[id]
+        fp = cls._vfiles[id]
+        del cls._vfiles[id]
         return fp.close()
 
     @classmethod
     def new(cls, fileobj):
         """Associate a new VirtualFile with a read fileobject, return id"""
-        count = cls.counter
-        cls.vfiles[count] = fileobj
-        cls.counter = count + 1
-        return count
+        cls._counter += 1
+        cls._vfiles[cls._counter] = fileobj
+        return cls._counter
 
     # And these are used by the client
     def __init__(self, connection, id):
         self.connection = connection
         self.id = id
 
-    def __iter__(self):
-        """Iterates lines in file, like normal iter(file) behavior"""
-        while 1:
-            line = self.readline()
-            if not line:
-                break
-            yield line
-
     def read(self, length=None):
         return self.connection.VirtualFile.readfromid(self.id, length)
-
-    def readline(self):
-        return self.connection.VirtualFile.readlinefromid(self.id)
 
     def write(self, buf):
         return self.connection.VirtualFile.writetoid(self.id, buf)
@@ -639,6 +617,7 @@ class VirtualFile:
         return self.connection.VirtualFile.closebyid(self.id)
 
 
+# @API(RedirectedRun, 200)
 def RedirectedRun(conn_number, func, *args):
     """Run func with args on connection with conn number conn_number
 

--- a/src/rdiff_backup/eas_acls.py
+++ b/src/rdiff_backup/eas_acls.py
@@ -34,6 +34,14 @@ try:
     import posix1e
 except ImportError:
     pass
+try:
+    import xattr.pyxattr_compat as xattr
+except ImportError:
+    try:
+        import xattr
+    except ImportError:
+        pass
+
 from rdiff_backup import C, Globals, log, metadata, rorpiter, rpath
 from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
@@ -71,7 +79,7 @@ class ExtendedAttributes:
     def read_from_rp(self, rp):
         """Set the extended attributes from an rpath"""
         try:
-            attr_list = rp.conn.xattr.list(rp.path, rp.issym())
+            attr_list = xattr.list(rp.path, rp.issym())
         except OSError as exc:
             if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.ETXTBSY):
                 return  # if not supported, consider empty
@@ -89,8 +97,7 @@ class ExtendedAttributes:
                 # Resource Fork handled elsewhere, except for directories
                 continue
             try:
-                self.attr_dict[attr] = \
-                    rp.conn.xattr.get(rp.path, attr, rp.issym())
+                self.attr_dict[attr] = xattr.get(rp.path, attr, rp.issym())
             except OSError as exc:
                 # File probably modified while reading, just continue
                 if exc.errno == errno.ENODATA:
@@ -105,10 +112,13 @@ class ExtendedAttributes:
 
     def write_to_rp(self, rp):
         """Write extended attributes to rpath rp"""
+        assert rp.conn is Globals.local_connection, (
+            "Function works locally not over '{co}'.".format(co=rp.conn))
+
         self._clear_rp(rp)
         for (name, value) in self.attr_dict.items():
             try:
-                rp.conn.xattr.set(rp.path, name, value, 0, rp.issym())
+                xattr.set(rp.path, name, value, 0, rp.issym())
             except OSError as exc:
                 # Mac and Linux attributes have different namespaces, so
                 # fail gracefully if can't call xattr.set
@@ -140,9 +150,9 @@ class ExtendedAttributes:
     def _clear_rp(self, rp):
         """Delete all the extended attributes in rpath"""
         try:
-            for name in rp.conn.xattr.list(rp.path, rp.issym()):
+            for name in xattr.list(rp.path, rp.issym()):
                 try:
-                    rp.conn.xattr.remove(rp.path, name, rp.issym())
+                    xattr.remove(rp.path, name, rp.issym())
                 except PermissionError:  # errno.EACCES
                     # SELinux attributes cannot be removed, and we don't want
                     # to bail out or be too noisy at low log levels.
@@ -321,13 +331,13 @@ class AccessControlLists:
 
     def read_from_rp(self, rp):
         """Set self.ACL from an rpath, or None if not supported"""
-        self.entry_list, self.default_entry_list = \
-            rp.conn.eas_acls.get_acl_lists_from_rp(rp)
+        self.entry_list, self.default_entry_list = get_acl_lists_from_rp(rp)
 
     def write_to_rp(self, rp, map_names=1):
         """Write current access control list to RPath rp"""
-        rp.conn.eas_acls.set_rp_acl(rp, self.entry_list,
-                                    self.default_entry_list, map_names)
+        assert rp.conn is Globals.local_connection, (
+            "Function works locally not over '{co}'.".format(co=rp.conn))
+        set_rp_acl(rp, self.entry_list, self.default_entry_list, map_names)
 
     def _set_from_text(self, text):
         """Set self.entry_list and self.default_entry_list from text"""
@@ -496,7 +506,7 @@ class AccessControlListFile(metadata.FlatFile):
                                       os.fsencode(str(acl)))
 
 
-# @API(set_rp_acl, 200)
+# @API(set_rp_acl, 200, 200)  # unused
 def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
     """Set given rp with ACL that acl_text defines.  rp should be local"""
     assert rp.conn is Globals.local_connection, (
@@ -526,7 +536,7 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
         def_acl.applyto(rp.path, posix1e.ACL_TYPE_DEFAULT)
 
 
-# @API(get_acl_lists_from_rp, 200)
+# @API(get_acl_lists_from_rp, 200, 200)  # unused
 def get_acl_lists_from_rp(rp):
     """Returns (acl_list, def_acl_list) from an rpath.  Call locally"""
     assert rp.conn is Globals.local_connection, (
@@ -707,11 +717,13 @@ def _list_to_acl(entry_list, map_names=1):
 
 
 def rpath_acl_get(rp):
-    """Get acls of given rpath rp.
+    """
+    Get acls of given rpath rp.
 
     This overrides a function in the rpath module.
-
     """
+    assert rp.conn is Globals.local_connection, (
+        "Function works locally not over '{co}'.".format(co=rp.conn))
     acl = AccessControlLists(rp.index)
     if not rp.issym():
         acl.read_from_rp(rp)
@@ -730,11 +742,13 @@ rpath.get_blank_acl = rpath_get_blank_acl
 
 
 def rpath_ea_get(rp):
-    """Get extended attributes of given rpath
+    """
+    Get extended attributes of given rpath
 
     This overrides a function in the rpath module.
-
     """
+    assert rp.conn is Globals.local_connection, (
+        "Function works locally not over '{co}'.".format(co=rp.conn))
     ea = ExtendedAttributes(rp.index)
     if not rp.issock() and not rp.isfifo():
         ea.read_from_rp(rp)

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -20,7 +20,6 @@
 
 import datetime
 import os  # needed to grab verbosity as environment variable
-import re
 import shutil
 import sys
 import textwrap
@@ -341,22 +340,6 @@ class ErrorLog:
             return cls._log_fileobj is not None
         else:
             return Globals.backup_writer.log.ErrorLog.isopen()
-
-    @classmethod
-    # @API(ErrorLog.write, 200)
-    def write(cls, error_type, rp, exc):
-        """Add line to log file indicating error exc with file rp"""
-        if not Globals.isbackup_writer:
-            return Globals.backup_writer.log.ErrorLog.write(
-                error_type, rp, exc)
-        logstr = cls._get_log_string(error_type, rp, exc)
-        Log(logstr, WARNING)
-        if Globals.null_separator:
-            logstr += "\0"
-        else:
-            logstr = re.sub("\n", " ", logstr)
-            logstr += "\n"
-        cls._log_fileobj.write(_to_bytes(logstr))
 
     @classmethod
     # @API(ErrorLog.write_if_open, 200)

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -656,9 +656,10 @@ class RPath(RORPath):
             self.base = None
 
     def __repr__(self):
-        return "<{cls}/{cid}:\n\tPath={rp}\n\tIndex={idx}\n\tData={data}>".format(
-            cls=self.__class__.__name__, cid=id(self), rp=self,
-            idx=self.get_safeindex(), data=self.data)
+        return ("<{cls}/{cid}:\n\tPath={rp}\n\tIndex={idx}\n"
+                "\tConnection={conn}\n\tData={data}>".format(
+                    cls=self.__class__.__name__, cid=id(self), rp=self,
+                    idx=self.get_safeindex(), conn=self.conn, data=self.data))
 
     def __fspath__(self):
         """
@@ -1657,7 +1658,7 @@ def copy_attribs(rpin, rpout):
     timestamps, so both must already exist.
 
     """
-    log.Log("Copying attributes from path {fp} to path {tp}".format(
+    log.Log("Copying attributes from path {fp!r} to path {tp!r}".format(
         fp=rpin, tp=rpout), log.DEBUG)
     assert rpin.lstat() == rpout.lstat() or rpin.isspecial(), (
         "Input '{irp!r}' and output '{orp!r}' paths must exist likewise, "
@@ -1692,7 +1693,7 @@ def copy_attribs_inc(rpin, rpout):
     permissions.
 
     """
-    log.Log("Copying inc attributes from path {fp} to path {tp}".format(
+    log.Log("Copying inc attributes from path {fp!r} to path {tp!r}".format(
         fp=rpin, tp=rpout), log.DEBUG)
     _check_for_files(rpin, rpout)
     if Globals.change_ownership:
@@ -1715,6 +1716,7 @@ def copy_attribs_inc(rpin, rpout):
         rpout.write_acl(rpin.get_acl(), map_names=0)
     if not rpin.isdev():
         rpout.setmtime(rpin.getmtime())
+    # TODO check why win_acls aren't copied
 
 
 def copy_with_attribs(rpin, rpout, compress=0):

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -322,11 +322,11 @@ def init_acls():
         win32api.CloseHandle(hnd)
 
 
-def _rpath_win_acl_get(rpath):
-    assert rpath.conn is Globals.local_connection, (
-        "Function works locally not over '{co}'.".format(co=rpath.conn))
+def _rpath_win_acl_get(rp):
+    assert rp.conn is Globals.local_connection, (
+        "Function works locally not over '{co}'.".format(co=rp.conn))
     acl = ACL()
-    acl.load_from_rp(rpath)
+    acl.load_from_rp(rp)
     return bytes(acl)
 
 
@@ -342,8 +342,8 @@ rpath.get_blank_win_acl = _rpath_get_blank_win_acl
 
 
 def _rpath_write_win_acl(rp, acl_str):
-    assert rpath.conn is Globals.local_connection, (
-        "Function works locally not over '{co}'.".format(co=rpath.conn))
+    assert rp.conn is Globals.local_connection, (
+        "Function works locally not over '{co}'.".format(co=rp.conn))
     acl = ACL()
     acl.from_string(acl_str)
     acl.write_to_rp(rp)

--- a/src/rdiff_backup/win_acls.py
+++ b/src/rdiff_backup/win_acls.py
@@ -19,12 +19,15 @@
 
 import re
 import os
-from . import C, metadata, rorpiter, rpath, log
+from rdiff_backup import C, Globals, log, metadata, rorpiter, rpath
 
 try:
     from win32security import (
         AdjustTokenPrivileges,
+        ConvertSecurityDescriptorToStringSecurityDescriptor,
+        ConvertStringSecurityDescriptorToSecurityDescriptor,
         DACL_SECURITY_INFORMATION,
+        GetNamedSecurityInfo,
         GetTokenInformation,
         GROUP_SECURITY_INFORMATION,
         INHERIT_ONLY_ACE,
@@ -39,6 +42,7 @@ try:
         SE_PRIVILEGE_ENABLED,
         SE_RESTORE_NAME,
         SE_SECURITY_NAME,
+        SetNamedSecurityInfo,
         TOKEN_ADJUST_PRIVILEGES,
         TokenPrivileges,
         TOKEN_QUERY,
@@ -79,8 +83,8 @@ class ACL:
             return
 
         try:
-            sd = rp.conn.win32security.GetNamedSecurityInfo(
-                os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
+            sd = GetNamedSecurityInfo(os.fsdecode(rp.path),
+                                      SE_FILE_OBJECT, ACL.flags)
         except (OSError, pywintypes.error) as exc:
             log.Log("Unable to read ACL from path {pa} due to "
                     "exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
@@ -117,7 +121,7 @@ class ACL:
             sd.SetSecurityDescriptorSacl(0, None, 0)
 
         try:
-            self.__acl = rp.conn.win32security.ConvertSecurityDescriptorToStringSecurityDescriptor(
+            self.__acl = ConvertSecurityDescriptorToStringSecurityDescriptor(
                 sd, SDDL_REVISION_1, ACL.flags)
         except (OSError, pywintypes.error) as exc:
             log.Log("Unable to convert ACL of path {pa} to string "
@@ -130,7 +134,7 @@ class ACL:
             return
 
         try:
-            sd = rp.conn.win32security.ConvertStringSecurityDescriptorToSecurityDescriptor(
+            sd = ConvertStringSecurityDescriptorToSecurityDescriptor(
                 os.fsdecode(self.__acl), SDDL_REVISION_1)
         except (OSError, pywintypes.error) as exc:
             log.Log("Unable to convert ACL string '{st!r}' to security "
@@ -164,7 +168,7 @@ class ACL:
             self._clear_rp(rp)
 
         try:
-            rp.conn.win32security.SetNamedSecurityInfo(
+            SetNamedSecurityInfo(
                 os.fsdecode(rp.path),
                 SE_FILE_OBJECT, ACL.flags,
                 sd.GetSecurityDescriptorOwner(),
@@ -201,8 +205,8 @@ class ACL:
         # not sure how to interpret this
         # I'll just clear all acl-s from rp.path
         try:
-            sd = rp.conn.win32security.GetNamedSecurityInfo(
-                os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
+            sd = GetNamedSecurityInfo(os.fsdecode(rp.path),
+                                      SE_FILE_OBJECT, ACL.flags)
         except (OSError, pywintypes.error) as exc:
             log.Log("Unable to read ACL from path {pa} for clearing them "
                     "due to exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
@@ -228,7 +232,7 @@ class ACL:
                 sd.SetSecurityDescriptorSacl(0, acl, 0)
 
         try:
-            rp.conn.win32security.SetNamedSecurityInfo(
+            SetNamedSecurityInfo(
                 os.fsdecode(rp.path),
                 SE_FILE_OBJECT,
                 ACL.flags,
@@ -319,6 +323,8 @@ def init_acls():
 
 
 def _rpath_win_acl_get(rpath):
+    assert rpath.conn is Globals.local_connection, (
+        "Function works locally not over '{co}'.".format(co=rpath.conn))
     acl = ACL()
     acl.load_from_rp(rpath)
     return bytes(acl)
@@ -336,6 +342,8 @@ rpath.get_blank_win_acl = _rpath_get_blank_win_acl
 
 
 def _rpath_write_win_acl(rp, acl_str):
+    assert rpath.conn is Globals.local_connection, (
+        "Function works locally not over '{co}'.".format(co=rpath.conn))
     acl = ACL()
     acl.from_string(acl_str)
     acl.write_to_rp(rp)

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -479,7 +479,7 @@ class RepoShadow:
 
 # ### COPIED FROM RESTORE (LIST) ####
 
-    # @API(list_files_changed_since, 201)
+    # @API(RepoShadow.list_files_changed_since, 201)
     @classmethod
     def list_files_changed_since(cls, mirror_rp, inc_rp, data_dir,
                                  restore_to_time):
@@ -511,7 +511,7 @@ class RepoShadow:
             yield rpath.RORPath(("%-7s %s" % (change, path_desc), ))
         cls.close_rf_cache()
 
-    # @API(list_files_at_time, 201)
+    # @API(RepoShadow.list_files_at_time, 201)
     @classmethod
     def list_files_at_time(cls, mirror_rp, inc_rp, data_dir, time):
         """
@@ -530,7 +530,7 @@ class RepoShadow:
 
 # ### COPIED FROM MANAGE ####
 
-    # @API(remove_increments_older_than, 201)
+    # @API(RepoShadow.remove_increments_older_than, 201)
     @classmethod
     def remove_increments_older_than(cls, baserp, time):
         """


### PR DESCRIPTION
- Remove unused functions Globals.is_not_None, .get/set_dict_val.
- Align Security and API documentation.
- Add connection information to __repr__ of RPath.

I'm hesitating to delete alltogether the API docs as they are mostly duplicate of the Security module and the `@API` marking. It sounds to me now like a source of errors rather than a source of information.

Note that this PR can only be merged once #648 has been merged.