### PR TITLE
Allow again for Python 3.6

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,7 +114,7 @@ sudo pip3 install rdiff-backup
 
 You need to make sure that the following requirements are met:
 
-* Python 3.7 or higher
+* Python 3.7 or higher (Python 3.6 is tolerated on supported platforms, but not regularly tested, and hence not recommended)
 * pip3 e.g.
 installed with `+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py;
 sudo python3 get-pip.py+`.

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ setup(
     # maintainer and maintainer_email could be used to differentiate the package owner
     url="https://rdiff-backup.net/",
     download_url="https://github.com/rdiff-backup/rdiff-backup/releases",
-    python_requires='~=3.7',
+    python_requires='~=3.6',
     platforms=['linux', 'win32'],
     packages=["rdiff_backup", "rdiffbackup",
               "rdiffbackup.actions", "rdiffbackup.utils", "rdiffbackup.meta",


### PR DESCRIPTION
Still not a recommended version as it isn't regularly tested but it should continue to work. This said, it will most probably be the last non-bug-fix release to support it.