### PR TITLE
Fix missing modules in Windows binary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,11 +83,10 @@ jobs:
       with:
         python-version: ${{ env.WIN_PYTHON_VERSION }}
         architecture: ${{ matrix.arch }}
-    # FIXME PyInstaller 5.2 and 5.3 fail to grab all modules
     - name: Install dependencies
       run: |
         python.exe -VV
-        pip.exe install --upgrade pywin32 pyinstaller==5.1 wheel certifi setuptools-scm tox PyYAML
+        pip.exe install --upgrade pywin32 wheel certifi setuptools-scm tox PyYAML
         python.exe -c 'import pywintypes, winnt, win32api, win32security, win32file, win32con'
         choco install ruby
         gem install asciidoctor

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,9 @@ defaults:
   run:
     shell: bash
 
+# FIXME PyInstaller v5.1 doesn't work with 3.10.7
 env:
-  WIN_PYTHON_VERSION: 3.10.7
+  WIN_PYTHON_VERSION: 3.10.5
   WIN_LIBRSYNC_VERSION: v2.3.2
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,8 @@ defaults:
   run:
     shell: bash
 
-# FIXME PyInstaller v5.1 doesn't work with 3.10.7
 env:
-  WIN_PYTHON_VERSION: 3.10.5
+  WIN_PYTHON_VERSION: 3.10.7
   WIN_LIBRSYNC_VERSION: v2.3.2
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,10 +83,11 @@ jobs:
       with:
         python-version: ${{ env.WIN_PYTHON_VERSION }}
         architecture: ${{ matrix.arch }}
+    # FIXME PyInstaller 5.2 and 5.3 fail to grab all modules
     - name: Install dependencies
       run: |
         python.exe -VV
-        pip.exe install --upgrade pywin32 pyinstaller wheel certifi setuptools-scm tox PyYAML
+        pip.exe install --upgrade pywin32 pyinstaller==5.1 wheel certifi setuptools-scm tox PyYAML
         python.exe -c 'import pywintypes, winnt, win32api, win32security, win32file, win32con'
         choco install ruby
         gem install asciidoctor

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -16,9 +16,8 @@ defaults:
   run:
     shell: bash
 
-# FIXME PyInstaller v5.1 doesn't work with 3.10.7
 env:
-  WIN_PYTHON_VERSION: 3.10.5
+  WIN_PYTHON_VERSION: 3.10.7
   WIN_LIBRSYNC_VERSION: v2.3.2
 
 jobs:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -16,8 +16,9 @@ defaults:
   run:
     shell: bash
 
+# FIXME PyInstaller v5.1 doesn't work with 3.10.7
 env:
-  WIN_PYTHON_VERSION: 3.10.7
+  WIN_PYTHON_VERSION: 3.10.5
   WIN_LIBRSYNC_VERSION: v2.3.2
 
 jobs:

--- a/tools/win_build_rdiffbackup.sh
+++ b/tools/win_build_rdiffbackup.sh
@@ -18,26 +18,18 @@ else
 fi
 
 PYEXE=python.exe
-PYINST=PyInstaller.exe
+TOXEXE=tox.exe
 if [[ -n ${PYDIRECT} ]]
 then
 	py_dir=C:/Python${bits}
 	PYEXE=${py_dir}/${PYEXE}
-	PYINST=${py_dir}/Scripts/${PYINST}
+	TOXEXE=${py_dir}/Scripts/${TOXEXE}
 fi
 
 LIBRSYNC_DIR=${HOME}/librsync${bits}
 export LIBRSYNC_DIR
 
-ver_name=rdiff-backup-$(${PYEXE} setup.py --version)
-py_ver_brief=${PYTHON_VERSION%.[0-9]}
+RDIFF_BACKUP_VERSION=rdiff-backup-$(${PYEXE} setup.py --version)-${bits}
+export RDIFF_BACKUP_VERSION
 
