### PR TITLE
Make more tests work under Windows

### DIFF
--- a/docs/Windows-DEVELOP.adoc
+++ b/docs/Windows-DEVELOP.adoc
@@ -158,6 +158,8 @@ Get a list of processes: `tasklist`
 
 Kill a process: `taskkill /IM firefox.exe /F`
 
+To get the return code of the last command (the equivalent of `$?` under Linux), call `echo %ERRORLEVEL%`.
+
 === Files handling
 
 To get a list of opened files, and the process accessing them:
@@ -170,6 +172,8 @@ openfiles /query /fo csv | find /I "<path>"
 ----
 
 With `icacls` you can list the (Windows) ACLs of a file.
+
+With `attrib` you can set the read-only attribute of a file.
 
 === Shells
 

--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -228,7 +228,7 @@ Start the server in debug mode so that it stops on an early breakpoint and can b
 See the https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#debug-client-server-mode[developer's documentation] for details.
 
 test _remote_location_1_ [_remote_location_2_ ...]::
-Test for the presence of a compatible rdiff-backup server as specified in the following remote location argument(s) (of which the filename section will be ignored).
+Test for the presence of a compatible rdiff-backup server as specified in the remote location argument(s) (of which the filename section will be checked for existence).
 See the <<_remote_operation,REMOTE OPERATION>> section for details.
 
 verify [*--at* _time_] _location_::

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -321,7 +321,7 @@ def set_all(setting_name, value):
     Where set relies on each connection to grab the value at a later stage,
     set_all forces the value on all connections at once.
     """
-    for conn in connections:
+    for conn in connection_dict.values():
         conn.Globals.set_local(setting_name, value)
 
 

--- a/src/rdiff_backup/longname.py
+++ b/src/rdiff_backup/longname.py
@@ -40,6 +40,7 @@ it later.
 
 import errno
 from rdiff_backup import Globals, log
+from rdiffbackup.utils import safestr
 
 _long_name_dir = b"long_filename_data"
 _long_name_rootrp = None
@@ -165,17 +166,10 @@ def update_rf(rf, rorp, mirror_root, rf_class):
     rf_class is the object type to return, RestoreFile or RegressFile
     """
 
-    def _safe_str(cmd):
-        """Transform bytes into string without risk of conversion error"""
-        if isinstance(cmd, str):
-            return cmd
-        else:
-            return str(cmd, errors='replace')
-
     def update_incs(rf, inc_base):
         """Swap inclist in rf with those with base inc_base and return"""
         log.Log("Restoring with increment base {ib} for file {rp}".format(
-            ib=_safe_str(inc_base), rp=rf), log.DEBUG)
+            ib=safestr.to_str(inc_base), rp=rf), log.DEBUG)
         rf.inc_rp = _get_long_rp(inc_base)
         rf.inc_list = _get_inclist(inc_base, rf_class)
         rf.set_relevant_incs()

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -634,7 +634,6 @@ class RPath(RORPath):
     identification (i.e. if two files have the the same (==) data
     dictionary, they are the same file).
     """
-    _regex_chars_to_quote = re.compile(b"[\\\\\\\"\\$`]")
     # class index to make temporary files unique, see get_temp_rpath
     _temp_file_index = 0
 
@@ -929,11 +928,6 @@ class RPath(RORPath):
                 if child_rp.contains_files():
                     return True
         return False
-
-    def quote(self):
-        """Return quoted self.path for use with os.system()"""
-        return b'"%s"' % self._regex_chars_to_quote.sub(
-            lambda m: b"\\" + m.group(0), self.path)
 
     def normalize(self):
         """Return RPath canonical version of self.path

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -32,6 +32,7 @@ from rdiff_backup import (
     rpath,
     Time,
 )
+from rdiffbackup.utils import safestr
 
 begin_time = None  # Parse statistics at or after this time...
 end_time = None  # ... and at or before this time (epoch seconds)
@@ -101,7 +102,7 @@ def version(rc):
 def os_system(cmd):
     sys.stdout.flush()
     if subprocess.call(cmd):
-        sys.exit("Error running command '%s'\n" % _safe_str(cmd))
+        sys.exit("Error running command '{rc}'".format(rc=safestr.to_str(cmd)))
 
 
 class StatisticsRPaths:
@@ -312,7 +313,8 @@ def _yield_fs_objs(filestatsobj):
             continue
         match = r.match(line)
         if not match:
