### PR TITLE
Update versions of different dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,8 @@ defaults:
     shell: bash
 
 env:
-  WIN_PYTHON_VERSION: 3.9.1
-  WIN_LIBRSYNC_VERSION: v2.2.1
+  WIN_PYTHON_VERSION: 3.10.7
+  WIN_LIBRSYNC_VERSION: v2.3.2
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # we could do it also as matrix but it takes longer
-        #python-version: [3.9,3.8,3.7,3.6]
+        #python-version: [3.10,3.9,3.8,3.7]
         #--- Build and deploy Linux wheels using manylinux containers ---
         # - build manylinux2010 (and manylinux1) x64
         # - build manylinux2010 i686
@@ -46,7 +46,7 @@ jobs:
           if [[ ${{ matrix.many-linux }} != *64 ]]; then PRE_CMD=linux32; fi
           #py=$(echo ${{ matrix.python-version }} | tr -d .)
           plat=manylinux${{ matrix.many-linux }}
-          $PRE_CMD /ws/tools/build_wheels.sh /ws ${plat} /opt/python/cp3{9,8,7,6}*/bin
+          $PRE_CMD /ws/tools/build_wheels.sh /ws ${plat} /opt/python/cp3{10,9,8,7}*/bin
     - name: Upload wheel artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9,3.8,3.7,3.6]
+        python-version: ["3.10",3.9,3.8,3.7]
     steps:
     - name: skip workflow if only docs PR
       id: skip-docs # id used for referencing step

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 env:
-  WIN_PYTHON_VERSION: 3.10.4
+  WIN_PYTHON_VERSION: 3.10.7
   WIN_LIBRSYNC_VERSION: v2.3.2
 
 jobs:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -194,7 +194,8 @@ The prefixes are to be understood as follows, in roughly decreasing order of imp
 
 === Changes
 
-* FIX: 64 bits version compiled with PyInstaller for Windows couldn't       find its module rdiff_backup, closes #555
+* FIX: 64 bits version compiled with PyInstaller for Windows couldn't
+       find its module rdiff_backup, closes #555
 
 === Authors
 
@@ -204,77 +205,135 @@ The prefixes are to be understood as follows, in roughly decreasing order of imp
 
 === Changes
 
-* CHG: Add no-compression defaults for videos .webm and tar       zStandart-compressed files .tzst
-* CHG: depend on importlib-metadata instead of setuptools to get       rdiff-backup veersion, closes #418
-* CHG: man page rdiff-backup-old(1) describes the old CLI,       rdiff-backup(1) the new one
-* CHG: option --test-server will test all servers even if one fails,       returning 1 in such case, 2 if the parameters were incorrect, output       has also slightly changed.
-* CHG: option --version outputs extended version information when used       in API versions above 200
-* CHG: Pickle protocol raised from 1 to 4, it shouldn't impact older       versions of rdiff-backup as protocol 4 is known since Python 3.4 and       the protocol version is recognized automatically on the receiving end
-* CHG: rdiff-backup now supports the newly released Python 3.9 and       stops supporting the obsolete Python 3.5.
-* CHG: restoring a specific increment requires now the use of       '--restore' parameter
-* CHG: the host placeholder in the remote schema is now '\{h}', '%s' is       deprecated.
-* CHG: the old command line interface without explicit actions is       considered deprecated
-* CHG: the Windows build uses Python 3.9 instead of Python 3.7 (nobody       should notice)
+* CHG: Add no-compression defaults for videos .webm and tar
+       zStandart-compressed files .tzst
+* CHG: depend on importlib-metadata instead of setuptools to get
+       rdiff-backup veersion, closes #418
+* CHG: man page rdiff-backup-old(1) describes the old CLI,
+       rdiff-backup(1) the new one
+* CHG: option --test-server will test all servers even if one fails,
+       returning 1 in such case, 2 if the parameters were incorrect, output
+       has also slightly changed.
+* CHG: option --version outputs extended version information when used
+       in API versions above 200
+* CHG: Pickle protocol raised from 1 to 4, it shouldn't impact older
+       versions of rdiff-backup as protocol 4 is known since Python 3.4 and
+       the protocol version is recognized automatically on the receiving end
+* CHG: rdiff-backup now supports the newly released Python 3.9 and
+       stops supporting the obsolete Python 3.5.
+* CHG: restoring a specific increment requires now the use of
+       '--restore' parameter
+* CHG: the host placeholder in the remote schema is now '\{h}', '%s' is
+       deprecated.
+* CHG: the old command line interface without explicit actions is
+       considered deprecated
+* CHG: the Windows build uses Python 3.9 instead of Python 3.7 (nobody
+       should notice)
 * DEV: action plugins are described and implemented as context manager
