### PR TITLE
NEW: Optionally show size of removed increments

### DIFF
--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -208,8 +208,8 @@ all the increments older than the given time will be deleted.
 See <<_time_formats,TIME FORMATS>> for details.
 
 --size;;
-Show the size of each increment being removed. The default
-is to _not_ show sizes.
+Show the size of each increment being removed.
+The default is to _not_ show sizes.
 
 restore [<<_creation_options,CREATION OPTIONS>>] [<<_compression_options,COMPRESSION OPTIONS>>] [<<_selection_options,SELECTION OPTIONS>>] [<<_filesystem_options,FILESYSTEM OPTIONS>>] [<<_user_group_options,USER GROUP OPTIONS>>] [*--at* _time_|*--increment*] _source_ _targetdir_::
 restore a source backup repository at a specific time or a specific     source increment to a target directory.

--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -195,7 +195,7 @@ If an rdiff-backup session fails, this action will undo the failed directory.
 This happens automatically if you attempt to back-up to a directory and the last backup failed.
 You can use the *--force* option to undo the last backup even if it wasn't failed.
 
-remove *increments* *--older-than* _time_ _repository_:: Remove the incremental backup information in the destination directory that has been around longer than the given time, or the oldest one if no time is provided.
+remove *increments* *--older-than* _time_ [*--size*] _repository_:: Remove the incremental backup information in the destination directory that has been around longer than the given time, or the oldest one if no time is provided.
 +
 By default, rdiff-backup will only delete information from one session at a time.
 To remove two or more sessions at the same time, supply the *--force* option (rdiff-backup will tell you if it is required).
@@ -206,6 +206,10 @@ Thus if you deleted a file two weeks ago, backed up immediately afterwards, and 
 --older-than _time_;;
 all the increments older than the given time will be deleted.
 See <<_time_formats,TIME FORMATS>> for details.
+
+--size;;
+Show the size of each increment being removed. The default
+is to _not_ show sizes.
 
 restore [<<_creation_options,CREATION OPTIONS>>] [<<_compression_options,COMPRESSION OPTIONS>>] [<<_selection_options,SELECTION OPTIONS>>] [<<_filesystem_options,FILESYSTEM OPTIONS>>] [<<_user_group_options,USER GROUP OPTIONS>>] [*--at* _time_|*--increment*] _source_ _targetdir_::
 restore a source backup repository at a specific time or a specific     source increment to a target directory.

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -22,9 +22,10 @@ A built-in rdiff-backup action plug-in to remove increments from a back-up
 repository.
 """
 
-from rdiff_backup import (Globals, log, manage, Time)
+from rdiff_backup import (Globals, log, manage, statistics, Time)
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
+from rdiffbackup.utils.argopts import BooleanOptionalAction
 
 
 class RemoveAction(actions.BaseAction):
@@ -42,6 +43,9 @@ class RemoveAction(actions.BaseAction):
         entity_parsers["increments"].add_argument(
             "--older-than", metavar="TIME",
             help="remove increments older than given time")
+        entity_parsers["increments"].add_argument(
+            "--size", action=BooleanOptionalAction, default=False,
+            help="also output size of each increment (might take longer)")
         entity_parsers["increments"].add_argument(
             "locations", metavar="[[USER@]SERVER::]PATH", nargs=1,
             help="location of repository to remove increments from")
@@ -94,7 +98,8 @@ class RemoveAction(actions.BaseAction):
                 self.repo.data_dir, 0)  # read_only=False
             self.repo.setup_quoting()
 
-        self.action_time = self._get_removal_time(self.values.older_than)
+        self.action_time = self._get_removal_time(self.values.older_than,
+                                                  self.values.size)
         if self.action_time is None:
             return ret_code | Globals.RET_CODE_ERR
 
@@ -120,7 +125,7 @@ class RemoveAction(actions.BaseAction):
 
         return ret_code
 
-    def _get_removal_time(self, time_string):
+    def _get_removal_time(self, time_string, show_increment_sizes):
         """
         Check remove older than time_string, return time in seconds
 