-            sys.stderr.write("Error parsing line: %s\n" % _safe_str(line))
+            sys.stderr.write("Error parsing line: '{li}'\n".format(
+                li=safestr.to_str(line)))
             continue
 
         filename = match.group(1)
@@ -545,14 +547,6 @@ def set_chars_to_quote():
     if Globals.chars_to_quote:
         FilenameMapping.set_init_quote_vals()
         Globals.rbdir = FilenameMapping.get_quotedrpath(Globals.rbdir)
-
-
-def _safe_str(cmd):
-    """Transform bytes into string without risk of conversion error"""
-    if isinstance(cmd, str):
-        return cmd
-    else:
-        return str(cmd, errors='replace')
 
 
 def main_run():

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -26,7 +26,8 @@ documentation on what this code does can be found on the man page.
 import os
 import re
 import sys
-from . import robust, rpath, Globals, log, rorpiter
+from rdiff_backup import Globals, log, robust, rorpiter, rpath
+from rdiffbackup.utils import safestr
 
 
 class SelectError(Exception):
@@ -693,18 +694,12 @@ probably isn't what you meant""".format(se=self.selection_functions[-1].name))
     def _glob_get_prefix_res(self, glob_str):
         """Return list of regexps equivalent to prefixes of glob_str"""
 
-        def _safe_str(cmd):
-            """Transform bytes into string without risk of conversion error"""
-            if isinstance(cmd, str):
-                return cmd
-            else:
-                return str(cmd, errors='replace')
-
         glob_parts = glob_str.split(b"/")
         if b"" in glob_parts[1:
                              -1]:  # "" OK if comes first or last, as in /foo/
             raise GlobbingError(
-                "Consecutive '/'s found in globbing string %s" % _safe_str(glob_str))
+                "Consecutive '/'s found in globbing string {gs}".format(
+                    gs=safestr.to_str(glob_str)))
 
         prefixes = [
             b"/".join(glob_parts[:i + 1]) for i in range(len(glob_parts))

--- a/src/rdiffbackup/actions/complete.py
+++ b/src/rdiffbackup/actions/complete.py
@@ -203,6 +203,7 @@ class CompleteAction(actions.BaseAction):
                     return prev_option.choices
                 elif (isinstance(prev_option.type, argparse.FileType)
                         or (prev_option.type == str
+                            and isinstance(prev_option.metavar, str)
                             and prev_option.metavar.endswith('_FILE'))):
                     return ["::file::"]
                 else:  # we can't make any statement about the parameter

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -31,6 +31,7 @@ handle that error.)
 import os
 import re
 from rdiff_backup import Globals, log, rpath
+from rdiffbackup.utils import safestr
 
 
 class QuotingException(Exception):
@@ -197,18 +198,10 @@ def _unquote_single(match):
     Unquote a single quoted character
     """
     if not len(match.group()) == 4:
-        raise QuotingException("Quoted group wrong size: '%s'." % _safe_str(match.group()))
+        raise QuotingException("Quoted group wrong size: '{qg}'".format(
+            qg=safestr.to_str(match.group())))
     try:
         return os.fsencode(chr(int(match.group()[1:])))
     except ValueError:
-        raise QuotingException("Quoted out of range: '%s'." % _safe_str(match.group()))
-
-
-def _safe_str(cmd):
-    """
-    Transform bytes into string without risk of conversion error
-    """
-    if isinstance(cmd, str):
-        return cmd
-    else:
-        return str(cmd, errors='replace')
+        raise QuotingException("Quoted out of range: '{qg}'".format(
+            qg=safestr.to_str(match.group())))

--- a/src/rdiffbackup/locations/map/longnames.py
+++ b/src/rdiffbackup/locations/map/longnames.py
@@ -39,6 +39,7 @@ it later.
 
 import errno
 from rdiff_backup import Globals, log
+from rdiffbackup.utils import safestr
 
 _long_name_dir = b"long_filename_data"
 _long_name_rootrp = None
@@ -172,21 +173,12 @@ def update_rf(rf, rorp, mirror_root, rf_class):
     rf_class is the object type to return, RestoreFile or RegressFile
     """
 
-    def _safe_str(cmd):
-        """
-        Transform bytes into string without risk of conversion error
-        """
-        if isinstance(cmd, str):
-            return cmd
-        else:
-            return str(cmd, errors='replace')
-
     def update_incs(rf, inc_base):
         """
         Swap inclist in rf with those with base inc_base and return
         """
         log.Log("Restoring with increment base {ib} for file {rp}".format(
-            ib=_safe_str(inc_base), rp=rf), log.DEBUG)
+            ib=safestr.to_str(inc_base), rp=rf), log.DEBUG)
         rf.inc_rp = _get_long_rp(inc_base)
         rf.inc_list = _get_inclist(inc_base, rf_class)
         rf.set_relevant_incs()

