### PR TITLE
Fix failing on restoring quoted sub-path

### DIFF
--- a/src/rdiff_backup/FilenameMapping.py
+++ b/src/rdiff_backup/FilenameMapping.py
@@ -177,13 +177,13 @@ def unquote(path):
 
 def get_quotedrpath(rp, separate_basename=0):
     """Return quoted version of rpath rp"""
-    assert not rp.index, (
-        "Trying to start quoting '{rp}' in the middle.".format(rp=rp))
     if separate_basename:
+        assert not rp.index, (
+            "Trying to start quoting '{rp}' in the middle.".format(rp=rp))
         dirname, basename = rp.dirsplit()
         return QuotedRPath(rp.conn, dirname, (unquote(basename), ), rp.data)
     else:
-        return QuotedRPath(rp.conn, rp.base, (), rp.data)
+        return QuotedRPath(rp.conn, rp.base, rp.index, rp.data)
 
 
 def _init_quoting_regexps():

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -156,13 +156,13 @@ def get_quotedrpath(rp, separate_basename=0):
     """
     Return quoted version of rpath rp
     """
-    assert not rp.index, (
-        "Trying to start quoting '{rp}' in the middle.".format(rp=rp))
     if separate_basename:
+        assert not rp.index, (
+            "Trying to start quoting '{rp}' in the middle.".format(rp=rp))
         dirname, basename = rp.dirsplit()
         return QuotedRPath(rp.conn, dirname, (unquote(basename), ), rp.data)
     else:
-        return QuotedRPath(rp.conn, rp.base, (), rp.data)
+        return QuotedRPath(rp.conn, rp.base, rp.index, rp.data)
 
 
 def get_quoting_regexps(chars_to_quote, quoting_char):

--- a/testing/action_backuprestore_test.py
+++ b/testing/action_backuprestore_test.py
@@ -80,6 +80,27 @@ class ActionBackupRestoreTest(unittest.TestCase):
         # all tests were successful
         self.success = True
 
+    def test_action_backuprestore_quoted(self):
+        """
+        test the backup and restore actions with quoted repository
+        """
+        # we backup using a specific chars-to-quote
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, False, self.from1_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "10000",
+             "--chars-to-quote", "A"),
+            b"backup", ()), 0)
+
+        # then we restore once the full repo, once a sub-path
+        self.assertEqual(comtst.rdiff_backup_action(
+            True, False, os.path.join(self.bak_path, b"itemX"), self.to1_path,
+            ("--api-version", "201"),
+            b"restore", ()), 0)
+        self.assertEqual(comtst.rdiff_backup_action(
+            True, True, self.bak_path, self.to2_path,
+            ("--api-version", "201"),
+            b"restore", ()), 0)
+
     def tearDown(self):
         # we clean-up only if the test was successful
         if self.success:


### PR DESCRIPTION
FIX: stop failing on quoting while restoring sub-path of repo with chars_to_quote, closes #722

Also adding a test case to cover the situation