### PR TITLE
Added patch for Python3.11 as per bpo-39573.

### DIFF
--- a/src/_librsyncmodule.c
+++ b/src/_librsyncmodule.c
@@ -25,6 +25,16 @@
 #include <librsync.h>
 #define RSM_JOB_BLOCKSIZE 65536
 
+/* ----------------------------------------------------------------------- *
+ * Update for Python 3.11 - Contributed by Victor Stinner in bpo-39573.
+ * Compatibility macro for older Python versions.
+ * ----------------------------------------------------------------------- */
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
+{ ob->ob_type = type; }
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+#endif
+
 static PyObject *librsyncError;
 
 /* Sets python error string from result */
@@ -540,8 +550,9 @@ PyMODINIT_FUNC PyInit__librsync(void)
 {
   PyObject *m, *d;
 
-  Py_TYPE(&_librsync_SigMakerType) = &PyType_Type;
-  Py_TYPE(&_librsync_DeltaMakerType) = &PyType_Type;
+  /* Update for Python 3.11 - bpo-39573. */
+  Py_SET_TYPE(&_librsync_SigMakerType, &PyType_Type);
+  Py_SET_TYPE(&_librsync_DeltaMakerType, &PyType_Type);
   static struct PyModuleDef librsync_def = {
             PyModuleDef_HEAD_INIT, "_librsync", "RSync Lib", -1, _librsyncMethods, };
   m = PyModule_Create(&librsync_def);


### PR DESCRIPTION
FIX: Added patch for Python3.11 as per bpo-39573. as noted in Issue #633.