--- a/src/rdiffbackup/meta/acl_win.py
+++ b/src/rdiffbackup/meta/acl_win.py
@@ -21,6 +21,7 @@ import re
 import os
 from rdiff_backup import C, Globals, log, rorpiter
 from rdiffbackup import meta
+from rdiffbackup.utils import safestr
 
 try:
     from win32security import (
@@ -183,18 +184,11 @@ class ACL:
                     "due to exception '{ex}'".format(pa=rp, ex=exc), log.INFO)
 
     def from_string(self, acl_str):
-
-        def _safe_str(cmd):
-            """Transform bytes into string without risk of conversion error"""
-            if isinstance(cmd, str):
-                return cmd
-            else:
-                return str(cmd, errors='replace')
-
         lines = acl_str.splitlines()
         if len(lines) != 2 or not lines[0][:8] == b"# file: ":
             raise meta.ParsingError(
-                "Bad record beginning: %s" % _safe_str(lines[0][:8]))
+                "Bad record beginning: '{br}'".format(
+                    br=safestr.to_str(lines[0][:8])))
         filename = lines[0][8:]
         if filename == b'.':
             self.index = ()

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -39,6 +39,7 @@ except ImportError:
 
 from rdiff_backup import C, Globals, log, rorpiter
 from rdiffbackup import meta
+from rdiffbackup.utils import safestr
 
 
 class ExtendedAttributes:
@@ -240,17 +241,9 @@ class ExtendedAttributesFile(meta.FlatFile):
     @staticmethod
     def join_iter(rorp_iter, ea_iter):
         """Update a rorp iter by adding the information from ea_iter"""
-
-        def _safe_str(cmd):
-            """Transform bytes into string without risk of conversion error"""
-            if isinstance(cmd, str):
-                return cmd
-            else:
-                return str(cmd, errors='replace')
-
         for rorp, ea in rorpiter.CollateIterators(rorp_iter, ea_iter):
             assert rorp, ("Missing rorp for EA index '{eaidx}'.".format(
-                eaidx=map(_safe_str, ea.index)))
+                eaidx=map(safestr.to_str, ea.index)))
             if not ea:
                 ea = get_meta_object(rorp.index)
             rorp.set_ea(ea)

--- a/src/rdiffbackup/utils/safestr.py
+++ b/src/rdiffbackup/utils/safestr.py
@@ -1,0 +1,29 @@
+# Copyright 2002 Ben Escoto
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+"""
+Simple function to safely transform bytes and other objects to string
+"""
+
+
+def to_str(something):
+    """Transform bytes into string without risk of conversion error"""
+    if isinstance(something, bytes):
+        return str(something, errors='replace')
+    else:
+        return str(something)

--- a/testing/action_compare_test.py
+++ b/testing/action_compare_test.py
@@ -90,9 +90,10 @@ class ActionCompareTest(unittest.TestCase):
             True, False, self.from2_path, self.bak_path,
             ("--api-version", "201"),
             b"compare", ("--at", "now", "--method", "hash")), 0)
