### PR TITLE
Fix regression of removal of read-only files

### DIFF
--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -89,7 +89,7 @@ class RegressAction(actions.BaseAction):
         # set the filesystem properties of the repository
         if Globals.get_api_version() < 201:  # compat200
             self.repo.base_dir.conn.fs_abilities.single_set_globals(
-                self.repo.base_dir, 0)  # read_only=False
+                self.repo.data_dir, 0)  # read_only=False
             self.repo.setup_quoting()
 
         return ret_code

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -91,7 +91,7 @@ class RemoveAction(actions.BaseAction):
         # set the filesystem properties of the repository
         if Globals.get_api_version() < 201:  # compat200
             self.repo.base_dir.conn.fs_abilities.single_set_globals(
-                self.repo.base_dir, 0)  # read_only=False
+                self.repo.data_dir, 0)  # read_only=False
             self.repo.setup_quoting()
 
         self.action_time = self._get_removal_time(self.values.older_than)

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -48,7 +48,7 @@ class ReadDir(Dir, locations.ReadLocation):
                 self._shadow = _dir_shadow.ReadDirShadow
             else:
                 self._shadow = self.base_dir.conn._dir_shadow.ReadDirShadow
-            self.fs_abilities = self._shadow.get_fs_abilities(self.base_dir)
+            self.fs_abilities = self.get_fs_abilities()
             if not self.fs_abilities:
                 return ret_code | Globals.RET_CODE_ERR
             else:
@@ -85,6 +85,12 @@ class ReadDir(Dir, locations.ReadLocation):
         else:  # FIXME we're retransforming bytes into a file pointer
             self._shadow.set_select(self.base_dir, select_opts,
                                     *list(map(io.BytesIO, select_data)))
+
+    def get_fs_abilities(self):
+        """
+        Shadow function for ReadDirShadow.get_fs_abilities
+        """
+        return self._shadow.get_fs_abilities(self.base_dir)
 
     def get_select(self):
         """
@@ -131,7 +137,7 @@ class WriteDir(Dir, locations.WriteLocation):
                 self._shadow = _dir_shadow.WriteDirShadow
             else:
                 self._shadow = self.base_dir.conn._dir_shadow.WriteDirShadow
-            self.fs_abilities = self._shadow.get_fs_abilities(self.base_dir)
+            self.fs_abilities = self.get_fs_abilities()
             if not self.fs_abilities:
                 return ret_code | Globals.RET_CODE_ERR
             else:
@@ -188,6 +194,12 @@ class WriteDir(Dir, locations.WriteLocation):
                 self.base_dir.conn.restore.TargetStruct.set_target_select(
                     self.base_dir, select_opts,
                     *list(map(io.BytesIO, select_data)))
+
+    def get_fs_abilities(self):
+        """
+        Shadow function for WriteDirShadow.get_fs_abilities
+        """
+        return self._shadow.get_fs_abilities(self.base_dir)
 
     def get_sigs_select(self):
         """


### PR DESCRIPTION
FIX: regression in fs abilities check on read-only files for read-write actions remove and regress, closes #738

Test will follow once issue #755 has been addressed, anyway it shouldn't happen again that easily. Took the chance to simply usage of fs_abilities.