@@ -132,9 +137,14 @@ class RemoveAction(actions.BaseAction):
         if action_time is None:
             return None
 
-        times_in_secs = [
-            inc.getinctime() for inc in self.repo.incs_dir.get_incfiles_list()
-        ]
+        if self.values.size:
+            triples = self.repo.get_increments_sizes()[:-1]
+            times_in_secs = [triple["time"] for triple in triples]
+        else:
+            times_in_secs = [
+                inc.getinctime() for inc
+                in self.repo.incs_dir.get_incfiles_list()
+            ]
         times_in_secs = [t for t in times_in_secs if t < action_time]
         if not times_in_secs:
             log.Log("No increments older than {at} found, exiting.".format(
@@ -142,7 +152,20 @@ class RemoveAction(actions.BaseAction):
             return -1
 
         times_in_secs.sort()
-        pretty_times = "\n".join(map(Time.timetopretty, times_in_secs))
+        if self.values.size:
+            sizes = [triple["size"] for triple in triples
+                     if triple["time"] in times_in_secs]
+            stat_obj = statistics.StatsObj()  # used for byte summary string
+
+            def format_time_and_size(time, size):
+                return "{: <24} {: >17}".format(
+                    Time.timetopretty(time),
+                    stat_obj.get_byte_summary_string(size))
+
+            pretty_times_map = map(format_time_and_size, times_in_secs, sizes)
+            pretty_times = "\n".join(pretty_times_map)
+        else:
+            pretty_times = "\n".join(map(Time.timetopretty, times_in_secs))
         if len(times_in_secs) > 1:
             if not self.values.force:
                 log.Log(

--- a/src/rdiffbackup/arguments.py
+++ b/src/rdiffbackup/arguments.py
@@ -260,6 +260,7 @@ def _make_values_like_new_compat200(values):  # noqa C901 "too complex"
             values.action = "remove"
             values.entity = "increments"
             values.older_than = values.remove_older_than
+            values.size = False
         elif values.restore_as_of:
             values.action = "restore"
             values.at = values.restore_as_of

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -58,7 +58,8 @@ class Repo(locations.Location):
             # we delay the error handling until the check step,
             # and as well the definition of ref_path and ref_inc
         else:
-            self.ref_type = self.ref_index = None
+            self.ref_index = ()
+            self.ref_type = None
 
         # Finish the initialization with the identified base_dir
         super().__init__(base_dir, force)
@@ -81,7 +82,9 @@ class Repo(locations.Location):
                 self.ref_inc = self.data_dir.append_path(b'increments',
                                                          self.ref_index)
         else:
-            self.ref_path = self.ref_inc = None
+            self.ref_path = self.base_dir
+            self.ref_inc = self.data_dir.append_path(b'increments',
+                                                     self.ref_index)
             log.Log("Using repository '{re}'".format(re=self.base_dir),
                     log.INFO)
         ret_code = Globals.RET_CODE_OK

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -126,7 +126,7 @@ class ActionRemoveTest(unittest.TestCase):
         self.assertEqual(comtst.rdiff_backup_action(
             False, None, self.bak_path, None,
             ("--api-version", "201", ),
-            b"remove", ("increments", "--older-than", "30001")),
+            b"remove", ("increments", "--older-than", "30001", "--size")),
             Globals.RET_CODE_OK)
         # and check that only the mirror is left
         self.assertEqual(comtst.rdiff_backup_action(


### PR DESCRIPTION
Adds a --size option to the remove increments command that causes it to add these increment size to the lines showing the removed increments.

Closes #740
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc
-->

## Changes done and why

> **NOTE:** if your explanation needs to be (very) different from your Git commit message, your Git commit might be insufficient, please re-think it and amend it! Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

## Checklist

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC, FIX, NEW and/or CHG (see top of the changelog for details)
