### PR TITLE
[DOC] Include both old and new CLI formats in examples

### DIFF
--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -6,7 +6,7 @@
 
 == Old vs. New Command Line Interface
 
-* Starting with `rdiff-backup` version 2.1, there have been two separate syntaxes for the command line interface, differentiated by the `--new` flag. Legacy CLI commands follow the syntax `rdiff-backup [options…​] [source…​] [destination…​]`, while the new CLI uses the syntax `rdiff-backup [options…​] action [sub-options…​] [locations…​]`. The functionality of the commands are the same, but for completeness the examples in this document will be given in both the old and new syntax side-by-side.
+* Starting with `rdiff-backup` version 2.1, there have been two separate syntaxes for the command line interface, differentiated by the `--new` flag. Legacy CLI commands follow the syntax `rdiff-backup [options…] [source…] [destination…]`, while the new CLI uses the syntax `rdiff-backup [global options…] action [action-specific options…] [locations…]`. The functionality of the commands are the same, but for completeness the examples in this document will be given in both the old and new syntax side-by-side.
 
 == Backing up
 

--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -13,48 +13,48 @@
 * Simplest case---backup local directory `foo` to local directory `bar`.
 `bar` will end up a copy of `foo`, except it will contain the directory foo/rdiff-backup-data, which will allow rdiff-backup to restore previous states.
 
-____
-`rdiff-backup foo bar`
+----
+rdiff-backup foo bar
 
-`rdiff-backup backup foo bar`
-____
+rdiff-backup backup foo bar
+----
 
 * Simple remote case---backup directory `/some/local-dir` to the directory `/whatever/remote-dir` on the machine hostname.net.
 It uses ssh to open the necessary pipe to the remote copy of rdiff-backup.
 Just like the above except one directory is on a remote computer.
 
-____
-`rdiff-backup /some/local-dir hostname.net::/whatever/remote-dir`
+----
+rdiff-backup /some/local-dir hostname.net::/whatever/remote-dir
 
-`rdiff-backup backup /some/local-dir hostname.net::/whatever/remote-dir`
-____
+rdiff-backup backup /some/local-dir hostname.net::/whatever/remote-dir
+----
 
 * This time the source directory is remote and the destination is local.
 Also, we have specified the username on the remote host (by default ssh will attempt to log you in with the same username you have on the local host).
 
-____
-`rdiff-backup user@hostname.net::/remote-dir local-dir`
+----
+rdiff-backup user@hostname.net::/remote-dir local-dir
 
-`rdiff-backup backup user@hostname.net::/remote-dir local-dir`
-____
+rdiff-backup backup user@hostname.net::/remote-dir local-dir
+----
 
 * It is even possible for both the source and destination directories to be on other machines.
 Below we have also added the `-v5` switch for greater verbosity (verbosity settings go from 0 to 9, with 3 as the default), and the `--print-statistics` switch so some statistics will be displayed at the end (even without this switch, the statistics will still be saved in the `rdiff-backup-data` directory).
 
-____
-`rdiff-backup -v5 --print-statistics user1@host1::/source-dir user2@host2::/dest-dir`
+----
+rdiff-backup -v5 --print-statistics user1@host1::/source-dir user2@host2::/dest-dir
 
-`rdiff-backup -v5 --print-statistics backup user1@host1::/source-dir user2@host2::/dest-dir`
-____
+rdiff-backup -v5 --print-statistics backup user1@host1::/source-dir user2@host2::/dest-dir
+----
 
 == Restoring
 
 * Suppose earlier we have run `rdiff-backup foo bar`, with both foo and bar local.
 We accidentally deleted `foo/dir` and now want to restore it from `bar/dir`.
 
-____
-`cp -a bar/dir foo/dir`
-____
+----
+cp -a bar/dir foo/dir
+----
 
 That's right, since rdiff-backup makes a mirror, we can retrieve files using standard commands like `cp`.
 
@@ -64,24 +64,24 @@ Of course, in all these examples it would be equally possible to have the source
 In this case we can't use `cp` to copying `host.net::remote-dir/file` to `local-dir/file` because they are on different machines.
 We can get rdiff-backup to restore the current version of that file using either of these::
 
-____
-`rdiff-backup --restore-as-of now host.net::/remote-dir/file local-dir/filerdiff-backup -r now host.net::/remote-dir/file local-dir/file`
+----
+rdiff-backup --restore-as-of now host.net::/remote-dir/file local-dir/filerdiff-backup -r now host.net::/remote-dir/file local-dir/file
 
