### PR TITLE
[DOC] Updated details for RHEL based systems

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,10 +33,8 @@ If the optional dependencies pylibacl and pyxattr are installed, rdiff-backup wi
 In older Linux distributions the rdiff-backup versions are of the 1.x series, which is not recommended for new installs anymore.
 Follow the instructions below to install the latest 2.x release of rdiff-backup.
 
-____
 CAUTION: rdiff-backup 1.x and 2.x aren't compatible and can't be mixed in server/client mode!
 See xref:docs/migration.adoc[how to migrate side-by-side].
-____
 
 === Ubuntu Focal or Debian Bullseye or newer (has 2.0)
 
@@ -61,9 +59,7 @@ sudo yum install rdiff-backup
 sudo yum install py3libacl pyxattr
 ----
 
-____
 NOTE: the last line is optional to get ACLs and EAs support.
-____
 
 === CentOS, AlmaLinux, Rocky Linux and RHEL 8 (from EPEL)
 
@@ -72,13 +68,11 @@ sudo dnf install epel-release
 sudo dnf --enablerepo=PowerTools install rdiff-backup
 ----
 
-____
 NOTE: you can add the option `--setopt=install_weak_deps=False` to the last line if you don't need ACLs and EAs support.
 You can install `python3-pylibacl` and `python3-pyxattr` also separately.
 Under RHEL, the repo to enable is https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/package_manifest/codereadylinuxbuilder-repository[codeready-builder-for-rhel-8-x86_64-rpms] in order to get access to pyxattr, instead of PowerTools.
 
 NOTE: This does not enable updates for `PowerTools`, check the distribution documentation for details on how to do this.
-____
 
 === Fedora 34+
 
@@ -86,9 +80,7 @@ ____
 sudo dnf install rdiff-backup
 ----
 
-____
 NOTE: for earlier versions, see the COPR instructions below.
-____
 
 === Debian and derivatives, Raspbian, etc. (from PyPi)
 
@@ -97,10 +89,8 @@ sudo apt install python3-pip python3-setuptools python3-pylibacl python3-pyxattr
 sudo pip3 install rdiff-backup
 ----
 
-____
 NOTE: If your platform is not i386 or amd64, e.g.
 ARM/MIPS/etc,   you may need the build dependencies `build-essentials`, `librsync-dev`.
-____
 
 === CentOS and RHEL 6 (from PyPi)
 
@@ -140,10 +130,8 @@ Then you should only need to call the following before you can use rdiff-backup:
 sudo pip3 install rdiff-backup
 ----
 
-____
 NOTE: especially if your platform is not i386 or amd64, e.g.
 ARM/MIPS/PowerPC/etc,   but also if the pip3 installation fails with `+include [...].h+` files missing,   you may need the build dependencies named like `python3-devel` or `librsync-dev`.
-____
 
 === Windows
 

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ In older Linux distributions the rdiff-backup versions are of the 1.x series, wh
 Follow the instructions below to install the latest 2.x release of rdiff-backup.
 
 ____
-*CAUTION:* rdiff-backup 1.x and 2.x aren't compatible and can't be mixed in server/client mode!
+CAUTION: rdiff-backup 1.x and 2.x aren't compatible and can't be mixed in server/client mode!
 See xref:docs/migration.adoc[how to migrate side-by-side].
 ____
 
@@ -53,7 +53,7 @@ sudo apt update
 sudo apt install rdiff-backup
 ----
 
-=== CentOS and RHEL 7 (From EPEL)
+=== CentOS and RHEL 7 (from EPEL)
 
 ----
 sudo yum install epel-release
@@ -62,10 +62,10 @@ sudo yum install py3libacl pyxattr
 ----
 
 ____
-*NOTE:* the last line is optional to get ACLs and EAs support.
+NOTE: the last line is optional to get ACLs and EAs support.
 ____
 
-=== CentOS, AlmaLinux, Rocky LInux and RHEL 8 (From EPEL)
+=== CentOS, AlmaLinux, Rocky Linux and RHEL 8 (from EPEL)
 
 ----
 sudo dnf install epel-release
@@ -73,12 +73,11 @@ sudo dnf --enablerepo=PowerTools install rdiff-backup
 ----
 
 ____
