### PR TITLE
Do not compress metadata files when no compression

### DIFF
--- a/src/rdiffbackup/meta/__init__.py
+++ b/src/rdiffbackup/meta/__init__.py
@@ -208,7 +208,8 @@ class FlatFile:
         """
         return cls._is_main
 
-    def __init__(self, rp_base, mode, check_path=1, compress=1, callback=None):
+    def __init__(self, rp_base, mode, check_path=1,
+                 compress=None, callback=None):
         """
         Open rp (or rp+'.gz') for reading ('r') or writing ('w')
 
@@ -219,14 +220,17 @@ class FlatFile:
         self.callback = callback
         self._record_buffer = []
         if check_path:
-            if (rp_base.isincfile()
+            if not (rp_base.isincfile()
                     and rp_base.getincbase_bname() == self._prefix):
-                compress = 1
-            else:
                 log.Log.FatalError(
                     "Checking the path '{pa}' went wrong.".format(pa=rp_base))
         if mode == 'r' or mode == 'rb':
             self.rp = rp_base
+            if compress is None:
+                if self.rp.isinccompressed():
+                    compress = True
+                else:
+                    compress = False
             self.fileobj = self.rp.open("rb", compress)
         elif mode == 'w' or mode == 'wb':
             if compress and check_path and not rp_base.isinccompressed():

--- a/src/rdiffbackup/meta_mgr.py
+++ b/src/rdiffbackup/meta_mgr.py
@@ -123,8 +123,12 @@ class Manager:
         def callback(rp):
             temprp[0] = rp
 
+        # Before API 201, metafiles couldn't be compressed
         writer = self._meta_main_class(
-            temprp[0], 'wb', check_path=0, callback=callback)
+            temprp[0], 'wb',
+            compress=(Globals.compression
+                      or Globals.get_api_version() < 201),
+            check_path=0, callback=callback)
         for rorp in self._get_meta_main_at_time(regress_time, None):
             writer.write_object(rorp)
         writer.close()
@@ -191,7 +195,11 @@ class Manager:
         assert rp.isincfile(), (
             "Path '{irp}' must be an increment file.".format(irp=rp))
         if meta_class.is_active() or force:
-            return meta_class(rp, 'w', callback=self._add_incrp)
+            # Before API 201, metafiles couldn't be compressed
+            return meta_class(rp, 'w',
+                              compress=(Globals.compression
+                                        or Globals.get_api_version() < 201),
+                              callback=self._add_incrp)
         else:
             return None
 


### PR DESCRIPTION
FIX: (API 201 only) do not compress metadata files if the --no-compression option is given, BEWARE that such a repo can't be read by rdiff-backup 2.0, closes #402

I changed a bit my opinion and pushed the change already, but it does only apply to version 201 of the API, so that people can decide to keep their old repo version. Also with the old API version, repos with uncompressed metadata can be read (but not written).