-`rdiff-backup -r now host.net::/remote-dir/file local-dir/file`
+rdiff-backup -r now host.net::/remote-dir/file local-dir/file
 
-`rdiff-backup restore --at now host.net::/remote-dir/file local-dir/filerdiff-backup host.net::/remote-dir/file local-dir/file`
-____
+rdiff-backup restore --at now host.net::/remote-dir/file local-dir/filerdiff-backup host.net::/remote-dir/file local-dir/file
+----
 
 The `--restore-as-of` (or `-r` for short) switch (`restore` action on the new CLI) tells rdiff-backup to restore instead of back up, and the `now` option indicates the current time.
 
 * But the main advantage of rdiff-backup is that it keeps version history.
 This command restores `host.net::/remote-dir/file` as it was 10 days ago into a new location `/tmp/file`.
 
-____
-`rdiff-backup -r 10D host.net::/remote-dir/file /tmp/file`
+----
+rdiff-backup -r 10D host.net::/remote-dir/file /tmp/file
 
-`rdiff-backup restore --at 10D host.net::/remote-dir/file /tmp/file`
-____
+rdiff-backup restore --at 10D host.net::/remote-dir/file /tmp/file
+----
 
 Other acceptable time strings include `5m4s` (5 minutes and 4 seconds) and `2002-03-05` (March 5th, 2002).
 For more information, see the TIME FORMATS section of the manual page.
@@ -90,11 +90,11 @@ For more information, see the TIME FORMATS section of the manual page.
 Increment files are stored in `host.net::/remote-dir/rdiff-backup-data/increments` and hold the previous versions of changed files.
 If you specify one directly:
 
-____
-`rdiff-backup host.net::/remote-dir/rdiff-backup-data/increments/file.2003-03-05T12:21:41-07:00.diff.gz local-dir/file`
+----
+rdiff-backup host.net::/remote-dir/rdiff-backup-data/increments/file.2003-03-05T12:21:41-07:00.diff.gz local-dir/file
 
-`rdiff-backup restore host.net::/remote-dir/rdiff-backup-data/increments/file.2003-03-05T12:21:41-07:00.diff.gz local-dir/file`
-____
+rdiff-backup restore host.net::/remote-dir/rdiff-backup-data/increments/file.2003-03-05T12:21:41-07:00.diff.gz local-dir/file
+----
 
 rdiff-backup will tell from the filename that it is an rdiff-backup increment file and thus enter restore mode.
 Above the restored version is written to `local-dir/file`.
