### PR TITLE
Fix selection issue with backslash under Windows

### DIFF
--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -705,9 +705,10 @@ probably isn't what you meant""".format(se=self.selection_functions[-1].name))
         prefixes = [
             b"/".join(glob_parts[:i + 1]) for i in range(len(glob_parts))
         ]
-        # we must make exception for root "/", only dir to end in slash
-        if prefixes[0] == b"":
-            prefixes[0] = b"/"
+        # we must make exception for root "/", or "X:/" under Windows,
+        # only dirs to end in slash
+        if prefixes[0] == b"" or re.fullmatch(b"[a-zA-Z]:", prefixes[0]):
+            prefixes[0] += b"/"
         return list(map(self._glob_to_re, prefixes))
 
     def _glob_to_re(self, pat):

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -57,7 +57,7 @@ commands =
 #    python testing/FilenameMappingtest.py  # issues with : in date/time-string
 #    python testing/fs_abilitiestest.py  # module 'os' has no attribute 'getuid'
     python testing/hashtest.py
-#    python testing/selectiontest.py  # too many errors to count...
+    python testing/selectiontest.py
 #    python testing/metadatatest.py  # issues with : in date/time/string
 #    python testing/rpathtest.py  # many small issues
     python testing/rorpitertest.py


### PR DESCRIPTION
FIX: recognizes now sub-path of root directory (X:/) as base path under Windows, closes #620
DEV: enable selectiontest.py under Windows

@desseim if you're able to review...