### PR TITLE
Fix issue with UNC paths losing first backslash

### DIFF
--- a/testing/setconnectionstest.py
+++ b/testing/setconnectionstest.py
@@ -23,6 +23,10 @@ class SetConnectionsTest(unittest.TestCase):
         self.assertEqual(pl(rb"foobar\\"), (None, b"foobar/", None))
         self.assertEqual(pl(rb"not\::too::many\\\::paths"),
                          (b"not::too", b"many/::paths", None))
+        self.assertEqual(pl(rb"\\hostname\unc\path"),
+                         (None, b"//hostname/unc/path", None))
+        self.assertEqual(pl(rb"remotehost::\\hostname\unc\path"),
+                         (b"remotehost", b"//hostname/unc/path", None))
 
         # test missing path and missing host
         self.assertIsNotNone(pl(rb"a host without\:path::")[2])


### PR DESCRIPTION
FIX: UNC path \\hostname\some\path would lose first backslash Thanks to @qx6uwumzvv for the report