@@ -108,11 +108,11 @@ This section assumes that rdiff-backup has been used in the past to back up to `
 
 * This commands deletes all information concerning file versions which have not been current for 2 weeks:
 
-____
-`rdiff-backup --remove-older-than 2W host.net::/remote-dir`
+----
+rdiff-backup --remove-older-than 2W host.net::/remote-dir
 
-`rdiff-backup remove increments --older-than 2W host.net::/remote-dir`
-____
+rdiff-backup remove increments --older-than 2W host.net::/remote-dir
+----
 
 Note that an existing file which hasn't changed for a year will still be preserved.
 But a file which was deleted 15 days ago cannot be restored after this command is run.
@@ -121,11 +121,11 @@ But a file which was deleted 15 days ago cannot be restored after this command i
 The `20B` below tells rdiff-backup to only preserve information from the last 20 rdiff-backup sessions.
 (`nnB` syntax is only available in versions after 0.13.1.)
 
-____
-`rdiff-backup --remove-older-than 20B host.net::/remote-dir`
+----
+rdiff-backup --remove-older-than 20B host.net::/remote-dir
 
-`rdiff-backup remove increments --older-than 20B host.net::/remote-dir`
-____
+rdiff-backup remove increments --older-than 20B host.net::/remote-dir
+----
 
 == File selection with include/exclude options
 
@@ -135,11 +135,11 @@ See the man page for a list of all the options and their definitions.
 
 * In this example we exclude `/mnt/backup` to avoid an infinite loop.
 
-____
-`rdiff-backup --exclude /mnt/backup / /mnt/backup`
+----
+rdiff-backup --exclude /mnt/backup / /mnt/backup
 
-`rdiff-backup backup --exclude /mnt/backup / /mnt/backup`
-____
+rdiff-backup backup --exclude /mnt/backup / /mnt/backup
+----
 
 (Actually rdiff-backup can automatically detect simple loops like the one above.) This is just an example, in reality it would be important to exclude `/proc` as well.
 
@@ -148,40 +148,40 @@ We have excluded `/proc`, `/tmp`, and `/mnt`.
 `/proc` in particular should never be backed up.
 Also, the source directory happens to be remote.
 
-____
-`rdiff-backup --exclude /tmp --exclude /mnt --exclude /proc user@host.net::/ /backup/host.net`
+----
+rdiff-backup --exclude /tmp --exclude /mnt --exclude /proc user@host.net::/ /backup/host.net
 
-`rdiff-backup backup --exclude /tmp --exclude /mnt --exclude /proc user@host.net::/ /backup/host.net`
-____
+rdiff-backup backup --exclude /tmp --exclude /mnt --exclude /proc user@host.net::/ /backup/host.net
+----
 
 * Multiple include and exclude options take precedence in the order they are given.
 The following command would back up `/usr/local/bin` but not `/usr/bin`.
 
-____
-`rdiff-backup --include /usr/local --exclude /usr / host.net::/backup`
+----
+rdiff-backup --include /usr/local --exclude /usr / host.net::/backup
 
-`rdiff-backup backup --include /usr/local --exclude /usr / host.net::/backup`
-____
+rdiff-backup backup --include /usr/local --exclude /usr / host.net::/backup
+----
 
 * rdiff-backup uses rsync-like wildcards, where `**` matches any path and `*` matches any path without a `/` in it.
 Thus this command:
 
-____
-`rdiff-backup --include /usr/local --include /var --exclude '**' / /backup`
+----
+rdiff-backup --include /usr/local --include /var --exclude '**' / /backup
 
-`rdiff-backup backup --include /usr/local --include /var --exclude '**' / /backup`
-____
+rdiff-backup backup --include /usr/local --include /var --exclude '**' / /backup
+----
 
 backs up only the `/usr/local` and `/var` directories.
 The single quotes `''` are not part of rdiff-backup and are only used because many shells will expand `**`.
 
 * Here is a more complicated example:
 
-____
-`rdiff-backup --include '**txt' --exclude /usr/local/games --include /usr/local --exclude /usr --exclude /backup --exclude /proc / /backup`
+----
+rdiff-backup --include '**txt' --exclude /usr/local/games --include /usr/local --exclude /usr --exclude /backup --exclude /proc / /backup
 
-`rdiff-backup backup --include '**txt' --exclude /usr/local/games --include /usr/local --exclude /usr --exclude /backup --exclude /proc / /backup`
-____
+rdiff-backup backup --include '**txt' --exclude /usr/local/games --include /usr/local --exclude /usr --exclude /backup --exclude /proc / /backup
+----
 
 The above command will back up any file ending in `txt`, even `/usr/local/games/pong/scores.txt` because that include has highest precedence.
 The contents of the directory `/usr/local/bin` will get backed up, but not `/usr/share` or `/usr/local/games/pong`.
@@ -189,18 +189,18 @@ The contents of the directory `/usr/local/bin` will get backed up, but not `/usr
 * rdiff-backup can also accept a list of files to be backed up.
 If the file `include-list` contains these two lines:
 
-____
-    /var
-    /usr/bin/gzip
-____
+----
+/var
+/usr/bin/gzip
+----
 
 Then this command:
 
-____
-`rdiff-backup --include-filelist include-list --exclude '**' / /backup`
+----
+rdiff-backup --include-filelist include-list --exclude '**' / /backup
 
-`rdiff-backup backup --include-filelist include-list --exclude '**' / /backup`
-____
+rdiff-backup backup --include-filelist include-list --exclude '**' / /backup
+----
 
 would only back up the files `/var`, `/usr`, `/usr/bin`, and `/usr/bin/gzip`, but not `/var/log` or `/usr/bin/gunzip`.
 Note that this differs from the `--include` option, since `--include /var` would also match `/var/log`.
@@ -208,22 +208,22 @@ Note that this differs from the `--include` option, since `--include /var` would
 * The same file list can both include and exclude files.
 If we create a file called `include-list` that contains these lines:
 
-____
-    **txt
-    - /usr/local/games
-    /usr/local
-    - /usr
-    - /backup
-    - /proc
-____
+----
+**txt
+- /usr/local/games
+/usr/local
+- /usr
+- /backup
+- /proc
+----
 
 Then the following command will do exactly the same thing as the complicated example two above.
 