+        # reduce verbosity to avoid file system quoting notes under Windows
         self.assertEqual(comtst.rdiff_backup_action(
             False, False, self.from3_path, self.bak_path,
-            ("--api-version", "201", "--parsable"),
+            ("--api-version", "201", "--parsable", "-v2"),
             b"compare", ("--method", "hash"), return_stdout=True),
             b"""---
 - path: fileChanged
@@ -110,9 +111,10 @@ class ActionCompareTest(unittest.TestCase):
             True, False, self.from1_path, self.bak_path,
             ("--api-version", "201"),
             b"compare", ("--at", "1B", "--method", "full")), 0)
+        # reduce verbosity to avoid file system quoting notes under Windows
         self.assertEqual(comtst.rdiff_backup_action(
             True, True, self.from3_path, self.bak_path,
-            ("--api-version", "201", "--parsable"),
+            ("--api-version", "201", "--parsable", "-v2"),
             b"compare", ("--method", "full"), return_stdout=True),
             b"""---
 - path: fileChanged

--- a/testing/action_list_test.py
+++ b/testing/action_list_test.py
@@ -10,7 +10,7 @@ import fileset
 
 class ActionListTest(unittest.TestCase):
     """
-    Test that rdiff-backup really restores what has been backed-up
+    Test that rdiff-backup properly lists files and increments
     """
 
     def setUp(self):

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -11,7 +11,7 @@ from rdiff_backup import Globals
 
 class ActionRemoveTest(unittest.TestCase):
     """
-    Test that rdiff-backup really restores what has been backed-up
+    Test that rdiff-backup properly removes increments
     """
 
     def setUp(self):

--- a/testing/action_test_test.py
+++ b/testing/action_test_test.py
@@ -1,24 +1,32 @@
+import os
 import unittest
 import commontest as comtst
 
 
 class ActionTestTest(unittest.TestCase):
     """Test api versioning functionality"""
+    def setUp(self):
+        if os.name == "nt":
+            self.dir1 = b"C:\\"
+            self.dir2 = b"C:\\"
+        else:
+            self.dir1 = b"/tmp"
+            self.dir2 = b"/var/tmp"
 
     def test_action_test(self):
         """test the "test" action"""
         # the test action works with one or two locations (or more)
         self.assertEqual(
-            comtst.rdiff_backup_action(False, False, b"/dummy1", b"/dummy2",
+            comtst.rdiff_backup_action(False, False, self.dir1, self.dir2,
                                        (), b"test", ()),
             0)
         self.assertEqual(
-            comtst.rdiff_backup_action(False, True, b"/dummy1", None,
+            comtst.rdiff_backup_action(False, True, self.dir1, None,
                                        (), b"test", ()),
             0)
         # but it doesn't work with a local one
         self.assertNotEqual(
-            comtst.rdiff_backup_action(False, True, b"/dummy1", b"/dummy2",
+            comtst.rdiff_backup_action(False, True, self.dir1, self.dir2,
                                        (), b"test", ()),
             0)
         # and it doesn't work without any location

--- a/testing/action_verify_test.py
+++ b/testing/action_verify_test.py
@@ -8,9 +8,9 @@ import commontest as comtst
 import fileset
 
 
-class ActionRemoveTest(unittest.TestCase):
+class ActionVerifyTest(unittest.TestCase):
     """
-    Test that rdiff-backup really restores what has been backed-up
+    Test that rdiff-backup properly verifies repositories
     """
 
     def setUp(self):

--- a/testing/cmdlinetest.py
+++ b/testing/cmdlinetest.py
@@ -325,6 +325,8 @@ class Final(PathSetter):
             compare_recursive(Local.wininc3, Local.rpout3, compare_hardlinks=0))
         self.rb_schema = old_schema
 
+    @unittest.skipIf(os.name == "nt",
+                     "Windows doesn't recognize case insensitivity")
     def testLegacy(self):
         """Test restoring directory with no mirror_metadata file"""
         self.delete_tmpdirs()

--- a/testing/comparetest.py
+++ b/testing/comparetest.py
@@ -5,6 +5,9 @@ from commontest import rdiff_backup, abs_output_dir, abs_test_dir, \
 from rdiff_backup import Globals, rpath
 """Test the compare.py module and overall compare functionality"""
 
+# FIXME the remote comparison tests have to be skipped under Windows
+# see https://github.com/rdiff-backup/rdiff-backup/issues/788
+
 
 class CompareTest(unittest.TestCase):
     def setUp(self):
@@ -42,6 +45,7 @@ class CompareTest(unittest.TestCase):
         """Test basic --compare and --compare-at-time modes"""
         self.generic_test(1, b"--compare")
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testBasicRemote(self):
         """Test basic --compare and --compare-at-time modes, both remote"""
         self.generic_test(0, b"--compare")
@@ -50,6 +54,7 @@ class CompareTest(unittest.TestCase):
         """Test --compare-hash and --compare-hash-at-time modes local"""
         self.generic_test(1, b"--compare-hash")
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testHashRemote(self):
         """Test --compare-hash and -at-time remotely"""
         self.generic_test(0, b"--compare-hash")
@@ -58,6 +63,7 @@ class CompareTest(unittest.TestCase):
         """Test --compare-full and --compare-full-at-time"""
         self.generic_test(1, b"--compare-full")
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testFullRemote(self):
         """Test full file compare remotely"""
         self.generic_test(0, b"--compare-full")
@@ -94,6 +100,7 @@ class CompareTest(unittest.TestCase):
         """Test basic local compare of single subdirectory"""
         self.generic_selective_test(1, b"--compare")
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelRemote(self):
         """Test --compare of single directory, remote"""
         self.generic_selective_test(0, b"--compare")
@@ -102,6 +109,7 @@ class CompareTest(unittest.TestCase):
         """Test --compare-hash of subdirectory, local"""
         self.generic_selective_test(1, b"--compare-hash")
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelHashRemote(self):
         """Test --compare-hash of subdirectory, remote"""
         self.generic_selective_test(0, b"--compare-hash")
@@ -110,6 +118,7 @@ class CompareTest(unittest.TestCase):
         """Test --compare-full of subdirectory, local"""
         self.generic_selective_test(1, b"--compare-full")
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelFullRemote(self):
         """Test --compare-full of subdirectory, remote"""
         self.generic_selective_test(0, b"--compare-full")

--- a/testing/incrementtest.py
+++ b/testing/incrementtest.py
@@ -14,15 +14,10 @@ def getrp(ending):
         lc, os.path.join(old_test_dir, b"various_file_types", ending))
 
 
+base_dir = getrp(b".")
 rf = getrp(b"regular_file")
 rf2 = getrp(b"two_hardlinked_files1")
 exec1 = getrp(b"executable")
-exec2 = getrp(b"executable2")
-sig = getrp(b"regular_file.sig")
-hl1, hl2 = list(
-    map(getrp, [b"two_hardlinked_files1", b"two_hardlinked_files2"]))
-test = getrp(b"test")
-dir = getrp(b".")
 sym = getrp(b"symbolic_link")
 nothing = getrp(b"nothing")
 
@@ -36,7 +31,6 @@ if os.name == "nt":
     prevtimestr = b"2001-09-02T02-48-33-07-00"
 else:
     prevtimestr = b"2001-09-02T02:48:33-07:00"
-t_pref = os.path.join(abs_output_dir, b"out.%s" % prevtimestr)
 t_diff = os.path.join(abs_output_dir, b"out.%s.diff" % prevtimestr)
 
 Globals.postset_regexp_local("no_compression_regexp",
@@ -81,6 +75,7 @@ class inctest(unittest.TestCase):
         self.assertEqual(missing_rp.getinctype(), b'missing')
         missing_rp.delete()
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testsnapshot(self):
         """Test making of a snapshot"""
         Globals.compression = None
@@ -96,6 +91,7 @@ class inctest(unittest.TestCase):
         self.assertTrue(rpath.cmp(snap_rp2, rf))
         snap_rp2.delete()
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testGzipsnapshot(self):
         """Test making a compressed snapshot"""
         Globals.compression = 1
@@ -113,16 +109,16 @@ class inctest(unittest.TestCase):
         self.assertTrue(rp.isinccompressed())
         rp.delete()
 
+    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testdir(self):
-        """Test increment on dir"""
-        rp = increment.Increment(sym, dir, target)
+        """Test increment on base_dir"""
+        rp = increment.Increment(sym, base_dir, target)
         self.check_time(rp)
         self.assertTrue(rp.lstat())
         self.assertTrue(target.isdir())
-        self.assertTrue(dir._equal_verbose(rp,
-                                           check_index=0,
-                                           compare_size=0,
-                                           compare_type=0))
+        self.assertTrue(base_dir._equal_verbose(rp, check_index=0,
+                                                compare_size=0,
+                                                compare_type=0))
         self.assertTrue(rp.isreg())
         rp.delete()
         target.delete()

--- a/testing/location_map_filenames_test.py
+++ b/testing/location_map_filenames_test.py
@@ -17,6 +17,8 @@ class LocationMapFilenamesTest(unittest.TestCase):
     def setUp(self):
         self.base_dir = os.path.join(comtst.abs_test_dir,
                                      b"location_map_filenames")
+        # Windows can't handle too long filenames
+        long_multi = 5 if os.name == "nt" else 25
         self.from1_struct = {
             "from1": {"subs": {
                 "fileABC": {"content": "initial"},
@@ -24,8 +26,10 @@ class LocationMapFilenamesTest(unittest.TestCase):
                 "dirAbCXyZ": {"type": "dir"},
                 "itemX": {"type": "dir"},
                 "itemY": {"type": "file"},
-                "longDiRnAm" * 25: {"type": "dir"},
-                "longFiLnAm" * 25: {"content": "not so long content"},
+                "longDiRnAm" * long_multi: {"type": "dir"},
+                "longFiLnAm" * long_multi: {"content": "not so long content"},
+                # it should be aux.123 but it can't be created under Windows
+                # and isn't special under Linux
                 "aux123": {"content": "looks like DOS file"},
                 "ends_in_blank ": {"content": "looks like DOS file"},
             }}
@@ -38,8 +42,10 @@ class LocationMapFilenamesTest(unittest.TestCase):
                 "diraBcXyZ": {"type": "dir"},
                 "itemX": {"type": "file"},
                 "itemY": {"type": "dir"},
-                "longDiRnAm" * 25: {"type": "dir"},
-                "longFiLnAm" * 25: {"content": "differently long"},
+                "longDiRnAm" * long_multi: {"type": "dir"},
+                "longFiLnAm" * long_multi: {"content": "differently long"},
+                # it should be aux.123 but it can't be created under Windows
+                # and isn't special under Linux
                 "aux123": {"content": "still looks like DOS file"},
                 "ends_in_blank ": {"content": "still looks like DOS file"},
             }}

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -25,14 +25,14 @@ commands =
 # The commented tests do not run on Windows yet and will be fixed & uncommented one by one
     python testing/action_backuprestore_test.py --verbose --buffer
     python testing/action_calculate_test.py --verbose --buffer
-#    python testing/action_compare_test.py --verbose --buffer
+    python testing/action_compare_test.py --verbose --buffer
     python testing/action_list_test.py --verbose --buffer
     python testing/action_regress_test.py --verbose --buffer
     python testing/action_remove_test.py --verbose --buffer
-#    python testing/action_test_test.py --verbose --buffer
+    python testing/action_test_test.py --verbose --buffer
     python testing/action_verify_test.py --verbose --buffer
     python testing/api_test.py --verbose --buffer
-#    python testing/location_map_filenames_test.py --verbose --buffer
+    python testing/location_map_filenames_test.py --verbose --buffer
 #    python testing/location_map_hardlinks_test.py --verbose --buffer
     python testing/location_lock_test.py --verbose --buffer
     python testing/utils_simpleps_test.py --verbose --buffer
@@ -46,7 +46,7 @@ commands =
 #    python testing/longnametest.py  # handling of long filenames too different
     python testing/robusttest.py
     python testing/connectiontest.py
-#    python testing/incrementtest.py  # issue with symlinks
+    python testing/incrementtest.py  # skipping symlinks
 #    python testing/hardlinktest.py  # too many path errors
 #    python testing/eas_aclstest.py  # no module named pwd under Windows
 #    python testing/FilenameMappingtest.py  # issues with : in date/time-string
@@ -54,13 +54,13 @@ commands =
     python testing/hashtest.py
     python testing/selectiontest.py
 #    python testing/metadatatest.py  # issues with : in date/time/string
-#    python testing/rpathtest.py  # many small issues
+    python testing/rpathtest.py
     python testing/rorpitertest.py
     python testing/rdifftest.py
 #    python testing/securitytest.py  # no os.getuid + backslash in path handlingon --server
 #    python testing/killtest.py  # cannot create symbolic link
 #    python testing/backuptest.py  # No module named rdiff_backup in server.py
-#    python testing/comparetest.py  # No module named rdiff_backup in server.py
+    python testing/comparetest.py
 #    python testing/regresstest.py  # issue with : in date/time/string
 #    python testing/restoretest.py  # too many issues to count
 #    python testing/cmdlinetest.py  # too many issues to count


### PR DESCRIPTION
## Changes done and why

* action_compare_test
* action_test_test
* location_map_filenames_test (by reducing filename length under Windows)
* incrementtest (skipping symlink tests)
* rpathtest (many small fixes, get rid of unused rpath.quote)
* comparetest (skip tests involving symlinks)

CHG: the remote directory/ies used for the 'test' action must exist for the test to succeed (it was always the case under Windows but is new for Linux)
DEV: replace the multiple _safe_str functions through utils.safestr.to_str
FIX: command line completion would fail on parameter --remote-schema
FIX: remove some typos due to cut&paste in action tests, closes #785
FIX: make Globals.set_all to work truly on all connections when working across two servers (and not only one client and one server), was necessary to make compare work when paths are quoted (especially under Windows)

(I could spend much more time on this, but it should be good enough for now, I think I'll continue once I've added symlink support)

## Checklist

- [ ] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [ ] commit contains a description of changes relevant to users prefixed by DOC, FIX, NEW and/or CHG (see top of the changelog for details)
