### PR TITLE
Refactor time functions

### DIFF
--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -91,8 +91,8 @@
 * `SetConnections.add_redirected_conn`
 * `SetConnections.init_connection_remote`
 * `statistics.record_error`
-* `Time.setcurtime_local`
-* `Time.setprevtime_local`
+* `Time.setcurtime_local`  **deprecated**
+* `Time.setprevtime_local`  **deprecated**
 * `user_group.init_group_mapping`  **deprecated**
 * `user_group.init_user_mapping`  **deprecated**
 
@@ -138,6 +138,7 @@
 ** `.set_config`
 ** `.set_rorp_cache`
 ** `.set_select`
+** `.setup_paths`
 ** `.touch_current_mirror`
 ** `.update_quoting`
 ** `.verify`

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -276,6 +276,12 @@ remote_tempdir = None
 # and pre-regress
 do_fsync = True
 
+# This is the current time, either as integer (epoch) or formatted string.
+# It is set once at the beginning of the program and defines the backup's
+# date and time
+current_time = None
+current_time_string = None
+
 # This represents the pickle protocol used by rdiff-backup over the connection
 # https://docs.python.org/3/library/pickle.html#pickle-protocols
 # Note that the receiving end will automatically recognize the protocol used so

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -123,7 +123,7 @@ def backup_touch_curmirror_local(rpin, rpout):
 
     """
     mirrorrp = Globals.rbdir.append(b'.'.join(
-        map(os.fsencode, (b"current_mirror", Time.curtimestr, "data"))))
+        map(os.fsencode, (b"current_mirror", Time.getcurtimestr(), "data"))))
     log.Log("Writing mirror marker {mm}".format(mm=mirrorrp), log.DEBUG)
     try:
         pid = os.getpid()

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -227,13 +227,15 @@ def _set_allowed_requests(sec_class, sec_level):
         "log.Log.log_to_file",
         "robust.install_signal_handlers",
         "SetConnections.add_redirected_conn",
-        "Time.setcurtime_local",
         # System
         # "gzip.GzipFile",  # ??? perhaps covered by VirtualFile
         # "open",  # ??? perhaps covered by VirtualFile
         "sys.stdout.write",
         # API < 201
         "FilenameMapping.set_init_quote_vals_local",
+        "Time.setcurtime_local",
+        # API >= 201
+        "_repo_shadow.RepoShadow.setup_paths",
     }
     if (sec_level == "read-only" or sec_level == "update-only"
             or sec_level == "read-write"):
@@ -372,9 +374,9 @@ def _set_allowed_requests(sec_class, sec_level):
             "log.Log.setverbosity",
             "log.Log.setterm_verbosity",
             "SetConnections.init_connection_remote",
-            "Time.setprevtime_local",
             # API < 201
             "Globals.postset_regexp_local",
+            "Time.setprevtime_local",
             "user_group.init_user_mapping",
             "user_group.init_group_mapping",
             # API >= 201

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -770,8 +770,8 @@ class SetGlobals:
     def set_compatible_timestamps(self):
         if Globals.chars_to_quote.find(b":") > -1:
             Globals.set_all('use_compatible_timestamps', 1)
-            Time.setcurtime(
-                Time.curtime)  # update Time.curtimestr on all conns
+            # Update the current time string to new timestamp format
+            Time.set_current_time(Time.getcurtime())
             log.Log("Enabled use_compatible_timestamps", log.INFO)
 
 

--- a/src/rdiff_backup/increment.py
+++ b/src/rdiff_backup/increment.py
@@ -22,45 +22,49 @@ import os
 from . import Globals, Time, rpath, Rdiff, log, statistics, robust
 
 
-def Increment(new, mirror, incpref):
-    """Main file incrementing function, returns inc file created
+def Increment(new, mirror, incpref, inc_time=None):
+    """
+    Main file incrementing function, returns inc file created
 
     new is the file on the active partition,
     mirror is the mirrored file from the last backup,
     incpref is the prefix of the increment file.
 
     This function basically moves the information about the mirror
-    file to incpref.
-
+    file to incpref, inc_time being the (previous) time of the mirror.
     """
     log.Log("Incrementing mirror file {mf}".format(mf=mirror), log.INFO)
     if ((new and new.isdir()) or mirror.isdir()) and not incpref.lstat():
         incpref.mkdir()
 