-*NOTE:* you can add the option `--setopt=install_weak_deps=False` to the 	last line if you don't need ACLs and EAs support.
-You can install 	`python3-pylibacl` and `python3-pyxattr` also separately.
-Under RHEL, the repo to enable is https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/package_manifest/codereadylinuxbuilder-repository[codeready-builder-for-rhel-8-x86_64-rpms] in order to get access 	to pyxattr, instead of PowerTools.
+NOTE: you can add the option `--setopt=install_weak_deps=False` to the last line if you don't need ACLs and EAs support.
+You can install `python3-pylibacl` and `python3-pyxattr` also separately.
+Under RHEL, the repo to enable is https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/package_manifest/codereadylinuxbuilder-repository[codeready-builder-for-rhel-8-x86_64-rpms] in order to get access to pyxattr, instead of PowerTools.
 
-*NOTE:* This does not enable updates for `PowerTools`, check the distribution
-documentation for details on how to do this.
+NOTE: This does not enable updates for `PowerTools`, check the distribution documentation for details on how to do this.
 ____
 
 === Fedora 34+
@@ -88,7 +87,7 @@ sudo dnf install rdiff-backup
 ----
 
 ____
-*NOTE:* for earlier versions, see the COPR instructions below.
+NOTE: for earlier versions, see the COPR instructions below.
 ____
 
 === Debian and derivatives, Raspbian, etc. (from PyPi)
@@ -99,7 +98,7 @@ sudo pip3 install rdiff-backup
 ----
 
 ____
-*NOTE:* If your platform is not i386 or amd64, e.g.
+NOTE: If your platform is not i386 or amd64, e.g.
 ARM/MIPS/etc,   you may need the build dependencies `build-essentials`, `librsync-dev`.
 ____
 
@@ -121,7 +120,7 @@ sudo dnf install python3-pip python3-setuptools py3libacl python3-pyxattr
 sudo pip3 install rdiff-backup
 ----
 
-=== Other Linux and UN*X-oid systems, e.g. BSD (From PyPi)
+=== Other Linux and UN*X-oid systems, e.g. BSD (from PyPi)
 
 You need to make sure that the following requirements are met:
 
@@ -142,7 +141,7 @@ sudo pip3 install rdiff-backup
 ----
 
 ____
-*NOTE:* especially if your platform is not i386 or amd64, e.g.
+NOTE: especially if your platform is not i386 or amd64, e.g.
 ARM/MIPS/PowerPC/etc,   but also if the pip3 installation fails with `+include [...].h+` files missing,   you may need the build dependencies named like `python3-devel` or `librsync-dev`.
 ____
 

--- a/README.adoc
+++ b/README.adoc
@@ -53,11 +53,10 @@ sudo apt update
 sudo apt install rdiff-backup
 ----
 
-=== CentOS and RHEL 7 (From COPR)
+=== CentOS and RHEL 7 (From EPEL)
 
 ----
-sudo yum install yum-plugin-copr epel-release
-sudo yum copr enable frankcrawford/rdiff-backup
+sudo yum install epel-release
 sudo yum install rdiff-backup
 sudo yum install py3libacl pyxattr
 ----
@@ -66,11 +65,10 @@ ____
 *NOTE:* the last line is optional to get ACLs and EAs support.
 ____
 
-=== CentOS and RHEL 8 (From COPR)
+=== CentOS, AlmaLinux, Rocky LInux and RHEL 8 (From EPEL)
 
 ----
-sudo dnf install dnf-plugins-core epel-release
-sudo dnf copr enable frankcrawford/rdiff-backup
+sudo dnf install epel-release
 sudo dnf --enablerepo=PowerTools install rdiff-backup
 ----
 
@@ -78,9 +76,12 @@ ____
 *NOTE:* you can add the option `--setopt=install_weak_deps=False` to the 	last line if you don't need ACLs and EAs support.
 You can install 	`python3-pylibacl` and `python3-pyxattr` also separately.
 Under RHEL, the repo to enable is https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/package_manifest/codereadylinuxbuilder-repository[codeready-builder-for-rhel-8-x86_64-rpms] in order to get access 	to pyxattr, instead of PowerTools.
+
+*NOTE:* This does not enable updates for `PowerTools`, check the distribution
+documentation for details on how to do this.
 ____
 
-=== Fedora 32+
+=== Fedora 34+
 
 ----
 sudo dnf install rdiff-backup
@@ -211,7 +212,7 @@ sudo apt update
 sudo apt install rdiff-backup
 ----
 
-==== Fedora, CentOS and RHEL
+==== Fedora, CentOS and RHEL (from COPR)
 
 On CentOS and RHEL (7 and 8):
 

--- a/docs/migration.adoc
+++ b/docs/migration.adoc
@@ -75,7 +75,36 @@ Start by installing the new rdiff-backup side-by-side on the remote server as fo
 
 ===== On CentOS/Redhat
 