-${PYEXE} setup.py bdist_wheel
-# add hook file to hooks-dir for each new plugin manager!
-${PYINST} --onefile --distpath build/${ver_name}-${bits} \
-	--paths=build/lib.${py_win_bits}-cpython-${py_ver_brief/./} \
-	--paths=${LIBRSYNC_DIR}/lib \
-	--paths=${LIBRSYNC_DIR}/bin \
-	--additional-hooks-dir=tools \
-	--console build/scripts-${py_ver_brief}/rdiff-backup \
-	--add-data=src/rdiff_backup.egg-info/PKG-INFO\;rdiff_backup.egg-info
+${TOXEXE} -c tox_win.ini -e buildexe

--- a/tools/win_build_rdiffbackup.sh
+++ b/tools/win_build_rdiffbackup.sh
@@ -35,9 +35,9 @@ py_ver_brief=${PYTHON_VERSION%.[0-9]}
 ${PYEXE} setup.py bdist_wheel
 # add hook file to hooks-dir for each new plugin manager!
 ${PYINST} --onefile --distpath build/${ver_name}-${bits} \
-	--paths=build/lib.${py_win_bits}-${py_ver_brief} \
-        --paths=${LIBRSYNC_DIR}/lib \
-        --paths=${LIBRSYNC_DIR}/bin \
+	--paths=build/lib.${py_win_bits}-cpython-${py_ver_brief/./} \
+	--paths=${LIBRSYNC_DIR}/lib \
+	--paths=${LIBRSYNC_DIR}/bin \
 	--additional-hooks-dir=tools \
 	--console build/scripts-${py_ver_brief}/rdiff-backup \
 	--add-data=src/rdiff_backup.egg-info/PKG-INFO\;rdiff_backup.egg-info

--- a/tools/win_provision.sh
+++ b/tools/win_provision.sh
@@ -10,7 +10,8 @@ for bits in 32 64
 do
 	C:/Python${bits}/python.exe -VV
 	C:/Python${bits}/Scripts/pip.exe install --upgrade \
-		pywin32 pyinstaller wheel certifi setuptools-scm tox PyYAML
+		pywin32 pyinstaller==5.1 wheel certifi setuptools-scm tox PyYAML
+# FIXME PyInstaller 5.2 and 5.3 fail to grab all modules
 	C:/Python${bits}/python.exe -c \
 		'import pywintypes, winnt, win32api, win32security, win32file, win32con'
 done

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -7,7 +7,7 @@
 # Use tox_slow.ini for longer running tests.
 
 [tox]
-envlist = py, flake8
+envlist = py, flake8, buildexe
 
 [testenv]
 # make sure those variables are passed down; you should define 
@@ -16,7 +16,7 @@ envlist = py, flake8
 passenv = RDIFF_TEST_* RDIFF_BACKUP_* LIBRSYNC_DIR
 deps =
     pywin32
-    pyinstaller
+    pyinstaller==5.1
     wheel
 whitelist_externals = cmd
 commands_pre =
@@ -81,7 +81,6 @@ commands =
 deps =
     flake8
     pywin32
-    pyinstaller
     wheel
 commands =
     flake8 setup.py src testing tools
@@ -97,3 +96,14 @@ exclude =
     __pycache__
     build
 max-complexity = 40
+
+[testenv:buildexe]
+# add hook file to hooks-dir for each new plugin manager!
+commands =
+    python setup.py bdist_wheel
+    pyinstaller --onefile --distpath build/{env:RDIFF_BACKUP_VERSION} \
+        --paths={env:LIBRSYNC_DIR}/lib \
+        --paths={env:LIBRSYNC_DIR}/bin \
+        --additional-hooks-dir=tools \
+        --console {envbindir}/rdiff-backup \
+        --copy-metadata rdiff-backup


### PR DESCRIPTION
I had basically to do two things to address #731

1. downgrade PyInstaller from 5.2/5.3 to 5.1
2. downgrade Python 3.10.7 to 3.10.5

Note that I won't close the issue with this PR, I consider this to be only a workaround and hope to find a better solution during the beta phase.