### PR TITLE
Fix hardlink rotation and various issues

### DIFF
--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -136,7 +136,6 @@
 ** `.regress`
 ** `.remove_current_mirror`
 ** `.set_config`
-** `.set_rorp_cache`
 ** `.set_select`
 ** `.setup_paths`
 ** `.touch_current_mirror`

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -238,10 +238,6 @@ print_statistics = None
 # rdiff-backup-data dir.  These can sometimes take up a lot of space.
 file_statistics = 1
 
-# On the writer connection, the following will be set to the mirror
-# Select iterator.
-select_mirror = None
-
 # On the backup writer connection, holds the root incrementing branch
 # object.  Access is provided to increment error counts.
 ITRB = None

--- a/src/rdiff_backup/Rdiff.py
+++ b/src/rdiff_backup/Rdiff.py
@@ -18,7 +18,7 @@
 # 02110-1301, USA
 """Invoke rdiff utility to make signatures, deltas, or patch"""
 
-from . import Globals, log, rpath, hash, librsync
+from rdiff_backup import Globals, log, rpath, hash, librsync
 
 
 def get_signature(rp, blocksize=None):
@@ -54,7 +54,8 @@ def write_patched_fp(basis_fp, delta_fp, out_fp):
 
 
 def patch_local(rp_basis, rp_delta, outrp=None, delta_compressed=None):
-    """Patch routine that must be run locally, writes to outrp
+    """
+    Patch routine that must be run locally, writes to outrp
 
     This should be run local to rp_basis because it needs to be a real
     file (librsync may need to seek around in it).  If outrp is None,
@@ -62,7 +63,6 @@ def patch_local(rp_basis, rp_delta, outrp=None, delta_compressed=None):
 
     The return value is the close value of the delta, so it can be
     used to produce hashes.
-
     """
     assert rp_basis.conn is Globals.local_connection, (
         "This function must run locally and not over '{conn}'.".format(
@@ -79,17 +79,19 @@ def patch_local(rp_basis, rp_delta, outrp=None, delta_compressed=None):
 
 
 def _find_blocksize(file_len):
-    """Return a reasonable block size to use on files of length file_len
+    """
+    Return a reasonable block size to use on files of length file_len
 
     If the block size is too big, deltas will be bigger than is
     necessary.  If the block size is too small, making deltas and
     patching can take a really long time.
-
     """
-    if file_len < 4096:
+    if file_len < 10240:
         return 64  # set minimum of 64 bytes
-    else:  # Use square root, rounding to nearest 16
-        return int(pow(file_len, 0.5) / 16) * 16
+    else:
+        # Use square root, rounding to nearest 16
+        # somewhat faster than int(pow(file_len, 0.5) / 16) * 16
+        return (file_len >> (file_len.bit_length() // 2 + 4)) << 4
 
 
 def _write_via_tempfile(fp, rp):

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -325,7 +325,6 @@ def _set_allowed_requests(sec_class, sec_level):
             "_repo_shadow.RepoShadow.patch_and_increment",
             "_repo_shadow.RepoShadow.remove_current_mirror",
             "_repo_shadow.RepoShadow.set_config",
-            "_repo_shadow.RepoShadow.set_rorp_cache",
             "_repo_shadow.RepoShadow.touch_current_mirror",
             "_repo_shadow.RepoShadow.update_quoting",
         ])

--- a/src/rdiff_backup/backup.py
+++ b/src/rdiff_backup/backup.py
@@ -74,10 +74,9 @@ class SourceStruct:
         """
         sel = selection.Select(rpath)
         sel.parse_selection_args(tuplelist, filelists)
-        sel_iter = sel.set_iter()
+        sel_iter = sel.get_select_iter()
         cache_size = Globals.pipeline_max_length * 3  # to and from+leeway
         cls._source_select = rorpiter.CacheIndexable(sel_iter, cache_size)
-        Globals.set('select_mirror', sel_iter)
 
     # @API(SourceStruct.get_source_select, 200, 200)
     @classmethod
@@ -226,7 +225,7 @@ class DestinationStruct:
             """Get the combined iterator from the filesystem"""
             sel = selection.Select(rpath)
             sel.parse_rbdir_exclude()
-            return sel.set_iter()
+            return sel.get_select_iter()
 
         meta_manager = meta_mgr.get_meta_manager(True)
         if use_metadata:

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -553,7 +553,7 @@ class FSAbilities:
         off by default.
 
         """