-TODO
+This installs the Python2 application `rdiff-backup-1` side-by-side with
+any other version `rdiff-backup` also installed.  If you wish this to be know
+as `rdiff-backup` you will need to rename or link it to the required name.
+
+CentOS and RHEL 7 (From COPR)
+ 
+----
+sudo yum install yum-plugin-copr epel-release
+sudo yum copr enable frankcrawford/python2-rdiff-backup
+sudo yum install python2-rdiff-backup
+----
+ 
+CentOS, AlmaLinux, Rocky Linux and RHEL 8 (From COPR)
+ 
+----
+sudo dnf install dnf-plugins-core epel-release
+sudo dnf copr enable frankcrawford/python2-rdiff-backup
+sudo dnf copr enable frankcrawford/python2-pyxattr
+sudo dnf --enablerepo=PowerTools install python2-rdiff-backup
+----
+
+Fedora (From COPR)
+ 
+----
+sudo dnf install dnf-plugins-core epel-release
+sudo dnf copr enable frankcrawford/python2-rdiff-backup
+sudo dnf copr enable frankcrawford/python2-pyxattr
+sudo dnf copr enable frankcrawford/python2-pylibacl
+sudo dnf install python2-rdiff-backup
+----
 
 ==== On Local
 
@@ -120,11 +149,39 @@ Then install the wrapper script to auto detect the version of rdiff-backup.
 
 ===== On CentOS
 
-TODO
+This installs the Python2 application `rdiff-backup-1` side-by-side with
+any other version `rdiff-backup` also installed.
+
+CentOS and RHEL 7 (From COPR)
+ 
+----
+sudo yum install yum-plugin-copr epel-release
+sudo yum copr enable frankcrawford/python2-rdiff-backup
+sudo yum install python2-rdiff-backup
+----
+ 
+CentOS, AlmaLinux, Rocky Linux and RHEL 8 (From COPR)
+ 
+----
+sudo dnf install dnf-plugins-core epel-release
+sudo dnf copr enable frankcrawford/python2-rdiff-backup
+sudo dnf copr enable frankcrawford/python2-pyxattr
+sudo dnf --enablerepo=PowerTools install python2-rdiff-backup
+----
+
+Fedora (From COPR)
+ 
+----
+sudo dnf install dnf-plugins-core epel-release
+sudo dnf copr enable frankcrawford/python2-rdiff-backup
+sudo dnf copr enable frankcrawford/python2-pyxattr
+sudo dnf copr enable frankcrawford/python2-pylibacl
+sudo dnf install python2-rdiff-backup
+----
 
 Once both version of rdiff-backup are installed side-by-side, you need to adapt your command line to make use of the rdiff-backup-wrap script that is used to auto-detect the version of rdiff-backup to be used.
 
-  rdiff-backup-wrap user@10.255.1.102:/source /destination
+  rdiff-backup-1 user@10.255.1.102:/source /destination
 
 ==== On Remote
 

--- a/docs/migration.adoc
+++ b/docs/migration.adoc
@@ -11,10 +11,8 @@ Alternatively it explains how to keep multiple versions of rdiff-backup installe
 The new version 2.x of rdiff-backup is compatible with repositories created with the legacy version 1.x.
 In other words, the data on the disk is fully compatible between the two.
 
-____
-*CAUTION:* *The network protocol of the legacy version is NOT compatible with the new version.* In other words, you must be running the same version of rdiff-backup locally and remotely.
+CAUTION: *The network protocol of the legacy version is NOT compatible with the new version.* In other words, you must be running the same version of rdiff-backup locally and remotely.
 For this reason, you might need to have a plan to transition from the legacy version to the new version depending of your use case.
-____
 
 You have two options for your migration:
 
@@ -51,9 +49,7 @@ e.g.:
 
     rdiff-backup /source user@10.255.1.102:/destination
 
-____
-*NOTE:* With this use case you must be careful as rdiff-backup legacy version is not compatible with the new version due to the migration to Python 3.
-____
+NOTE: With this use case you must be careful as rdiff-backup legacy version is not compatible with the new version due to the migration to Python 3.
 
 ==== On Remote
 
@@ -122,9 +118,7 @@ e.g.:
 
     rdiff-backup user@10.255.1.102:/source /destination
 
-____
-*NOTE:* With this use case you must be careful as rdiff-backup legacy version is not compatible with the new version due to the migration to Python 3.
-____
+NOTE: With this use case you must be careful as rdiff-backup legacy version is not compatible with the new version due to the migration to Python 3.
 
 ==== On Local
 