-* DEV: add coding conventions under docs/CODING.md to be followed by       developers and reviewers.
-This is a living document which will be       expanded over time.
-* DEV: add docs/api folder with API description to be followed and API       v200.
-* DEV: added coding rules for sorting of items like functions,       variables, methods, classes, etc.
-* DEV: add Globals.PICKLE_PROTOCOL constant and raise it's version from       1 to 4
-* DEV: add new package rdiffbackup.locations for directory and       repository modules.
-* DEV: add requirements.txt to help GitHub detect our dependencies and       warn about security flaws, closes #434
-* DEV: all API interfaces are marked directly in the code with @API to       simply recognition while coding.
+* DEV: add coding conventions under docs/CODING.md to be followed by
+       developers and reviewers. This is a living document which will be
+       expanded over time.
+* DEV: add docs/api folder with API description to be followed and API
+       v200.
+* DEV: added coding rules for sorting of items like functions,
+       variables, methods, classes, etc.
+* DEV: add Globals.PICKLE_PROTOCOL constant and raise it's version from
+       1 to 4
+* DEV: add new package rdiffbackup.locations for directory and
+       repository modules.
+* DEV: add requirements.txt to help GitHub detect our dependencies and
+       warn about security flaws, closes #434
+* DEV: all API interfaces are marked directly in the code with @API to
+       simply recognition while coding.
 * DEV: document docstrings and import recommendations.
-* DEV: documented that compatibility functions are to have a postfix       `_compat<API>`.
+* DEV: documented that compatibility functions are to have a postfix
+       `_compat<API>`.
 * DEV: Explain or remove many asserts throughout the code, closes #398
 * DEV: fix issue in ACL tests when user isn't named like group
 * DEV: increase crossversion check to old version 2.0.5
-* DEV: introduction of an 'actions' plug-in interface described in the       architecture documentation.
-* DEV: Make flake8 check python scripts and simplify       rdiff-backup-statistics
-* DEV: make it easier to use and test rdiff-backup directly from the       Git repo under Windows using Vagrant
+* DEV: introduction of an 'actions' plug-in interface described in the
+       architecture documentation.
+* DEV: Make flake8 check python scripts and simplify
+       rdiff-backup-statistics
+* DEV: make it easier to use and test rdiff-backup directly from the
+       Git repo under Windows using Vagrant
 * DEV: man page can be generated from markdown
-* DEV: migrate from Travis-CI (thanks for all the fish) to GitHub       actions for our CI/CD pipeline
-* DEV: pin specific version of pyenv-win in Travis CI so that changes       don't make the pipeline without control
-* DEV: prefix all internal functions, variables and classes with       underscore to get more clarify in the code
-* DEV: reduce max complexity to 20 by simplfiying more functions,       mostly using mapping dictionaries
-* DEV: reduce max complexity to 30 and rename CompareRecursive to       compare_recursive.
-* DEV: Re-write tox.ini to make sure that also sub-processes are part       of the coverage calculation, raises test coverage above 80%
+* DEV: migrate from Travis-CI (thanks for all the fish) to GitHub
+       actions for our CI/CD pipeline
+* DEV: pin specific version of pyenv-win in Travis CI so that changes
+       don't make the pipeline without control
+* DEV: prefix all internal functions, variables and classes with
+       underscore to get more clarify in the code
+* DEV: reduce max complexity to 20 by simplfiying more functions,
+       mostly using mapping dictionaries
+* DEV: reduce max complexity to 30 and rename CompareRecursive to
+       compare_recursive.
+* DEV: Re-write tox.ini to make sure that also sub-processes are part
+       of the coverage calculation, raises test coverage above 80%
 * DEV: TempFile.new(_in_dir) is replaced by RPath.get_temp_rpath
