### PR TITLE
Fix comparaison code inconsistency

### DIFF
--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -690,7 +690,8 @@ Also note that they can be combined, so that for example a return code 3 might b
 0 - OK:: the action was completely successful
 1 - ERROR:: something fatal happened, the whole action failed
 2 - WARNING:: any kind of unexpected behavior without complete failure
-4 - FILE:: the action failed on a single file (or more), but it succeeded overall
+4 - FILE ERROR:: the action failed on a single file (or more), but it wasn't the reason for a complete failure
+8 - FILE WARNING:: the action stumbled on a single file (or more), or detected differences in a comparaison
 
 == BUGS
 

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -61,7 +61,8 @@ api_version = {
 RET_CODE_OK = 0  # everything is fine
 RET_CODE_ERR = 1  # some fatal error happened, the whole action failed
 RET_CODE_WARN = 2  # any kind of unexpected issue without complete failure
-RET_CODE_FILE = 4  # a single file (or more) failure
+RET_CODE_FILE_ERR = 4  # a single file (or more) failure
+RET_CODE_FILE_WARN = 8  # a single file (or more) warning or difference
 
 # This determines how many bytes to read at a time when copying
 blocksize = 131072

--- a/src/rdiff_backup/Main.py
+++ b/src/rdiff_backup/Main.py
@@ -111,8 +111,12 @@ def _main_run(arglist, security_override=False):
         log.Log("Action {ac} emitted warnings, "
                 "see previous messages for details".format(
                     ac=parsed_args.action), log.WARNING)
-    if ret_val & Globals.RET_CODE_FILE:
+    if ret_val & Globals.RET_CODE_FILE_ERR:
         log.Log("Action {ac} failed on one or more files, "
+                "see previous messages for details".format(
+                    ac=parsed_args.action), log.WARNING)
+    if ret_val & Globals.RET_CODE_FILE_WARN:
+        log.Log("Action {ac} emitted warnings on one or more files, "
                 "see previous messages for details".format(
                     ac=parsed_args.action), log.WARNING)
 

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -87,7 +87,7 @@ class CompareAction(actions.BaseAction):
         if return_code & Globals.RET_CODE_ERR:
             return return_code
 
-        return_code = self.repo.setup()
+        return_code = self.repo.setup(self.dir)
         if return_code & Globals.RET_CODE_ERR:
             return return_code
 
@@ -190,11 +190,11 @@ class CompareAction(actions.BaseAction):
                                  explicit_start=True, explicit_end=True))
         if not changed_files_found:
             log.Log("No changes found. Directory matches backup data", log.NOTE)
-            return 0
+            return Globals.RET_CODE_OK
         else:
             log.Log("Directory has {fd} file differences to backup".format(
                 fd=changed_files_found), log.WARNING)
-            return 1
+            return Globals.RET_CODE_FILE_WARN
 
 
 def get_plugin_class():

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -931,7 +931,8 @@ class Dir2RepoSetGlobals(SetGlobals):
 
         if self.src_fsa.case_sensitive and not self.dest_fsa.case_sensitive:
             ctq.append(b"A-Z")  # Quote upper case
-        if not self.dest_fsa.extended_filenames:
+        # on a read-only file system, the variable would be None, to be ignored
+        if self.dest_fsa.extended_filenames is False:
             ctq.append(b'\000-\037')  # Quote 0 - 31
             ctq.append(b'\200-\377')  # Quote non-ASCII characters 0x80 - 0xFF
         if self.dest_fsa.win_reserved_filenames:

--- a/testing/action_compare_test.py
+++ b/testing/action_compare_test.py
@@ -7,6 +7,8 @@ import unittest
 import commontest as comtst
 import fileset
 
+from rdiff_backup import Globals
+
 
 class ActionCompareTest(unittest.TestCase):
     """
@@ -58,10 +60,10 @@ class ActionCompareTest(unittest.TestCase):
     def test_action_compare(self):
         """test different ways of comparing directories"""
         # first try without date
-        self.assertNotEqual(comtst.rdiff_backup_action(
+        self.assertEqual(comtst.rdiff_backup_action(
             False, True, self.from1_path, self.bak_path,
             ("--api-version", "201"),
-            b"compare", ("--method", "meta")), 0)
+            b"compare", ("--method", "meta")), Globals.RET_CODE_FILE_WARN)
         self.assertEqual(comtst.rdiff_backup_action(
             True, False, self.from2_path, self.bak_path,
             ("--api-version", "201"),
@@ -74,16 +76,16 @@ class ActionCompareTest(unittest.TestCase):
             False, True, self.from1_path, self.bak_path,
             ("--api-version", "201"),
             b"compare", ("--at", "10000")), 0)
-        self.assertNotEqual(comtst.rdiff_backup_action(
+        self.assertEqual(comtst.rdiff_backup_action(
             True, False, self.from2_path, self.bak_path,
             ("--api-version", "201"),
-            b"compare", ("--at", "15000")), 0)
+            b"compare", ("--at", "15000")), Globals.RET_CODE_FILE_WARN)
 
         # then try to compare with hashes
-        self.assertNotEqual(comtst.rdiff_backup_action(
+        self.assertEqual(comtst.rdiff_backup_action(
             False, True, self.from1_path, self.bak_path,
             ("--api-version", "201"),
-            b"compare", ("--method", "hash")), 0)
+            b"compare", ("--method", "hash")), Globals.RET_CODE_FILE_WARN)
         self.assertEqual(comtst.rdiff_backup_action(
             True, False, self.from2_path, self.bak_path,
             ("--api-version", "201"),
@@ -100,10 +102,10 @@ class ActionCompareTest(unittest.TestCase):
 """)
 
         # then try to compare full
-        self.assertNotEqual(comtst.rdiff_backup_action(
+        self.assertEqual(comtst.rdiff_backup_action(
             False, True, self.from1_path, self.bak_path,
             ("--api-version", "201"),
-            b"compare", ("--method", "full")), 0)
+            b"compare", ("--method", "full")), Globals.RET_CODE_FILE_WARN)
         self.assertEqual(comtst.rdiff_backup_action(
             True, False, self.from1_path, self.bak_path,
             ("--api-version", "201"),


### PR DESCRIPTION
DEV: use file system object for two file systems in comparaison action, closes #643

DEV: split RET_CODE_FILE in RET_CODE_FILE_ERR AND _WARN so that file warnings can be used to detect comparaison differences

A purely internal change to make code slightly more consistent.