### PR TITLE
Fix issue with null device on Samba share

### DIFF
--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -375,6 +375,9 @@ The list might grow but issues are currently known with especially slow combinat
 * "complex" file systems on a NAS (e.g. ZFS on SMB or NFS)
 * SSHFS
 
+NOTE: using a Samba/SMB/CIFS share in version `vers=1.0` also causes issues, because features, like ACL support, are not properly detected.
+If you get a lot of exceptions '[Errno 13] Permission denied' with info verbosity, you're probably impacted and might want to change the protocol version.
+
 == How to backup safely from case aware to case aware file system?
 
 File systems like VFAT or NTFS are what I call case aware file systems:

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1239,13 +1239,11 @@ class RPath(RORPath):
         try:
             self.conn.os.mknod(self.path, mode,
                                self.conn.os.makedev(major, minor))
-        except (OSError, AttributeError) as e:
-            if isinstance(e, AttributeError) or e.errno == errno.EPERM:
-                # AttributeError will be raised by Python 2.2, which
-                # doesn't have os.mknod
-                log.Log("unable to mknod device file {df} - "
-                        "using touch instead".format(df=self), log.INFO)
-                self.touch()
+        except OSError as exc:
+            log.Log("Unable to mknod device file '{df}' due to "
+                    "exception '{ex}', using touch instead".format(
+                        df=self, ex=exc), log.INFO)
+            self.touch()
         self.setdata()
 
     def fsync(self, fp=None):

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -334,13 +334,10 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
     try:
         acl.applyto(rp.path)
     except OSError as exc:
-        if exc.errno == errno.EOPNOTSUPP:
-            log.Log(
-                "Unable to set ACL on path {pa} due to exception '{ex}'".format(
-                    pa=rp, ex=exc), log.INFO)
-            return
-        else:
-            raise
+        log.Log(
+            "Unable to set ACL on path {pa} due to exception '{ex}'".format(
+                pa=rp, ex=exc), log.INFO)
+        return
 
     if rp.isdir():
         if default_entry_list:


### PR DESCRIPTION
The issue was due to using an outdated version of the protocol, but still, the code wasn't perfect.
FIX: ignore failing creation of a device and applying of ACLs in all circumstances, makes rdiff-backup more robust on CIFSv1, closes #678

@rrendec you might want to review