-        for rp in selection.Select(dir_rp).set_iter():
+        for rp in selection.Select(dir_rp).get_select_iter():
             if rp.isreg():
                 try:
                     rfork = rp.append(b'..namedfork', b'rsrc')

--- a/src/rdiff_backup/librsync.py
+++ b/src/rdiff_backup/librsync.py
@@ -24,7 +24,7 @@ which is written in C.  The goal was to use C as little as possible...
 """
 
 import array
-from . import _librsync
+from rdiff_backup import _librsync
 
 blocksize = _librsync.RSM_JOB_BLOCKSIZE
 
@@ -117,11 +117,11 @@ class SigFile(LikeFile):
     """File-like object which incrementally generates a librsync signature"""
 
     def __init__(self, infile, blocksize=_librsync.RS_DEFAULT_BLOCK_LEN):
-        """SigFile initializer - takes basis file
+        """
+        SigFile initializer - takes basis file
 
         basis file only needs to have read() and close() methods.  It
         will be closed when we come to the end of the signature.
-
         """
         LikeFile.__init__(self, infile)
         try:

--- a/src/rdiff_backup/restore.py
+++ b/src/rdiff_backup/restore.py
@@ -254,9 +254,9 @@ class TargetStruct:
     def get_initial_iter(cls, target):
         """Return selector previously set with set_initial_iter"""
         if cls._select:
-            return cls._select.set_iter()
+            return cls._select.get_select_iter()
         else:
-            return selection.Select(target).set_iter()
+            return selection.Select(target).get_select_iter()
 
     # @API(TargetStruct.patch, 200, 200)
     @classmethod

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -181,8 +181,7 @@ class BackupAction(actions.BaseAction):
             self.repo.touch_current_mirror(Time.getcurtimestr())
 
         source_rpiter = self.dir.get_select()
-        self.repo.set_rorp_cache(source_rpiter, previous_time)
-        dest_sigiter = self.repo.get_sigs()
+        dest_sigiter = self.repo.get_sigs(source_rpiter, previous_time)
         source_diffiter = self.dir.get_diffs(dest_sigiter)
         self.repo.patch_or_increment(source_diffiter, previous_time)
 
@@ -204,15 +203,6 @@ class BackupAction(actions.BaseAction):
             return
         if rpout.path[:len(rpin.path) + 1] != rpin.path + b'/':
             return