@@ -174,9 +168,7 @@ When this happen, the wrapper script deployed on the local server will detect th
 The idea is to have a central backup server where multiple clients can connect to, without risk of encountering compatibility issues between different versions of the client connecting to the same server.
 Because all the clients can't migrate at the same time, it must be made sure that the server is able to support multiple versions of rdiff-backup at the same time.
 
-____
-*NOTE:* the same approach can be used to support multiple clients of different versions but the use case doesn't seem as useful, hence it is left to the interpretation of the reader.
-____
+NOTE: the same approach can be used to support multiple clients of different versions but the use case doesn't seem as useful, hence it is left to the interpretation of the reader.
 
 === Server side
 
@@ -195,9 +187,7 @@ ${BASEDIR}/rdiff-backup-2.0/bin/pip install pylibacl pyxattr  # optional
 ${BASEDIR}/rdiff-backup-2.0/bin/rdiff-backup --version  # result is 2.0.5
 ----
 
-____
-*NOTE:* you can also only create major versions virtualenvs, like `rdiff-backup-2`, or even z-Versions like `rdiff-backup-2.0.5` but the middle version seems like a reasonable middle-way.
-____
+NOTE: you can also only create major versions virtualenvs, like `rdiff-backup-2`, or even z-Versions like `rdiff-backup-2.0.5` but the middle version seems like a reasonable middle-way.
 
 Optionally, you can add to your PATH an executable script `rdiff-backup-2.0` with a content like the following, so that the clients don't need to care about the full-path (which will be our assumption in the following lines):
 
@@ -207,9 +197,7 @@ BASEDIR=/usr/local/lib
 exec ${BASEDIR}/$(basename $0)/bin/rdiff-backup "$@"
 ----
 
-____
-*TIP:* the `basename` trick allows you to only maintain one script, linked (hard or soft) under multiple names.
-____
+TIP: the `basename` trick allows you to only maintain one script, linked (hard or soft) under multiple names.
 
 Repeat for each version of rdiff-backup you want to maintain in parallel.
 
@@ -229,10 +217,8 @@ rdiff-backup --remote-schema 'ssh -C {h} rdiff-backup-{Vx}.{Vy} server' \
 	backup /sourcedir user@serverhost::/backup-repo
 ----
 
-____
-*TIP:* for older versions of rdiff-backup, one could surely write a wrapper script mimicking the same behaviour, using something along the line of `$(rdiff-backup --version | awk -F'[.
+TIP: for older versions of rdiff-backup, one could surely write a wrapper script mimicking the same behaviour, using something along the line of `$(rdiff-backup --version | awk -F'[.
 ]' '{print $2 "." $3}')`.
-____
 
 And that's it for the side-by-side installation...
 
@@ -246,9 +232,7 @@ After version 2.0.5, a new Command Line Interface (CLI) has been introduced in r
 
 The following tables show the main differences between those three versions of the rdiff-backup CLI, using typical usage examples.
 
-____
-*NOTE:* the new features aren't explained, only the mapping from the old syntax to the new one.
-____
+NOTE: the new features aren't explained, only the mapping from the old syntax to the new one.
 
 The differences between the old and the legacy CLI are, obviously, limited and restricted to the restore use cases:
 

--- a/docs/migration.adoc
+++ b/docs/migration.adoc
@@ -73,7 +73,7 @@ Start by installing the new rdiff-backup side-by-side on the remote server as fo
      $ rdiff-backup –version
      rdiff-backup 1.2.8
 
-===== On CentOS/Redhat
+===== On CentOS/RHEL
 
 This installs the Python2 application `rdiff-backup-1` side-by-side with
 any other version `rdiff-backup` also installed.  If you wish this to be know
@@ -147,41 +147,20 @@ Then install the wrapper script to auto detect the version of rdiff-backup.
      $ curl https://raw.githubusercontent.com/rdiff-backup/rdiff-backup/master/tools/misc/rdiff-backup-wrap -o /usr/bin/rdiff-backup-wrap
      $ chmod +x /usr/bin/rdiff-backup-wrap
 
