### PR TITLE
Add wheel building using manylinux_2_28

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,12 @@ jobs:
         # we could do it also as matrix but it takes longer
         #python-version: [3.10,3.9,3.8,3.7]
         #--- Build and deploy Linux wheels using manylinux containers ---
-        # - build manylinux2010 (and manylinux1) x64
-        # - build manylinux2010 i686
+        # - build manylinux2010 x64 and i686
         # - build manylinux2014 x64
+        # - build manylinux_2_28 x64
         # avoiding manylinux2014_i686 because does not provide librsync-devel
-        many-linux: [2010_x86_64, 2010_i686, 2014_x86_64]
+        # manylinux_2_24 is already deprecated
+        many-linux: [2010_x86_64, 2010_i686, 2014_x86_64, _2_28_x86_64]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -10,7 +10,11 @@ build_dir=${basedir}/build
 dist_dir=${basedir}/dist
 
 # Install a system package required by our library
-yum install -y librsync-devel rubygems
+if ! yum install -y librsync-devel rubygems
+then  # re-try with EPEL
+	yum install -y epel-release
+	yum install -y librsync-devel rubygems
+fi
 
 # asciidoctor 2.x isn't compatible with Ruby 1.8
 ruby_version=$(rpm -qi ruby | awk -F' *: *' '$1=="Version" {print $2}')


### PR DESCRIPTION
NEW: new rdiff-backup wheels based on manylinux_2_28, compatible with more recent Linux versions, closes #721