### PR TITLE
Remove circular dependency in meta

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1440,13 +1440,13 @@ class RPath(RORPath):
 
 
 class MaybeGzip:
-    """Represent a file object that may or may not be compressed
+    """
+    Represent a file object that may or may not be compressed
 
     We don't want to compress 0 length files.  This class lets us
     delay the opening of the file until either the first write (so we
     know it has data and should be compressed), or close (when there's
     no data).
-
     """
 
     def __init__(self, base_rp, callback=None):

--- a/src/rdiffbackup/meta/__init__.py
+++ b/src/rdiffbackup/meta/__init__.py
@@ -20,7 +20,7 @@
 Base module for any metadata class to derive from.
 """
 
-from rdiff_backup import log, rpath
+from rdiff_backup import log
 
 
 class ParsingError(Exception):
@@ -238,6 +238,7 @@ class FlatFile:
                 def callback(rp):
                     self.rp = rp
 
+                from rdiff_backup import rpath  # to avoid a circular dependency
                 self.fileobj = rpath.MaybeGzip(rp_base, callback)
             else:
                 self.rp = rp_base

--- a/tools/win_provision.sh
+++ b/tools/win_provision.sh
@@ -10,8 +10,7 @@ for bits in 32 64
 do
 	C:/Python${bits}/python.exe -VV
 	C:/Python${bits}/Scripts/pip.exe install --upgrade \
-		pywin32 pyinstaller==5.1 wheel certifi setuptools-scm tox PyYAML
-# FIXME PyInstaller 5.2 and 5.3 fail to grab all modules
+		pywin32 pyinstaller wheel certifi setuptools-scm tox PyYAML
 	C:/Python${bits}/python.exe -c \
 		'import pywintypes, winnt, win32api, win32security, win32file, win32con'
 done

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -16,7 +16,7 @@ envlist = py, flake8
 passenv = RDIFF_TEST_* RDIFF_BACKUP_* LIBRSYNC_DIR
 deps =
     pywin32
-    pyinstaller==5.1
+    pyinstaller == 5.4
     wheel
 whitelist_externals = cmd
 commands_pre =


### PR DESCRIPTION
FIX: remove circular dependency in meta to rpath to allow for newer PyInstaller under Windows, closes #731

Corrected version of PR #734 