### PR TITLE
Output logs as text instead of bytes

### DIFF
--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -110,26 +110,25 @@ class Logger:
     def log_to_term(self, message, verbosity):
         """Write message to stdout/stderr"""
         if verbosity <= 2 or Globals.server:
-            termfp = sys.stderr.buffer
+            termfp = sys.stderr
         else:
-            termfp = sys.stdout.buffer
+            termfp = sys.stdout
         if Globals.get_api_version() < 201:  # compat200
             tmpstr = self._format(message, self.term_verbosity)
-            termfp.write(_to_bytes(tmpstr, encoding=sys.stdout.encoding))
+            termfp.write(tmpstr)
         else:
             tmpstr = self._format(message, self.term_verbosity, verbosity)
             # if the verbosity is below 9 and the string isn't deemed
             # pre-formatted by newlines (we ignore the last character)
             if self.verbosity <= DEBUG and "\n" not in tmpstr[:-1]:
-                termfp.write(_to_bytes(
+                termfp.write(
                     textwrap.fill(
                         tmpstr, subsequent_indent=" " * 9,
                         break_long_words=False,
                         break_on_hyphens=False,
-                        width=shutil.get_terminal_size().columns - 1) + "\n",
-                    encoding=sys.stdout.encoding))
+                        width=shutil.get_terminal_size().columns - 1) + "\n")
             else:
-                termfp.write(_to_bytes(tmpstr, encoding=sys.stdout.encoding))
+                termfp.write(tmpstr)
 
     def conn(self, direction, result, req_num):
         """Log some data on the connection

--- a/tox.ini
+++ b/tox.ini
@@ -35,45 +35,45 @@ commands_pre =
 # also for sub-processes, like for "client/server" rdiff-backup
 	python -c 'with open("{envsitepackagesdir}/coverage.pth","w") as fd: fd.write("import coverage; coverage.process_startup()\n")'
 commands =
-	coverage run testing/action_backuprestore_test.py
-	coverage run testing/action_compare_test.py
-	coverage run testing/action_list_test.py
-	coverage run testing/action_regress_test.py
-	coverage run testing/action_remove_test.py
-	coverage run testing/action_test_test.py
-	coverage run testing/action_verify_test.py
-	coverage run testing/api_test.py
-	coverage run testing/location_map_filenames_test.py
-	coverage run testing/ctest.py
-	coverage run testing/timetest.py
-	coverage run testing/librsynctest.py
-	coverage run testing/statisticstest.py
-	coverage run testing/user_grouptest.py
-	coverage run testing/setconnectionstest.py
-	coverage run testing/iterfiletest.py
-	coverage run testing/longnametest.py
-	coverage run testing/robusttest.py
-	coverage run testing/connectiontest.py
-	coverage run testing/incrementtest.py
-	coverage run testing/hardlinktest.py
-	coverage run testing/eas_aclstest.py
-	coverage run testing/FilenameMappingtest.py
-	coverage run testing/fs_abilitiestest.py
-	coverage run testing/hashtest.py
-	coverage run testing/selectiontest.py
-	coverage run testing/metadatatest.py
-	coverage run testing/rpathtest.py
-	coverage run testing/rorpitertest.py
-	coverage run testing/rdifftest.py
-	coverage run testing/securitytest.py
-	coverage run testing/killtest.py
-	coverage run testing/backuptest.py
-	coverage run testing/comparetest.py
-	coverage run testing/regresstest.py
-	coverage run testing/restoretest.py
-	coverage run testing/cmdlinetest.py
-	coverage run testing/rdiffbackupdeletetest.py
-	coverage run testing/errorsrecovertest.py
+	coverage run testing/action_backuprestore_test.py --verbose --buffer
+	coverage run testing/action_compare_test.py --verbose --buffer
+	coverage run testing/action_list_test.py --verbose --buffer
+	coverage run testing/action_regress_test.py --verbose --buffer
+	coverage run testing/action_remove_test.py --verbose --buffer
+	coverage run testing/action_test_test.py --verbose --buffer
+	coverage run testing/action_verify_test.py --verbose --buffer
+	coverage run testing/api_test.py --verbose --buffer
+	coverage run testing/location_map_filenames_test.py --verbose --buffer
+	coverage run testing/ctest.py --verbose --buffer
+	coverage run testing/timetest.py --verbose --buffer
+	coverage run testing/librsynctest.py --verbose --buffer
+	coverage run testing/statisticstest.py --verbose --buffer
+	coverage run testing/user_grouptest.py --verbose --buffer
+	coverage run testing/setconnectionstest.py --verbose --buffer
+	coverage run testing/iterfiletest.py --verbose --buffer
+	coverage run testing/longnametest.py --verbose --buffer
+	coverage run testing/robusttest.py --verbose --buffer
+	coverage run testing/connectiontest.py --verbose --buffer
+	coverage run testing/incrementtest.py --verbose --buffer
+	coverage run testing/hardlinktest.py --verbose --buffer
+	coverage run testing/eas_aclstest.py --verbose --buffer
+	coverage run testing/FilenameMappingtest.py --verbose --buffer
+	coverage run testing/fs_abilitiestest.py --verbose --buffer
+	coverage run testing/hashtest.py --verbose --buffer
+	coverage run testing/selectiontest.py --verbose --buffer
+	coverage run testing/metadatatest.py --verbose --buffer
+	coverage run testing/rpathtest.py --verbose --buffer
+	coverage run testing/rorpitertest.py --verbose --buffer
+	coverage run testing/rdifftest.py --verbose --buffer
+	coverage run testing/securitytest.py --verbose --buffer
+	coverage run testing/killtest.py --verbose --buffer
+	coverage run testing/backuptest.py --verbose --buffer
+	coverage run testing/comparetest.py --verbose --buffer
+	coverage run testing/regresstest.py --verbose --buffer
+	coverage run testing/restoretest.py --verbose --buffer
+	coverage run testing/cmdlinetest.py --verbose --buffer
+	coverage run testing/rdiffbackupdeletetest.py --verbose --buffer
+	coverage run testing/errorsrecovertest.py --verbose --buffer
 	coverage run testing/rdb_arguments.py --verbose --buffer
 # can only work on OS/X TODO later
 #	coverage run testing/resourceforktest.py

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -30,4 +30,4 @@ commands_pre =
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =
-    python testing/roottest.py
+    python testing/roottest.py --verbose --buffer


### PR DESCRIPTION
FIX: allow --buffer option while testing by logging to terminal as string, closes #546