-____
-`rdiff-backup --include-globbing-filelist include-list / /backup`
+----
+rdiff-backup --include-globbing-filelist include-list / /backup
 
-`rdiff-backup backup --include-globbing-filelist include-list / /backup`
-____
+rdiff-backup backup --include-globbing-filelist include-list / /backup
+----
 
 Above we have used `--include-globbing-filelist` instead of `--include-filelist` so that the lines would be interpreted as if they were specified on the command line.
 Otherwise, for instance, `**txt` would be considered the name of a file, not a globbing string.
@@ -234,54 +234,54 @@ The following examples assume that you have run `rdiff-backup in-dir out-dir` in
 
 * This command finds all new or old files which contain the string `frobniz`.
 
-____
-`find out-dir -name '*frobniz*'`
-____
+----
+find out-dir -name '*frobniz*'
+----
 
 rdiff-backup doesn't obscure the names of files at all, so often using traditional tools work well.
 
 * Either of these equivalent commands lists the times of the available versions of the file `out-dir/file`.
 It may be useful if you need to restore an older version of `in-dir/file` but aren't sure which one.
 
-____
-`rdiff-backup --list-increments out-dir/filerdiff-backup -l out-dir/file`
+----
+rdiff-backup --list-increments out-dir/filerdiff-backup -l out-dir/file
 
-`rdiff-backup list increments out-dir/filerdiff-backup -l out-dir/file`
-____
+rdiff-backup list increments out-dir/filerdiff-backup -l out-dir/file
+----
 
 * The following command lists all the files under `out-dir/subdir` which has changed in the last 5 days.
 
-____
-`rdiff-backup --list-changed-since 5D out-dir/subdir`
+----
+rdiff-backup --list-changed-since 5D out-dir/subdir
 
-`rdiff-backup list files --changed-since 5D out-dir/subdir`
-____
+rdiff-backup list files --changed-since 5D out-dir/subdir
+----
 
 * This command lists all the files that were present in `out-dir/subdir` 5 days ago.
 This includes files that have not changed recently as well as those that have been deleted in the last 5 days.
 
-____
-`rdiff-backup --list-at-time 5D out-dir/subdir`
+----
+rdiff-backup --list-at-time 5D out-dir/subdir
 
-`rdiff-backup list files --at 5D out-dir/subdir`
-____
+rdiff-backup list files --at 5D out-dir/subdir
+----
 
 * rdiff-backup writes one statistics file per session to the `out-dir/rdiff-backup-data` directory.
 An average of the files can be displayed using the `--calculate-average` option and specifying the statistics files to use.
 
-____
-`rdiff-backup --calculate-average out-dir/rdiff-backup-data/session_statistics*`
+----
+rdiff-backup --calculate-average out-dir/rdiff-backup-data/session_statistics*
 
-`rdiff-backup calculate --method average out-dir/rdiff-backup-data/session_statistics*`
-____
+rdiff-backup calculate --method average out-dir/rdiff-backup-data/session_statistics*
+----
 
 == Miscellaneous other commands
 
 * If you are having problems connecting to a remote host, the `--test-server` command may be useful.
 This command simply verifies that there is a working rdiff-backup server on the remote side.
 
-____
-`rdiff-backup --test-server hostname.net::/ignored`
+----
+rdiff-backup --test-server hostname.net::/ignored
 
-`rdiff-backup test hostname.net::/ignored`
-____
+rdiff-backup test hostname.net::/ignored
+----

--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -4,6 +4,10 @@
 :toc:
 :toc-title: Sections
 
+== Old vs. New Command Line Interface
+
+* Starting with `rdiff-backup` version 2.1, there have been two separate syntaxes for the command line interface, differentiated by the `--new` flag. Legacy CLI commands follow the syntax `rdiff-backup [options…​] [source…​] [destination…​]`, while the new CLI uses the syntax `rdiff-backup [options…​] action [sub-options…​] [locations…​]`. The functionality of the commands are the same, but for completeness the examples in this document will be given in both the old and new syntax side-by-side.
+
 == Backing up
 
 * Simplest case---backup local directory `foo` to local directory `bar`.
@@ -11,14 +15,18 @@
 
 ____
 `rdiff-backup foo bar`
