### PR TITLE
Fix useless warning about enforced quoting

### DIFF
--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -888,11 +888,12 @@ class BackupSetGlobals(SetGlobals):
                 actual_ctq = suggested_ctq
             else:
                 actual_ctq = Globals.chars_to_quote
-                log.Log("File system at '{fs}' suggested quoting '{sq}' but "
-                        "override quoting '{oq}' will be used. "
-                        "Assuming you know what you are doing".format(
-                            fs=ctq_rp, sq=suggested_ctq, oq=actual_ctq),
-                        log.NOTE)
+                if actual_ctq != suggested_ctq:
+                    log.Log("File system at '{fs}' suggested quoting '{sq}' "
+                            "but override quoting '{oq}' will be used. "
+                            "Assuming you know what you are doing".format(
+                                fs=ctq_rp, sq=suggested_ctq, oq=actual_ctq),
+                            log.NOTE)
             ctq_rp.write_bytes(actual_ctq)
             return actual_ctq
 
@@ -911,8 +912,8 @@ class BackupSetGlobals(SetGlobals):
         else:
             actual_ctq = Globals.chars_to_quote  # Globals override
             if actual_ctq != suggested_ctq:
-                log.Log("File system at '{fs}' suggested quoting '{sq}' but "
-                        "override quoting '{oq}' will be used. "
+                log.Log("File system at '{fs}' suggested quoting '{sq}' "
+                        "but override quoting '{oq}' will be used. "
                         "Assuming you know what you are doing".format(
                             fs=ctq_rp, sq=suggested_ctq, oq=actual_ctq),
                         log.NOTE)

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -957,11 +957,12 @@ class Dir2RepoSetGlobals(SetGlobals):
                 actual_ctq = suggested_ctq
             else:
                 actual_ctq = Globals.chars_to_quote
-                log.Log("File system at '{fs}' suggested quoting '{sq}' but "
-                        "override quoting '{oq}' will be used. "
-                        "Assuming you know what you are doing".format(
-                            fs=repo, sq=suggested_ctq, oq=actual_ctq),
-                        log.NOTE)
+                if actual_ctq != suggested_ctq:
+                    log.Log("File system at '{fs}' suggested quoting '{sq}' "
+                            "but override quoting '{oq}' will be used. "
+                            "Assuming you know what you are doing".format(
+                                fs=repo, sq=suggested_ctq, oq=actual_ctq),
+                            log.NOTE)
             repo.set_chars_to_quote(actual_ctq)
             return actual_ctq
 
@@ -978,8 +979,8 @@ class Dir2RepoSetGlobals(SetGlobals):
         else:
             actual_ctq = Globals.chars_to_quote  # Globals override
             if actual_ctq != suggested_ctq:
-                log.Log("File system at '{fs}' suggested quoting '{sq}' but "
-                        "override quoting '{oq}' will be used. "
+                log.Log("File system at '{fs}' suggested quoting '{sq}' "
+                        "but override quoting '{oq}' will be used. "
                         "Assuming you know what you are doing".format(
                             fs=repo, sq=suggested_ctq, oq=actual_ctq),
                         log.NOTE)


### PR DESCRIPTION
FIX: rdiff-backup would complain about enforced quoting overriding suggested quoting even though they were the same