+    if inc_time is None:  # compat200
+        inc_time = Time.prevtime
+
     if not mirror.lstat():
-        incrp = _make_missing_increment(incpref)
+        incrp = _make_missing_increment(incpref, inc_time)
     elif mirror.isdir():
-        incrp = _make_dir_increment(mirror, incpref)
+        incrp = _make_dir_increment(mirror, incpref, inc_time)
     elif new.isreg() and mirror.isreg():
-        incrp = _make_diff_increment(new, mirror, incpref)
+        incrp = _make_diff_increment(new, mirror, incpref, inc_time)
     else:
-        incrp = _make_snapshot_increment(mirror, incpref)
+        incrp = _make_snapshot_increment(mirror, incpref, inc_time)
     statistics.process_increment(incrp)
     return incrp
 
 
-def get_inc(rp, typestr, time=None):
-    """Return increment like rp but with time and typestr suffixes
+def get_inc(rp, typestr, inc_time):
+    """
+    Return increment like rp but with time and typestr suffixes
 
     To avoid any quoting, the returned rpath has empty index, and the
     whole filename is in the base (which is not quoted).
-
     """
-    if time is None:
-        time = Time.prevtime
+    if inc_time is None:  # compat200
+        inc_time = Time.prevtime
 
     def addtostr(s):
-        return b'.'.join(map(os.fsencode, (s, Time.timetostring(time), typestr)))
+        return b'.'.join(map(os.fsencode,
+                             (s, Time.timetostring(inc_time), typestr)))
 
     if rp.index:
         incrp = rp.__class__(rp.conn, rp.base,
@@ -78,9 +82,9 @@ def get_inc(rp, typestr, time=None):
 # === Internal functions ===
 
 
-def _make_missing_increment(incpref):
+def _make_missing_increment(incpref, inc_time):
     """Signify that mirror file was missing"""
-    incrp = get_inc(incpref, "missing")
+    incrp = get_inc(incpref, "missing", inc_time)
     incrp.touch()
     return incrp
 
@@ -91,13 +95,13 @@ def _is_compressed(mirror):
             and not Globals.no_compression_regexp.match(mirror.path))
 
 
-def _make_snapshot_increment(mirror, incpref):
+def _make_snapshot_increment(mirror, incpref, inc_time):
     """Copy mirror to incfile, since new is quite different"""
     compress = _is_compressed(mirror)
     if compress and mirror.isreg():
-        snapshotrp = get_inc(incpref, b"snapshot.gz")
+        snapshotrp = get_inc(incpref, b"snapshot.gz", inc_time)
     else:
-        snapshotrp = get_inc(incpref, b"snapshot")
+        snapshotrp = get_inc(incpref, b"snapshot", inc_time)
 
     if mirror.isspecial():  # check for errors when creating special increments
         eh = robust.get_error_handler("SpecialFileError")
@@ -112,13 +116,13 @@ def _make_snapshot_increment(mirror, incpref):
     return snapshotrp
 
 
-def _make_diff_increment(new, mirror, incpref):
+def _make_diff_increment(new, mirror, incpref, inc_time):
     """Make incfile which is a diff new -> mirror"""
     compress = _is_compressed(mirror)
     if compress:
-        diff = get_inc(incpref, b"diff.gz")
+        diff = get_inc(incpref, b"diff.gz", inc_time)
     else:
-        diff = get_inc(incpref, b"diff")
+        diff = get_inc(incpref, b"diff", inc_time)
 
     old_new_perms, old_mirror_perms = (None, None)
 
@@ -142,9 +146,9 @@ def _make_diff_increment(new, mirror, incpref):
     return diff
 
 
-def _make_dir_increment(mirrordir, incpref):
+def _make_dir_increment(mirrordir, incpref, inc_time):
     """Make file indicating directory mirrordir has changed"""
-    dirsign = get_inc(incpref, "dir")
+    dirsign = get_inc(incpref, "dir", inc_time)
     dirsign.touch()
     rpath.copy_attribs_inc(mirrordir, dirsign)
     return dirsign

--- a/src/rdiff_backup/metadata.py
+++ b/src/rdiff_backup/metadata.py
@@ -604,7 +604,7 @@ class Manager:
     def _writer_helper(self, prefix, flatfileclass, typestr, time):
         """Used in the get_xx_writer functions, returns a writer class"""
         if time is None:
-            timestr = Time.curtimestr
+            timestr = Time.getcurtimestr()
         else:
             timestr = Time.timetobytes(time)
         triple = map(os.fsencode, (prefix, timestr, typestr))

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -281,7 +281,7 @@ class StatFileObj(StatsObj):
         for attr in self._stat_file_attrs:
             self.set_stat(attr, 0)
         if start_time is None:
-            start_time = Time.curtime
+            start_time = Time.getcurtime()
         self.StartTime = start_time
         self.Errors = 0
 
@@ -343,7 +343,7 @@ class FileStats:
             "FileStats has already been initialized.")
         rpbase = Globals.rbdir.append(b"file_statistics")
         suffix = Globals.compression and 'data.gz' or 'data'
-        cls._rp = increment.get_inc(rpbase, suffix, Time.curtime)
+        cls._rp = increment.get_inc(rpbase, suffix, Time.getcurtime())
         assert not cls._rp.lstat(), (
             "Path '{rp}' shouldn't be existing.".format(rp=cls._rp))
         cls._fileobj = cls._rp.open("wb", compress=Globals.compression)
@@ -443,7 +443,7 @@ def write_active_statfileobj(end_time=None):
     global _active_statfileobj
     assert _active_statfileobj, "Stats object must be set before writing."
     rp_base = Globals.rbdir.append(b"session_statistics")
-    session_stats_rp = increment.get_inc(rp_base, 'data', Time.curtime)
+    session_stats_rp = increment.get_inc(rp_base, 'data', Time.getcurtime())
     _active_statfileobj.finish(end_time)
     _active_statfileobj.write_stats_to_rp(session_stats_rp)
     _active_statfileobj = None

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -460,7 +460,7 @@ class BaseAction:
 
         # once the connection is set, we can define "now" as being the current
         # time, unless the user defined a fixed a current time.
-        Time.setcurtime(self.values.current_time)
+        Time.set_current_time(self.values.current_time)
 
         return self
 
@@ -524,7 +524,11 @@ class BaseAction:
         number of past backups.
         """
         try:
