### PR TITLE
[DOC] Add notes about old Windows version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -136,10 +136,14 @@ ARM/MIPS/PowerPC/etc,   but also if the pip3 installation fails with `+include [
 
 === Windows
 
-Just download and unpack the file `rdiff-backup-VERSION.win32exe.zip` available as _asset_ attached to one of the releases available in the https://github.com/rdiff-backup/rdiff-backup/releases[releases section] and drop the binary `rdiff-backup.exe` somewhere in your PATH and it should work, as it comes with all dependencies included.
+Just download and unpack the file `rdiff-backup-VERSION.win64exe.zip` (or win32 if need be).
+It is available as _asset_ attached to one of the releases available in the https://github.com/rdiff-backup/rdiff-backup/releases[releases section].
+Then drop the binary `rdiff-backup.exe` somewhere in your PATH and it should work, as it comes with all dependencies included.
+
+NOTE: starting with rdiff-backup 2.1.1 embedding Python 3.10, rdiff-backup https://www.python.org/downloads/windows/[cannot be used on Windows 7 or earlier].
 
 For remote operations, you will need to have an SSH package installed.
-We recommand using OpenSSH from http://www.mls-software.com/opensshd.html
+The standard one provided by Microsoft is probably your safest choice, else we recommend using OpenSSH from http://www.mls-software.com/opensshd.html[mls-software.com].
 
 == BASIC USAGE
 

--- a/docs/Windows-README.adoc
+++ b/docs/Windows-README.adoc
@@ -30,6 +30,8 @@ ____
 
 == Additional Issues
 
+=== include and exclude paths
+
 Currently, _rdiff-backup_'s `--include` and `--exclude` options do not support Windows paths with `\` as the directory separator.
 Instead, it is necessary to use `/` which is the Unix directory separator.
 
@@ -53,6 +55,25 @@ Follow this example:
  > rdiff-backup.exe --include c:\\/foo --exclude c:\\/** c:\/ c:\bar
 
 The `\\` is necessary in the `--include` and `--exclude` options because those options permit regular-expressions, and `\` is the escape character in regular-expressions, and thus needs to be escaped itself.
+
+=== Too old version of Windows
+
+If trying to start rdiff-backup, you get a dialog:
+
+____
+The program can't start because api-ms-win-core-path-l1-1-0.dll is missing from your computer.
+Try reinstalling the program to fix this problem.
+____
+
+And then on the command line something like:
+
+____
+Error loading Python DLL 'C:\Users\myuser\AppData\Local\Temp\_MEI395202\python39.dll
+LoadLibrary: The specified module could not be found.
+____
+
+Then you're most probably running a version of Windows not supported by the version of Python embedded in `rdiff-backup.exe`.
+The release notes and/or the installation instructions should give you the necessary information, else check the https://www.python.org/downloads/windows/[Python for Windows download page].
 
 == Troubleshooting
 


### PR DESCRIPTION
CHG: rdiff-backup doesn't support (or even work) on Windows 7 and older

DOC: add note about old versions of Windows not being supported due to Python support matrix, closes #715