+
+`rdiff-backup backup foo bar`
 ____
 
 * Simple remote case---backup directory `/some/local-dir` to the directory `/whatever/remote-dir` on the machine hostname.net.
 It uses ssh to open the necessary pipe to the remote copy of rdiff-backup.
-Just like the above except one directory is on a remove computer.
+Just like the above except one directory is on a remote computer.
 
 ____
 `rdiff-backup /some/local-dir hostname.net::/whatever/remote-dir`
+
+`rdiff-backup backup /some/local-dir hostname.net::/whatever/remote-dir`
 ____
 
 * This time the source directory is remote and the destination is local.
@@ -26,6 +34,8 @@ Also, we have specified the username on the remote host (by default ssh will att
 
 ____
 `rdiff-backup user@hostname.net::/remote-dir local-dir`
+
+`rdiff-backup backup user@hostname.net::/remote-dir local-dir`
 ____
 
 * It is even possible for both the source and destination directories to be on other machines.
@@ -33,6 +43,8 @@ Below we have also added the `-v5` switch for greater verbosity (verbosity setti
 
 ____
 `rdiff-backup -v5 --print-statistics user1@host1::/source-dir user2@host2::/dest-dir`
+
+`rdiff-backup -v5 --print-statistics backup user1@host1::/source-dir user2@host2::/dest-dir`
 ____
 
 == Restoring
@@ -54,15 +66,21 @@ We can get rdiff-backup to restore the current version of that file using either
 
 ____
 `rdiff-backup --restore-as-of now host.net::/remote-dir/file local-dir/filerdiff-backup -r now host.net::/remote-dir/file local-dir/file`
+
+`rdiff-backup -r now host.net::/remote-dir/file local-dir/file`
+
+`rdiff-backup restore --at now host.net::/remote-dir/file local-dir/filerdiff-backup host.net::/remote-dir/file local-dir/file`
 ____
 
-The `--restore-as-of` (or `-r` for short) switch tells rdiff-backup to restore instead of back up, and the `now` option indicates the current time.
+The `--restore-as-of` (or `-r` for short) switch (`restore` action on the new CLI) tells rdiff-backup to restore instead of back up, and the `now` option indicates the current time.
 
 * But the main advantage of rdiff-backup is that it keeps version history.
 This command restores `host.net::/remote-dir/file` as it was 10 days ago into a new location `/tmp/file`.
 
 ____
 `rdiff-backup -r 10D host.net::/remote-dir/file /tmp/file`
+
+`rdiff-backup restore --at 10D host.net::/remote-dir/file /tmp/file`
 ____
 
 Other acceptable time strings include `5m4s` (5 minutes and 4 seconds) and `2002-03-05` (March 5th, 2002).
@@ -74,6 +92,8 @@ If you specify one directly:
 
 ____
 `rdiff-backup host.net::/remote-dir/rdiff-backup-data/increments/file.2003-03-05T12:21:41-07:00.diff.gz local-dir/file`
+
+`rdiff-backup restore host.net::/remote-dir/rdiff-backup-data/increments/file.2003-03-05T12:21:41-07:00.diff.gz local-dir/file`
 ____
 
 rdiff-backup will tell from the filename that it is an rdiff-backup increment file and thus enter restore mode.
@@ -90,6 +110,8 @@ This section assumes that rdiff-backup has been used in the past to back up to `
 
 ____
 `rdiff-backup --remove-older-than 2W host.net::/remote-dir`
+
+`rdiff-backup remove increments --older-than 2W host.net::/remote-dir`
 ____
 
 Note that an existing file which hasn't changed for a year will still be preserved.
@@ -101,6 +123,8 @@ The `20B` below tells rdiff-backup to only preserve information from the last 20
 
 ____
 `rdiff-backup --remove-older-than 20B host.net::/remote-dir`
+
+`rdiff-backup remove increments --older-than 20B host.net::/remote-dir`
 ____
 
 == File selection with include/exclude options
@@ -113,6 +137,8 @@ See the man page for a list of all the options and their definitions.
 
 ____
 `rdiff-backup --exclude /mnt/backup / /mnt/backup`
+
+`rdiff-backup backup --exclude /mnt/backup / /mnt/backup`
 ____
 
 (Actually rdiff-backup can automatically detect simple loops like the one above.) This is just an example, in reality it would be important to exclude `/proc` as well.
@@ -124,6 +150,8 @@ Also, the source directory happens to be remote.
 
 ____
 `rdiff-backup --exclude /tmp --exclude /mnt --exclude /proc user@host.net::/ /backup/host.net`
+
+`rdiff-backup backup --exclude /tmp --exclude /mnt --exclude /proc user@host.net::/ /backup/host.net`
 ____
 
 * Multiple include and exclude options take precedence in the order they are given.
@@ -131,6 +159,8 @@ The following command would back up `/usr/local/bin` but not `/usr/bin`.
 
 ____
 `rdiff-backup --include /usr/local --exclude /usr / host.net::/backup`
+
+`rdiff-backup backup --include /usr/local --exclude /usr / host.net::/backup`
 ____
 
 * rdiff-backup uses rsync-like wildcards, where `**` matches any path and `*` matches any path without a `/` in it.
@@ -138,6 +168,8 @@ Thus this command:
 
 ____
 `rdiff-backup --include /usr/local --include /var --exclude '**' / /backup`
+
+`rdiff-backup backup --include /usr/local --include /var --exclude '**' / /backup`
 ____
 
 backs up only the `/usr/local` and `/var` directories.
@@ -147,6 +179,8 @@ The single quotes `''` are not part of rdiff-backup and are only used because ma
 
 ____
 `rdiff-backup --include '**txt' --exclude /usr/local/games --include /usr/local --exclude /usr --exclude /backup --exclude /proc / /backup`
+
+`rdiff-backup backup --include '**txt' --exclude /usr/local/games --include /usr/local --exclude /usr --exclude /backup --exclude /proc / /backup`
 ____
 
 The above command will back up any file ending in `txt`, even `/usr/local/games/pong/scores.txt` because that include has highest precedence.
@@ -164,6 +198,8 @@ Then this command:
 
 ____
 `rdiff-backup --include-filelist include-list --exclude '**' / /backup`
+
+`rdiff-backup backup --include-filelist include-list --exclude '**' / /backup`
 ____
 
 would only back up the files `/var`, `/usr`, `/usr/bin`, and `/usr/bin/gzip`, but not `/var/log` or `/usr/bin/gunzip`.
@@ -185,6 +221,8 @@ Then the following command will do exactly the same thing as the complicated exa
 
 ____
 `rdiff-backup --include-globbing-filelist include-list / /backup`
+
+`rdiff-backup backup --include-globbing-filelist include-list / /backup`
 ____
 
 Above we have used `--include-globbing-filelist` instead of `--include-filelist` so that the lines would be interpreted as if they were specified on the command line.
@@ -207,12 +245,16 @@ It may be useful if you need to restore an older version of `in-dir/file` but ar
 
 ____
 `rdiff-backup --list-increments out-dir/filerdiff-backup -l out-dir/file`
+
+`rdiff-backup list increments out-dir/filerdiff-backup -l out-dir/file`
 ____
 
 * The following command lists all the files under `out-dir/subdir` which has changed in the last 5 days.
 
 ____
 `rdiff-backup --list-changed-since 5D out-dir/subdir`
+
+`rdiff-backup list files --changed-since 5D out-dir/subdir`
 ____
 
 * This command lists all the files that were present in `out-dir/subdir` 5 days ago.
@@ -220,6 +262,8 @@ This includes files that have not changed recently as well as those that have be
 
 ____
 `rdiff-backup --list-at-time 5D out-dir/subdir`
+
+`rdiff-backup list files --at 5D out-dir/subdir`
 ____
 
 * rdiff-backup writes one statistics file per session to the `out-dir/rdiff-backup-data` directory.
@@ -227,6 +271,8 @@ An average of the files can be displayed using the `--calculate-average` option 
 
 ____
 `rdiff-backup --calculate-average out-dir/rdiff-backup-data/session_statistics*`
+
+`rdiff-backup calculate --method average out-dir/rdiff-backup-data/session_statistics*`
 ____
 
 == Miscellaneous other commands
@@ -236,4 +282,6 @@ This command simply verifies that there is a working rdiff-backup server on the 
 
 ____
 `rdiff-backup --test-server hostname.net::/ignored`
+
+`rdiff-backup test hostname.net::/ignored`
 ____


### PR DESCRIPTION
There's a bit of a documentation gap where the new CLI has been in place since 2.1, but all of the examples on the documentation page are still written in the legacy syntax. This PR updates the examples to put legacy and modern commands side-by-side. The intention is that new users can learn the new syntax, and legacy users can still get documentation on the legacy syntax while also getting some guidance on how to update their commands.