-* DEV: there is a new namespace 'rdiffbackup' for new/clean code       according to strategy.
-* DOC: add architecture documentation for better understanding of the       overall code structure
+* DEV: there is a new namespace 'rdiffbackup' for new/clean code
+       according to strategy.
+* DOC: add architecture documentation for better understanding of the
+       overall code structure
 * DOC: add hint on how to use batch file under Windows
-* DOC: add how to use Microsoft's OpenSSH from 32-bits rdiff-backup,       closes #494, closes #496
-* DOC: clarify in the man page(s) that only slashes are allowed in       selection patterns under Windows, closes #531
-* DOC: clarify selection principles in man-page that pattern matching       doesn't resolve relative vs.
-absolute paths and that it is done on the       complete path, closes #533
-* DOC: clarify that the host part belongs together with the double       colons, closes #480
-* DOC: comparaison of old and new Command Line Interface added to the       migration documentation
-* DOC: comparaison of old and new Command Line Interface added to the       migration documentation
-* DOC: docs/migration.md describes how to install rdiff-backup side by       side and use old versions 'forever', closes #523
+* DOC: add how to use Microsoft's OpenSSH from 32-bits rdiff-backup,
+       closes #494, closes #496
+* DOC: clarify in the man page(s) that only slashes are allowed in
+       selection patterns under Windows, closes #531
+* DOC: clarify selection principles in man-page that pattern matching
+       doesn't resolve relative vs. absolute paths and that it is done on the
+       complete path, closes #533
+* DOC: clarify that the host part belongs together with the double
+       colons, closes #480
+* DOC: comparaison of old and new Command Line Interface added to the
+       migration documentation
+* DOC: comparaison of old and new Command Line Interface added to the
+       migration documentation
+* DOC: docs/migration.md describes how to install rdiff-backup side by
+       side and use old versions 'forever', closes #523
 * DOC: document how to use Putty as SSH client thanks to @xastor in #496
-* DOC: document more clearly that rdiff-backup 1.x and 2.x are       incompatible, closes #513
-* DOC: explain the prefixes used in the changelog with focus on       potentially incompatible __CH__an__G__es, closes #436
-* DOC: make the installation instructions for other Linux and UN*X-OID       e.g.
-BSD systems using PyPI more complete, considering build       dependencies.
-Closes #487
+* DOC: document more clearly that rdiff-backup 1.x and 2.x are
+       incompatible, closes #513
+* DOC: explain the prefixes used in the changelog with focus on
+       potentially incompatible __CH__an__G__es, closes #436
+* DOC: make the installation instructions for other Linux and UN*X-OID
+       e.g. BSD systems using PyPI more complete, considering build
+       dependencies. Closes #487
 * DOC: man page has been clarified regarding --no-hard-links option
