### PR TITLE
Replace CentOS8 with CentOS 8 stream in Vagrant config

### DIFF
--- a/tools/windows/Vagrantfile
+++ b/tools/windows/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "samba", autostart: false do |samba|
-    samba.vm.box = "centos/8"
+    samba.vm.box = "centos/stream8"
   end
 
   # WARNING: if following line is removed, Vagrant seems to act like it would


### PR DESCRIPTION
Because CentOS 8 isn't supported / updated anymore

A one-liner to review (or not).