-            return Time.genstrtotime(timestr, rp=ref_rp)
+            if Globals.get_api_version() < 201:  # compat200
+                return Time.genstrtotime(timestr, rp=ref_rp)
+            else:
+                sessions = self.repo.get_increment_times(ref_rp)
+                return Time.genstrtotime(timestr, session_times=sessions)
         except Time.TimeException as exc:
             log.Log("Time string '{ts}' couldn't be parsed "
                     "due to '{ex}'".format(ts=timestr, ex=exc), log.ERROR)

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -95,7 +95,7 @@ class CompareAction(actions.BaseAction):
         if Globals.get_api_version() < 201:  # compat200
             self.repo.base_dir.conn.fs_abilities.single_set_globals(
                 self.repo.base_dir, 1)  # read_only=True
-            self.repo.init_quoting()
+            self.repo.setup_quoting()
 
         (select_opts, select_data) = selection.get_prepared_selections(
             self.values.selections)

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -98,7 +98,7 @@ class ListAction(actions.BaseAction):
         if Globals.get_api_version() < 201:  # compat200
             self.repo.base_dir.conn.fs_abilities.single_set_globals(
                 self.repo.base_dir, 1)  # read_only=True
-            self.repo.init_quoting()
+            self.repo.setup_quoting()
 
         self.mirror_rpath = self.repo.base_dir.new_index(
             self.repo.restore_index)

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -89,7 +89,7 @@ class RegressAction(actions.BaseAction):
         if Globals.get_api_version() < 201:  # compat200
             self.repo.base_dir.conn.fs_abilities.single_set_globals(
                 self.repo.base_dir, 0)  # read_only=False