-* FIX: avoid breaking on non-readable files, causing ListError, closes       #34, closes #245
-* FIX: avoids MemoryError on Windows when compiling for 64 bits, closes       #453
-* FIX: cross device link error on ZFS with project quota, closes #519       (#522)
-* FIX: get rid of spurious resource warnings due to subprocess still       running, closes #165
-* FIX: longnames are correctly reversed when regressing a failed       back-up, closes #9
-* FIX: PID handling when process is interrupted now works properly       under Windows.
-* FIX: setting tempdir under Windows might fail with error about mix of       bytes and str, closes #540
-* FIX: support long paths under Windows 10 v1607 or later, once enabled       in registry/GPO (see Windows README for details), closes #236
-* FIX: When using the --remove-older-than option with --tempdir, the       --tempdir
-* NEW: both 32 and 64 bits version of rdiff-backup are now built for       Windows
-* NEW: new action 'info' to output system information, try       'rdiff-backup info'
-* NEW: option --api-version to explicitly set the actual API version,       maximum version is 201, default is 200, compatible with 2.0.x
+* FIX: avoid breaking on non-readable files, causing ListError, closes
+       #34, closes #245
+* FIX: avoids MemoryError on Windows when compiling for 64 bits, closes
+       #453
+* FIX: cross device link error on ZFS with project quota, closes #519
+       (#522)
+* FIX: get rid of spurious resource warnings due to subprocess still
+       running, closes #165
+* FIX: longnames are correctly reversed when regressing a failed
+       back-up, closes #9
+* FIX: PID handling when process is interrupted now works properly
+       under Windows.
+* FIX: setting tempdir under Windows might fail with error about mix of
+       bytes and str, closes #540
+* FIX: support long paths under Windows 10 v1607 or later, once enabled
+       in registry/GPO (see Windows README for details), closes #236
+* FIX: When using the --remove-older-than option with --tempdir, the
+       --tempdir
+* NEW: both 32 and 64 bits version of rdiff-backup are now built for
+       Windows
+* NEW: new action 'info' to output system information, try
+       'rdiff-backup info'
+* NEW: option --api-version to explicitly set the actual API version,
+       maximum version is 201, default is 200, compatible with 2.0.x
 * NEW: rdiff-backup has a `--help` parameter, closes #280
-* NEW: rdiff-backup has a new interface with actions and sub-options,       use `--new --help` to get the help
-* NEW: rdiff-backup has the concept of API version between client and       server
+* NEW: rdiff-backup has a new interface with actions and sub-options,
+       use `--new --help` to get the help
+* NEW: rdiff-backup has the concept of API version between client and
+       server
 * NEW: rdiff-backup-statistics has --help and --version options
-* NEW: the current rdiff-backup version can be used in the remote       schema with 'x.y.z' being split as placeholders '\{vx}', '\{vy}', '\{vz}'       so that one can install (via pip) and use a specific major/minor       version of rdiff-backup (see the migration docs for details).
+* NEW: the current rdiff-backup version can be used in the remote
+       schema with 'x.y.z' being split as placeholders '\{vx}', '\{vy}', '\{vz}'
+       so that one can install (via pip) and use a specific major/minor
+       version of rdiff-backup (see the migration docs for details).
 
 === Authors
 
@@ -290,11 +349,14 @@ Closes #487
 === Changes
 
 * CHG: development status now set to stable in PyPI classifiers
-* CHG: increased version of bundled Python Windows version from 3.7.5       to 3.7.7.
-(#426)
-* DEV: add measurement of test coverage to tox.ini and limit to 70% for       further improvement, closes #113
-* DEV: make CI pipeline faster by joining small jobs together to avoid       VM creation overhead.
-* DOC: add few development notes about profiling rdiff-backup for time       and memory consumption
+* CHG: increased version of bundled Python Windows version from 3.7.5
+       to 3.7.7. (#426)
+* DEV: add measurement of test coverage to tox.ini and limit to 70% for
+       further improvement, closes #113
+* DEV: make CI pipeline faster by joining small jobs together to avoid
+       VM creation overhead.
+* DOC: add few development notes about profiling rdiff-backup for time
+       and memory consumption
 
 === Authors
 
@@ -304,27 +366,45 @@ Closes #487
 
 === Changes
 
-* CHG: explicitly refuse to back-up to exFAT because it doesn't handle       properly case insensitive deletion of files, closes #38
-* CHG: setuptools is a runtime dependency for installation and tests so       that version appears correctly instead of DEV, closes #305
-* CHG: testing explicitly for existence of tempdir might make certain       setups fail now because tempdir was silently ignored
+* CHG: explicitly refuse to back-up to exFAT because it doesn't handle
+       properly case insensitive deletion of files, closes #38
+* CHG: setuptools is a runtime dependency for installation and tests so
+       that version appears correctly instead of DEV, closes #305
+* CHG: testing explicitly for existence of tempdir might make certain
+       setups fail now because tempdir was silently ignored
 * DEV: Add a misc script to setup an ArchLinux as development platform
-* DEV: add a new Vagrant configuration to do some smoke tests between       the current/development version and any older one
-* DEV: Add samba server with pre-defined shares to Windows vagrant       setup to allow for more extensive tests on shares
-* DEV: fix compatibility in rollsum and sum-size with rdiff 2.2/2.3       leading to errors in librsynctest, closes #304
-* DEV: function rpath.getdevnums now also returns the device type,       block or char
+* DEV: add a new Vagrant configuration to do some smoke tests between
+       the current/development version and any older one
+* DEV: Add samba server with pre-defined shares to Windows vagrant
+       setup to allow for more extensive tests on shares
+* DEV: fix compatibility in rollsum and sum-size with rdiff 2.2/2.3
+       leading to errors in librsynctest, closes #304
+* DEV: function rpath.getdevnums now also returns the device type,
+       block or char
 * DEV: replace deprecated xattr.+++<verb>+++xattr with xattr.+++<verb>+++function, closes #177+++</verb>++++++</verb>+++
-* DOC: added clearer instructions for installing weak dependencies to       support ACLs and EAs under CentOS and RHEL
-* DOC: fix semi-broken nongnu.org links in manpages of rdiff-backup and       rdiff-backup-statistics
-* FIX: add python3-setuptools as a run time dependency to Debian       package so --version works and doesn't output DEV, closes #305.
-* FIX: address `PY_SSIZE_T` deprecation warning appearing under Python       3.8 in the C code, closes #374
-* FIX: avoid error module 'errno' has no attribute 'EDEADLOCK' under       MacOSX, closes #366
-* FIX: avoid issue with backslash at the end of file path under       Windows, closes #395
-* FIX: avoid TypeError: a bytes-like object is required, not 'str' when       logging error message by fixing encoding, closes #380
-* FIX: explicitly test existence of tempdir and avoid "Can't mix       strings and bytes in path components" error, closes #367
-* FIX: failed on certain device files with no such file or directory       error, closes #401
-* FIX: Force encoding of log file to be UTF-8 on all platforms and be       lenient to avoid codec errors on logging, closes #356
+* DOC: added clearer instructions for installing weak dependencies to
+       support ACLs and EAs under CentOS and RHEL
+* DOC: fix semi-broken nongnu.org links in manpages of rdiff-backup and
+       rdiff-backup-statistics
+* FIX: add python3-setuptools as a run time dependency to Debian
+       package so --version works and doesn't output DEV, closes #305.
+* FIX: address `PY_SSIZE_T` deprecation warning appearing under Python
+       3.8 in the C code, closes #374
+* FIX: avoid error module 'errno' has no attribute 'EDEADLOCK' under
+       MacOSX, closes #366
+* FIX: avoid issue with backslash at the end of file path under
+       Windows, closes #395
+* FIX: avoid TypeError: a bytes-like object is required, not 'str' when
+       logging error message by fixing encoding, closes #380
+* FIX: explicitly test existence of tempdir and avoid "Can't mix
+       strings and bytes in path components" error, closes #367
+* FIX: failed on certain device files with no such file or directory
+       error, closes #401
+* FIX: Force encoding of log file to be UTF-8 on all platforms and be
+       lenient to avoid codec errors on logging, closes #356
 * FIX: Improve handling of files in use under Windows, closes #392
-* FIX: more meaningful error message when trying to test-server a local       path, closes #396
+* FIX: more meaningful error message when trying to test-server a local
+       path, closes #396
 
 === Authors
 
@@ -339,9 +419,12 @@ Closes #487
 
 === Changes
 
-* CHG: multimedia files with extensions ogv, oga, ogm and mkv aren't       compressed any more.
-* CHG: Rename CHANGELOG to CHANGELOG.md, format to markdown and fix       references, closes #279
-* FIX: handle properly include/exclude files with Windows/DOS endings,       closes #357
+* CHG: multimedia files with extensions ogv, oga, ogm and mkv aren't
+       compressed any more.
+* CHG: Rename CHANGELOG to CHANGELOG.md, format to markdown and fix
+       references, closes #279
+* FIX: handle properly include/exclude files with Windows/DOS endings,
+       closes #357
 
 === Authors
 
@@ -353,22 +436,37 @@ Closes #487
 
 === Changes
 
-* CHG: return error code 2 instead of number of failed files during       repo verification to have a consistent return code (1 would be any       other kind of error, or 0 if everything is well), closes #338
-* FIX: Added backticks to `<file>` in develop docs so missing word is       shown, closes #303
+* CHG: return error code 2 instead of number of failed files during
+       repo verification to have a consistent return code (1 would be any
+       other kind of error, or 0 if everything is well), closes #338
+* FIX: Added backticks to `<file>` in develop docs so missing word is
+       shown, closes #303
 * FIX: allow again to backup from and to Windows shares, closes #337
-* FIX: avoid bytes/str object issue under MacOS/X while checking forks       FS abilities, closes #320
-* FIX: avoid charmap encoding errors during logging on Windows due to       extended characters, closes #344
-* FIX: avoid IndexError: string index out of range error when using       accentuated characters in exclude/include patterns, closes #340
-* FIX: avoid test error when using librsync >= 2.2 by adding -R rollsum       to rdiff call in librsynctest, closes #304
-* FIX: fail with meaningful error message on metadata mirror files with       duplicate timestamps, closes #322
-* FIX: sequence of exception leading to abort when logging tuple of       bytes because of unreachable directory, closes #310
-* NEW: Create a new rdiff-backup-delete script which can remove a file       and all its history from a backup repository (use with care).
-* NEW: option --allow-duplicate-timestamps to only warn about duplicate       timestamps in metadata mirror files, use this option with care and only       to clean an impacted backup repository.
-* DOC: add Fedora and RHEL to installation instructions, and evoke       Raspbian, closes #316
+* FIX: avoid bytes/str object issue under MacOS/X while checking forks
+       FS abilities, closes #320
+* FIX: avoid charmap encoding errors during logging on Windows due to
+       extended characters, closes #344
+* FIX: avoid IndexError: string index out of range error when using
+       accentuated characters in exclude/include patterns, closes #340
+* FIX: avoid test error when using librsync >= 2.2 by adding -R rollsum
+       to rdiff call in librsynctest, closes #304
+* FIX: fail with meaningful error message on metadata mirror files with
+       duplicate timestamps, closes #322
+* FIX: sequence of exception leading to abort when logging tuple of
+       bytes because of unreachable directory, closes #310
+* NEW: Create a new rdiff-backup-delete script which can remove a file
+       and all its history from a backup repository (use with care).
+* NEW: option --allow-duplicate-timestamps to only warn about duplicate
+       timestamps in metadata mirror files, use this option with care and only
+       to clean an impacted backup repository.
+* DOC: add Fedora and RHEL to installation instructions, and evoke
+       Raspbian, closes #316
 * DOC: Update installation steps to make them clearer to users
 * DOC: improved installation and contributors documentation
-* DEV: clarify version tag pattern and their influence on releases,       closes #326
-* DEV: much better automated installation of Windows development VM via       Vagrant/Ansible
+* DEV: clarify version tag pattern and their influence on releases,
+       closes #326
+* DEV: much better automated installation of Windows development VM via
+       Vagrant/Ansible
 * DEV: errorsrecovertest test script to test recovering from old errors.
 
 === Authors
@@ -384,9 +482,12 @@ Closes #487
 
 === Changes
 
-* FIX: Add workaround to avoid error when backup directory is under the       source directory (see issue #296), there is a warning but the backup       can succeed.
+* FIX: Add workaround to avoid error when backup directory is under the
+       source directory (see issue #296), there is a warning but the backup
+       can succeed.
 * FIX: bytestotime() should return None on decode failure (Closes #295)
-* NEW: add a unit test for bytestotime() in order to avoid a regression       like issue #295.
+* NEW: add a unit test for bytestotime() in order to avoid a regression
+       like issue #295.
 
 === Authors
 
@@ -397,10 +498,13 @@ Closes #487
 
 === Changes
 
-* FIX: UpdateError: Updated mirror temp file does not match source,       Closes #237
-* CHG: Add new logo and improve visual appeal of the README (Closes:       #286) (#287)
+* FIX: UpdateError: Updated mirror temp file does not match source,
+       Closes #237
+* CHG: Add new logo and improve visual appeal of the README (Closes:
+       #286) (#287)
 * NEW: Add Windows developments documentations, closes #220
-* FIX: do not fail when starting with uid/gid equal to maximum, avoid       OverflowError on os.chown
+* FIX: do not fail when starting with uid/gid equal to maximum, avoid
+       OverflowError on os.chown
 
 === Authors
 
@@ -412,24 +516,33 @@ Closes #487
 
 === Changes
 
-* FIX: remove too specific Debian packages from GitHub deployment,       closes #263
-* NEW: add a new tool to help generate the changelog (description in       DEVELOP.md)
+* FIX: remove too specific Debian packages from GitHub deployment,
+       closes #263
+* NEW: add a new tool to help generate the changelog (description in
+       DEVELOP.md)
 * DOC: new release rules and procedure added to docs/DEVELOP.md
 * FIX: avoid double unquoting of increment file infos, closes #266
-* FIX: versioning of Debian packages follows without glitch the overall       tag based versioning.
-* DEV: automate via Travis deployment pipeline release to PyPI and Test       PyPI.
-* FIX: remove some more ugly bytes output in strings using _safe_str,       closes #238
-* FIX: added and moved hardlinks were not correctly counted and       restored, Closes #239
-* FIX: rdiff-backup complained about missing SHA checksums of       hardlinks, Closes #78
-* FIX: avoid int is not iterable error when calling remote command on       Windows
+* FIX: versioning of Debian packages follows without glitch the overall
+       tag based versioning.
+* DEV: automate via Travis deployment pipeline release to PyPI and Test
+       PyPI.
+* FIX: remove some more ugly bytes output in strings using _safe_str,
+       closes #238
+* FIX: added and moved hardlinks were not correctly counted and
+       restored, Closes #239
+* FIX: rdiff-backup complained about missing SHA checksums of
+       hardlinks, Closes #78
+* FIX: avoid int is not iterable error when calling remote command on
+       Windows
 * DEV: flake8 checks only setup.py, src, testing and tools code.
-* NEW: add support for SOURCE_DATE_EPOCH to override the build date,       making reproducible builds possible.
-* NEW: sparse files are handled more efficiently, if not compressed and       depending on file system
+* NEW: add support for SOURCE_DATE_EPOCH to override the build date,
+       making reproducible builds possible.
+* NEW: sparse files are handled more efficiently, if not compressed and
+       depending on file system
 
 === Authors
 
-* Bernhard M.
-Wiedemann
+* Bernhard M. Wiedemann
 * Eric L
 * Otto Kekäläinen
 * Patrik Dufresne

--- a/README.adoc
+++ b/README.adoc
@@ -114,7 +114,7 @@ sudo pip3 install rdiff-backup
 
 You need to make sure that the following requirements are met:
 
-* Python 3.6 or higher
+* Python 3.7 or higher
 * pip3 e.g.
 installed with `+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py;
 sudo python3 get-pip.py+`.

--- a/README.adoc
+++ b/README.adoc
@@ -121,7 +121,7 @@ sudo python3 get-pip.py+`.
 * librsync 1.0.0 or higher
 * pylibacl (optional, to support ACLs)
 * pyxattr (optional, to support extended attributes) - the xattr library (without py) isn't regularly tested but should work and you will be helped
-* if Python's version is 3.7.x or below, importlib-metadata 1.x (or alternatively setuptools)
+* if Python's version is 3.7.x or below, importlib-metadata (or alternatively setuptools)
 * psutil as an optional dependency (else rdiff-backup uses `ps`/`tasklist`)
 * SSH for remote operations
 

--- a/docs/DEVELOP.adoc
+++ b/docs/DEVELOP.adoc
@@ -125,6 +125,8 @@ All of those should come packaged with your system or available from https://pyp
 *** tox.ini, tox_root.ini, tox_dist.ini and tox_slow.ini - check for `envlist`
 *** .github/workflows/test_linux.yml - check for `python-version`
 *** .github/workflows/deploy.yml - check for `/opt/python/cp3...` (and possibly `many-linux`)
+*** setup.py - check for `python-requires`
+*** README.adoc - check for Python references
 * Python libraries:
 ** `setup.py`
 ** `requirements.txt`

--- a/docs/DEVELOP.adoc
+++ b/docs/DEVELOP.adoc
@@ -114,6 +114,26 @@ All of those should come packaged with your system or available from https://pyp
 * Pylibacl - http://pylibacl.sourceforge.net/
 * Pyxattr - http://pyxattr.sourceforge.net/
 
+==== Changing dependencies versions
+
+* Python interpreter:
+** Windows:
+*** .github/workflows/test_windows.yml - check for `WIN_PYTHON_VERSION`
+*** .github/workflows/deploy.yml - check for `WIN_PYTHON_VERSION`
+*** tools/windows/group_vars/windows_hosts/generic.yml - check for `python_version` and `python_version_full` 
+** Linux:
+*** tox.ini, tox_root.ini, tox_dist.ini and tox_slow.ini - check for `envlist`
+*** .github/workflows/test_linux.yml - check for `python-version`
+*** .github/workflows/deploy.yml - check for `/opt/python/cp3...` (and possibly `many-linux`)
+* Python libraries:
+** `setup.py`
+** `requirements.txt`
+** `tox*.ini`
+** `.github/workflows/*.yml`
+** `tools/windows/playbook-provision.yml`
+** `tools/*.sh`
+** check documentation
+
 === Build and install using Makefile
 
 The project has a link:../Makefile[Makefile] that defines steps like `all`, `build`, `test` and others.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 # mandatory
 setuptools
 setuptools-scm
-importlib-metadata ~= 1.0 ; python_version < "3.8"
+importlib-metadata ; python_version < "3.8"
 PyYAML  # for rdiff-backup >= 2.1
 
 # optional

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ setup(
     # maintainer and maintainer_email could be used to differentiate the package owner
     url="https://rdiff-backup.net/",
     download_url="https://github.com/rdiff-backup/rdiff-backup/releases",
-    python_requires='~=3.6',
+    python_requires='~=3.7',
     platforms=['linux', 'win32'],
     packages=["rdiff_backup", "rdiffbackup",
               "rdiffbackup.actions", "rdiffbackup.utils", "rdiffbackup.meta",

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ setup(
         'clean': clean,
     },
     install_requires=[
-        'importlib-metadata ~= 1.0 ; python_version < "3.8"',
+        'importlib-metadata ; python_version < "3.8"',
         'PyYAML',
     ],
     setup_requires=['setuptools_scm'],

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -32,7 +32,7 @@ esac
 # Compile wheels
 for PYBIN in $pybindirs; do
     "${PYBIN}/pip" install --user \
-        'importlib-metadata ~= 1.0 ; python_version < "3.8"' 'PyYAML'
+        'importlib-metadata ; python_version < "3.8"' 'PyYAML'
     "${PYBIN}/pip" wheel ${basedir} -w ${build_dir}/
 done
 

--- a/tools/windows/group_vars/windows_hosts/generic.yml
+++ b/tools/windows/group_vars/windows_hosts/generic.yml
@@ -14,4 +14,4 @@ win_arch: "{{ (win_bits == '64') | ternary('x64', 'x86') }}"
 win_python_arch: "{{ (win_bits == '64') | ternary('win-amd64', 'win32') }}"
 
 python_version: "3.10"
-python_version_full: "{{ python_version }}.4"
+python_version_full: "{{ python_version }}.7"

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # Use tox_slow.ini for longer running tests.
 
 [tox]
-envlist = py36, py37, py38, py39, flake8
+envlist = py37, py38, py39, py310, flake8
 
 [testenv]
 # make sure those variables are passed down; you should define 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv =
 	COVERAGE_FILE = {envlogdir}/coverage.sqlite
 	COVERAGE_PROCESS_START = {toxinidir}/tox.ini
 deps =
-	importlib-metadata ~= 1.0 ; python_version < "3.8"
+	importlib-metadata ; python_version < "3.8"
 	PyYAML
 	pyxattr
 	pylibacl

--- a/tox_dist.ini
+++ b/tox_dist.ini
@@ -6,7 +6,7 @@
 # Configuration file for creating binary packages, esp. wheels
 
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39, py310
 
 [testenv]
 # make sure those variables are passed down; you should define 

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -8,7 +8,7 @@
 # Use tox_slow.ini for longer running tests and tox.ini for normal tests.
 
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39, py310
 # some directories to avoid creating files with root rights that
 # couldn't be overwritten by the non-root tests:
 toxworkdir = {toxinidir}/.tox.root

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -20,7 +20,7 @@ isolated_build_env = .package.root
 # or explicitly the RDIFF_* ones:
 passenv = SUDO_USER SUDO_UID SUDO_GID RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
-    importlib-metadata ~= 1.0 ; python_version < "3.8"
+    importlib-metadata ; python_version < "3.8"
     PyYAML
     pyxattr
     pylibacl

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -7,7 +7,7 @@
 # Call with `tox -c tox_slow.ini`
 
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39, py310
 
 [testenv]
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -12,7 +12,7 @@ envlist = py36, py37, py38, py39
 [testenv]
 passenv = RDIFF_TEST_* RDIFF_BACKUP_*
 deps =
-    importlib-metadata ~= 1.0 ; python_version < "3.8"
+    importlib-metadata ; python_version < "3.8"
     PyYAML
     pyxattr
     pylibacl


### PR DESCRIPTION
CHG: embed Python 3.10.7 instead of 3.10.4 in Windows rdiff-backup, shouldn't impact end-users DEV: remove dependency on importlib-metadata 1.x, it can be now any version

- reformat the changelog which was slightly broken
- add documentation on where to change dependency versions (all over the place)