-===== On CentOS
-
-This installs the Python2 application `rdiff-backup-1` side-by-side with
-any other version `rdiff-backup` also installed.
-
-CentOS and RHEL 7 (From COPR)
- 
-----
-sudo yum install yum-plugin-copr epel-release
-sudo yum copr enable frankcrawford/python2-rdiff-backup
-sudo yum install python2-rdiff-backup
-----
- 
-CentOS, AlmaLinux, Rocky Linux and RHEL 8 (From COPR)
- 
-----
-sudo dnf install dnf-plugins-core epel-release
-sudo dnf copr enable frankcrawford/python2-rdiff-backup
-sudo dnf copr enable frankcrawford/python2-pyxattr
-sudo dnf --enablerepo=PowerTools install python2-rdiff-backup
-----
-
-Fedora (From COPR)
- 
-----
-sudo dnf install dnf-plugins-core epel-release
-sudo dnf copr enable frankcrawford/python2-rdiff-backup
-sudo dnf copr enable frankcrawford/python2-pyxattr
-sudo dnf copr enable frankcrawford/python2-pylibacl
-sudo dnf install python2-rdiff-backup
-----
-
 Once both version of rdiff-backup are installed side-by-side, you need to adapt your command line to make use of the rdiff-backup-wrap script that is used to auto-detect the version of rdiff-backup to be used.
 
-  rdiff-backup-1 user@10.255.1.102:/source /destination
+  rdiff-backup-wrap user@10.255.1.102:/source /destination
+
+===== On CentOS/RHEL
+
+Install the Python2 application `rdiff-backup-1` side-by-side with
+any other version `rdiff-backup` as per the instructions above.
+
+At that point you need to setup a script that will select either `rdiff-backup`
+or `rdiff-backup-1` based on a list or some other configuration.
+
+If you wish to use the `rdiff-backup-wrap` script listed above, modify the
+script to change the `CMD` from `rdiff-backup2` to `rdiff-backup-1`.
 
 ==== On Remote
 
@@ -196,7 +175,7 @@ The idea is to have a central backup server where multiple clients can connect t
 Because all the clients can't migrate at the same time, it must be made sure that the server is able to support multiple versions of rdiff-backup at the same time.
 
 ____
-*NOTE:* the same approach can be used to support multiple clients of 	different versions but the use case doesn't seem as useful, hence 	it is left to the interpretation of the reader.
+*NOTE:* the same approach can be used to support multiple clients of different versions but the use case doesn't seem as useful, hence it is left to the interpretation of the reader.
 ____
 
 === Server side
@@ -217,7 +196,7 @@ ${BASEDIR}/rdiff-backup-2.0/bin/rdiff-backup --version  # result is 2.0.5
 ----
 
 ____
-*NOTE:* you can also only create major versions virtualenvs, like 	`rdiff-backup-2`, or even z-Versions like `rdiff-backup-2.0.5` but 	the middle version seems like a reasonable middle-way.
+*NOTE:* you can also only create major versions virtualenvs, like `rdiff-backup-2`, or even z-Versions like `rdiff-backup-2.0.5` but the middle version seems like a reasonable middle-way.
 ____
 
 Optionally, you can add to your PATH an executable script `rdiff-backup-2.0` with a content like the following, so that the clients don't need to care about the full-path (which will be our assumption in the following lines):
@@ -229,7 +208,7 @@ exec ${BASEDIR}/$(basename $0)/bin/rdiff-backup "$@"
 ----
 
 ____
-*TIP:* the `basename` trick allows you to only maintain one script, 	linked (hard or soft) under multiple names.
+*TIP:* the `basename` trick allows you to only maintain one script, linked (hard or soft) under multiple names.
 ____
 
 Repeat for each version of rdiff-backup you want to maintain in parallel.
@@ -251,7 +230,7 @@ rdiff-backup --remote-schema 'ssh -C {h} rdiff-backup-{Vx}.{Vy} server' \
 ----
 
 ____
-*TIP:* for older versions of rdiff-backup, one could surely write a 	wrapper script mimicking the same behaviour, using something along the 	line of `$(rdiff-backup --version | awk -F'[.
+*TIP:* for older versions of rdiff-backup, one could surely write a wrapper script mimicking the same behaviour, using something along the line of `$(rdiff-backup --version | awk -F'[.
 ]' '{print $2 "." $3}')`.
 ____
 
@@ -268,7 +247,7 @@ After version 2.0.5, a new Command Line Interface (CLI) has been introduced in r
 The following tables show the main differences between those three versions of the rdiff-backup CLI, using typical usage examples.
 
 ____
-*NOTE:* the new features aren't explained, only the mapping from the old 	syntax to the new one.
+*NOTE:* the new features aren't explained, only the mapping from the old syntax to the new one.
 ____
 
 The differences between the old and the legacy CLI are, obviously, limited and restricted to the restore use cases:


### PR DESCRIPTION
DOC: Update for standard RHEL based installs from EPEL  Only use COPR for development releases.
DOC: Finally added migration details for RHEL based systems.