-            self.repo.init_quoting()
+            self.repo.setup_quoting()
 
         # TODO validate how much of the following lines and methods
         # should go into the directory/repository modules

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -92,7 +92,7 @@ class RemoveAction(actions.BaseAction):
         if Globals.get_api_version() < 201:  # compat200
             self.repo.base_dir.conn.fs_abilities.single_set_globals(
                 self.repo.base_dir, 0)  # read_only=False
-            self.repo.init_quoting()
+            self.repo.setup_quoting()
 
         # TODO validate how much of the following lines and methods
         # should go into the directory/repository modules

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -127,7 +127,7 @@ class RestoreAction(actions.BaseAction):
         if Globals.get_api_version() < 201:  # compat200
             self.dir.base_dir.conn.fs_abilities.restore_set_globals(
                 self.dir.base_dir)
-            self.repo.init_quoting()
+            self.repo.setup_quoting()
 
         if log.Log.verbosity > 0:
             try:  # the source repository could be read-only

--- a/src/rdiffbackup/actions/verify.py
+++ b/src/rdiffbackup/actions/verify.py
@@ -83,7 +83,7 @@ class VerifyAction(actions.BaseAction):
             # set the filesystem properties of the repository
             self.repo.base_dir.conn.fs_abilities.single_set_globals(
                 self.repo.base_dir, 1)  # read_only=True
-            self.repo.init_quoting()
+            self.repo.setup_quoting()
             self.mirror_rpath = self.repo.base_dir.new_index(
                 self.repo.restore_index)
         self.inc_rpath = self.repo.data_dir.append_path(

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -805,8 +805,8 @@ class SetGlobals:
     def set_compatible_timestamps(self):
         if Globals.chars_to_quote.find(b":") > -1:
             Globals.set_all('use_compatible_timestamps', 1)
-            Time.setcurtime(
-                Time.curtime)  # update Time.curtimestr on all conns
+            # Update the current time string to new timestamp format
+            Time.set_current_time(Time.getcurtime())
             log.Log("Enabled use_compatible_timestamps", log.INFO)
 
 

--- a/testing/action_regress_test.py
+++ b/testing/action_regress_test.py
@@ -63,6 +63,8 @@ class ActionRegressTest(unittest.TestCase):
         fileset.create_fileset(self.base_dir, self.from3_struct)
         fileset.create_fileset(self.base_dir, self.from4_struct)
         fileset.remove_fileset(self.base_dir, {"bak": {}})
+        fileset.remove_fileset(self.base_dir, {"to2": {}})
+        fileset.remove_fileset(self.base_dir, {"to4": {}})
         self.bak_path = os.path.join(self.base_dir, b"bak")
         self.to2_path = os.path.join(self.base_dir, b"to2")
         self.to4_path = os.path.join(self.base_dir, b"to4")

--- a/testing/incrementtest.py
+++ b/testing/incrementtest.py
@@ -30,8 +30,8 @@ target = rpath.RPath(lc, os.path.join(abs_output_dir, b"out"))
 out2 = rpath.RPath(lc, os.path.join(abs_output_dir, b"out2"))
 out_gz = rpath.RPath(lc, os.path.join(abs_output_dir, b"out.gz"))
 
-Time.setcurtime(1000000000)
-Time.setprevtime(999424113)
+Time.set_current_time(1000000000)
+Time.setprevtime_compat200(999424113)
 if os.name == "nt":
     prevtimestr = b"2001-09-02T02-48-33-07-00"
 else:

--- a/testing/timetest.py
+++ b/testing/timetest.py
@@ -24,7 +24,7 @@ class TimeTest(unittest.TestCase):
 
     def testConversion(self):
         """test timetostring and stringtotime"""
-        Time.setcurtime()
+        Time.set_current_time()
         self.assertIsInstance(Time.curtime, (float, int))
         self.assertIsInstance(Time.curtimestr, str)
         self.assertTrue(


### PR DESCRIPTION
- merge local and remote get_mirror_time functions of repo
- slightly improve get_increment_times and add repo shadow function
- rename repo.init_quoting to setup_quoting to clarify call during setup
- add repo.setup_paths to define default paths of a repository
- slightly clean-up the Time module
- deprecate Time.setprevtime and Time.setprevtime_local
- deprecate Time.setcurtime, replacing with Gloabals variables