### PR TITLE
Added pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/code_and_more.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code_and_more.md
@@ -1,0 +1,16 @@
+---
+name: Documentation only pull request
+about: Provide improvements to the documentation
+title: "[DOC] "
+labels: ''
+assignees: ''
+
+---
+
+## Changes done and why
+
+> **NOTE:** if your explanation needs to be (very) different from your Git commit message, your Git commit might be insufficient, please re-think it and amend it! Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+## Checklist
+
+- [ ] commit contains a description of changes relevant to users prefixed by DOC (see top of the changelog for details)

--- a/.github/PULL_REQUEST_TEMPLATE/doc_only.md
+++ b/.github/PULL_REQUEST_TEMPLATE/doc_only.md
@@ -1,0 +1,18 @@
+---
+name: Code and otherwise pull request
+about: Provide generic improvements
+title: ""
+labels: ''
+assignees: ''
+
+---
+
+## Changes done and why
+
+> **NOTE:** if your explanation needs to be (very) different from your Git commit message, your Git commit might be insufficient, please re-think it and amend it! Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+## Checklist
+
+- [ ] changes to the code have been reflected in the documentation
+- [ ] changes to the code have been covered by new/modified tests
+- [ ] commit contains a description of changes relevant to users prefixed by DOC, FIX, NEW and/or CHG (see top of the changelog for details)


### PR DESCRIPTION
DEV: added pull request templates differentiating between doc and code PRs

It was necessary to address testing coverage required by OpenSSF Best Practices