-
-        # relative_rpout_comps = tuple(
-        #     rpout.path[len(rpin.path) + 1:].split(b'/'))
-        # relative_rpout = rpin.new_index(relative_rpout_comps)
-        # FIXME: this fails currently because the selection object isn't stored
-        #        but an iterable, the object not being pickable.
-        #        Related to issue #296
-        # if not Globals.select_mirror.Select(relative_rpout):
-        #     return
 
         log.Log("The target directory '{td}' may be contained in the "
                 "source directory '{sd}'. "

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -581,7 +581,7 @@ class FSAbilities:
         regular file is found, resource_fork support will be turned
         off by default.
         """
-        for rp in selection.Select(dir_rp).set_iter():
+        for rp in selection.Select(dir_rp).get_select_iter():
             if rp.isreg():
                 try:
                     rfork = rp.append(b'..namedfork', b'rsrc')

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -293,18 +293,12 @@ information in it.
                 self.base_dir.conn.restore.MirrorStruct.set_mirror_select(
                     target_rp, select_opts, *list(map(io.BytesIO, select_data)))
 
-    def set_rorp_cache(self, source_iter, use_increment):
-        """
-        Shadow function for RepoShadow.set_rorp_cache
-        """
-        return self._shadow.set_rorp_cache(self.base_dir, source_iter,
-                                           use_increment)
-
-    def get_sigs(self):
+    def get_sigs(self, source_iter, use_increment):
         """
         Shadow function for RepoShadow.get_sigs
         """
-        return self._shadow.get_sigs(self.base_dir, self.remote_transfer)
+        return self._shadow.get_sigs(self.base_dir, source_iter,
+                                     use_increment, self.remote_transfer)
 
     def patch_or_increment(self, source_diffiter, previous_time):
         """
@@ -314,8 +308,7 @@ information in it.
             return self._shadow.patch_and_increment(
                 self.base_dir, source_diffiter, self.incs_dir, previous_time)
         else:
-            return self._shadow.patch(
-                self.base_dir, source_diffiter)
+            return self._shadow.patch(self.base_dir, source_diffiter)
 
     def touch_current_mirror(self, current_time_str):
         """
@@ -438,7 +431,7 @@ information in it.
             mirror_select = selection.Select(mirror_base)
             if not self.restore_index:  # must exclude rdiff-backup-directory
                 mirror_select.parse_rbdir_exclude()
-            return mirror_select.set_iter()
+            return mirror_select.get_select_iter()
 
         def get_inc_select():
             """Return iterator of increment rpaths"""
@@ -447,7 +440,7 @@ information in it.
             for base_inc in inc_base.get_incfiles_list():
                 yield base_inc
             if inc_base.isdir():
-                inc_select = selection.Select(inc_base).set_iter()
+                inc_select = selection.Select(inc_base).get_select_iter()
                 for inc in inc_select:
                     yield inc
 

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -279,7 +279,7 @@ class Final(PathSetter):
 
         def delete_long(base_rp, length=100):
             """Delete filenames longer than length given"""
-            for rp in selection.Select(base_rp).set_iter():
+            for rp in selection.Select(base_rp).get_select_iter():
                 if len(rp.dirsplit()[1]) > length:
                     rp.delete()
 

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -43,7 +43,7 @@ if os.name == "nt":
 def Myrm(dirstring):
     """Run myrm on given directory string"""
     root_rp = rpath.RPath(Globals.local_connection, dirstring)
-    for rp in selection.Select(root_rp).set_iter():
+    for rp in selection.Select(root_rp).get_select_iter():
         if rp.isdir():
             rp.chmod(0o700)  # otherwise may not be able to remove
     path = root_rp.path
@@ -467,7 +467,7 @@ def _get_selection_functions(src_rp, dest_rp,
         src_select.parse_rbdir_exclude()
         dest_select.parse_rbdir_exclude()
 
-    return src_select.set_iter(), dest_select.set_iter()
+    return src_select.get_select_iter(), dest_select.get_select_iter()
 
 
 def compare_recursive(src_rp, dest_rp,

--- a/testing/hardlinktest.py
+++ b/testing/hardlinktest.py
@@ -40,7 +40,7 @@ class HardlinkTest(unittest.TestCase):
         """See if the partial inode dictionary is correct"""
         Globals.preserve_hardlinks = 1
         reset_hardlink_dicts()
-        for dsrp in selection.Select(self.hlinks_rp3).set_iter():
+        for dsrp in selection.Select(self.hlinks_rp3).get_select_iter():
             Hardlink.add_rorp(dsrp)
 
         self.assertEqual(len(list(Hardlink._inode_index.keys())), 3)
@@ -48,13 +48,13 @@ class HardlinkTest(unittest.TestCase):
     def testCompletedDict(self):
         """See if the hardlink dictionaries are built correctly"""
         reset_hardlink_dicts()
-        for dsrp in selection.Select(self.hlinks_rp1).set_iter():
+        for dsrp in selection.Select(self.hlinks_rp1).get_select_iter():
             Hardlink.add_rorp(dsrp)
             Hardlink.del_rorp(dsrp)
         self.assertEqual(Hardlink._inode_index, {})
 
         reset_hardlink_dicts()
-        for dsrp in selection.Select(self.hlinks_rp2).set_iter():
+        for dsrp in selection.Select(self.hlinks_rp2).get_select_iter():
             Hardlink.add_rorp(dsrp)
             Hardlink.del_rorp(dsrp)
         self.assertEqual(Hardlink._inode_index, {})

--- a/testing/location_map_hardlinks_test.py
+++ b/testing/location_map_hardlinks_test.py
@@ -1,0 +1,89 @@
+"""
+Test the handling of hardlinks with api version >= 201
+"""
+import os
+import unittest
+
+import commontest as comtst
+import fileset
+
+
+class LocationMapHardlinksTest(unittest.TestCase):
+    """
+    Test that rdiff-backup properly handles hardlinks
+    """
+
+    def setUp(self):
+        self.base_dir = os.path.join(comtst.abs_test_dir,
+                                     b"location_map_hardlinks")
+        self.from1_struct = {
+            "from1": {"subs": {
+                "hardlink1": {"content": "initial"},
+                "hardlink2": {"link": "hardlink1"},
+                "hardlink3": {"link": "hardlink1"},
+            }}
+        }
+        self.from1_path = os.path.join(self.base_dir, b"from1")
+        fileset.create_fileset(self.base_dir, self.from1_struct)
+        fileset.remove_fileset(self.base_dir, {"bak": {}})
+        fileset.remove_fileset(self.base_dir, {"to1": {}})
+        self.bak_path = os.path.join(self.base_dir, b"bak")
+        self.to1_path = os.path.join(self.base_dir, b"to1")
+        self.success = False
+
+    def test_location_map_hardlinks_rotate(self):
+        """
+        verify that hardlinked files can be rotated, see issue #272
+        i.e. first one removed and new one added.
+        """
+        # backup a 1st time
+        self.assertEqual(comtst.rdiff_backup_action(
+            True, True, self.from1_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "10000"),
+            b"backup", ()), 0)
+
+        # kind of rotate the hard linked file
+        os.remove(os.path.join(self.from1_path, b'hardlink1'))
+        os.link(os.path.join(self.from1_path, b'hardlink3'),
+                os.path.join(self.from1_path, b'hardlink4'))
+
+        # backup a 2nd time
+        self.assertEqual(comtst.rdiff_backup_action(
+            True, True, self.from1_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "20000"),
+            b"backup", ()), 0)
+
+        # verify that the files still have the same inode in the repo
+        self.assertEqual(
+            os.lstat(os.path.join(self.bak_path, b'hardlink2')).st_ino,
+            os.lstat(os.path.join(self.bak_path, b'hardlink3')).st_ino)
+        self.assertEqual(
+            os.lstat(os.path.join(self.bak_path, b'hardlink3')).st_ino,
+            os.lstat(os.path.join(self.bak_path, b'hardlink4')).st_ino)
+
+        # restore the hardlinked files
+        self.assertEqual(comtst.rdiff_backup_action(
+            True, True, self.bak_path, self.to1_path,
+            ("--api-version", "201"), b"restore", ()), 0)
+
+        # verify that the files have been properly restored with same inodes
+        self.assertEqual(
+            os.lstat(os.path.join(self.to1_path, b'hardlink2')).st_ino,
+            os.lstat(os.path.join(self.to1_path, b'hardlink3')).st_ino)
+        self.assertEqual(
+            os.lstat(os.path.join(self.to1_path, b'hardlink3')).st_ino,
+            os.lstat(os.path.join(self.to1_path, b'hardlink4')).st_ino)
+
+        # all tests were successful
+        self.success = True
+
+    def tearDown(self):
+        # we clean-up only if the test was successful
+        if self.success:
+            fileset.remove_fileset(self.base_dir, self.from1_struct)
+            fileset.remove_fileset(self.base_dir, {"bak": {}})
+            fileset.remove_fileset(self.base_dir, {"to1": {}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/metadatatest.py
+++ b/testing/metadatatest.py
@@ -79,7 +79,7 @@ class MetadataTest(unittest.TestCase):
         self.make_temp()
         rootrp = rpath.RPath(Globals.local_connection,
                              os.path.join(old_test_dir, b"bigdir"))
-        rpath_iter = selection.Select(rootrp).set_iter()
+        rpath_iter = selection.Select(rootrp).get_select_iter()
 
         start_time = time.time()
         mf = stdattr.AttrFile(temprp, 'w')
@@ -142,7 +142,7 @@ class MetadataTest(unittest.TestCase):
         # the following 3 lines make sure that we ignore incorrect files
         sel = selection.Select(rootrp)
         sel.parse_selection_args((), ())
-        rps = list(sel.set_iter())
+        rps = list(sel.get_select_iter())
 
         self.assertFalse(temprp.lstat())
         write_mf = stdattr.AttrFile(temprp, 'w')
@@ -196,7 +196,7 @@ class MetadataTest(unittest.TestCase):
                                             stdattr.get_plugin_class())
             sel = selection.Select(rp)
             sel.parse_selection_args((), ())  # make sure incorrect files are filtered out
-            for rorp in sel.set_iter():
+            for rorp in sel.get_select_iter():
                 metawriter.write_object(rorp)
             metawriter.close()
 
@@ -204,7 +204,7 @@ class MetadataTest(unittest.TestCase):
             sel = selection.Select(rootrp)
             sel.parse_selection_args((), ())  # make sure incorrect files are filtered out
             self.assertTrue(iter_equal(
-                sel.set_iter(), man._get_meta_main_at_time(time, None)))
+                sel.get_select_iter(), man._get_meta_main_at_time(time, None)))
 
         self.make_temp()
         Globals.rbdir = tempdir

--- a/testing/rorpitertest.py
+++ b/testing/rorpitertest.py
@@ -125,9 +125,9 @@ class ITRBadder2(rorpiter.ITRBranch):
 
     def can_fast_process(self, index):
         if len(index) == 3:
-            return 1
+            return True
         else:
-            return None
+            return False
 
     def fast_process_file(self, index):
         self.total += index[0] + index[1] + index[2]

--- a/testing/selectiontest.py
+++ b/testing/selectiontest.py
@@ -348,7 +348,7 @@ class ParseSelectionArgsTest(unittest.TestCase):
         self.Select.parse_selection_args(tuplelist, self.remake_filelists(filelists))
         self.assertTrue(
             iter_equal(iter_map(lambda dsrp: dsrp.index,
-                                self.Select.set_iter()),
+                                self.Select.get_select_iter()),
                        map(tuple_fsencode, indices), verbose=1))
 
     def remake_filelists(self, filelist):

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands =
 	coverage run testing/action_verify_test.py --verbose --buffer
 	coverage run testing/api_test.py --verbose --buffer
 	coverage run testing/location_map_filenames_test.py --verbose --buffer
+	coverage run testing/location_map_hardlinks_test.py --verbose --buffer
 	coverage run testing/ctest.py --verbose --buffer
 	coverage run testing/timetest.py --verbose --buffer
 	coverage run testing/librsynctest.py --verbose --buffer


### PR DESCRIPTION
- get rid of Globals.select_mirror which wasn't used anymore
- rename select.set_iter to select.get_select_iter and simplify function
- make Rdiff._find_blocksize slightly faster by using bitwise shift

DEV: remove RepoShadow.set_rorp_cache from API, make internal to simplify

CHG: (API 201 only) no more increments are created for files where only metadata changed, this spares some disk space and inodes, thanks to rknichols for the idea

FIX: (API 201 only) when removing the first hardlink and adding a new one, all hardlinks remain linked together in repo, closes #272