### PR TITLE
Fix EINVAL exception when trying to remove EA on NFS

### DIFF
--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -415,6 +415,7 @@ class FSAbilities:
             if write:
                 xattr.set(rp.path, b"user.test", test_ea)
                 read_ea = xattr.get(rp.path, b"user.test")
+                xattr.remove(rp.path, b"user.test")
         except OSError as exc:
             log.Log("Extended attributes not supported by filesystem at "
                     "path {pa} due to exception '{ex}'".format(pa=rp, ex=exc),

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -432,6 +432,7 @@ class FSAbilities:
             if write:
                 xattr.set(rp.path, b"user.test", test_ea)
                 read_ea = xattr.get(rp.path, b"user.test")
+                xattr.remove(rp.path, b"user.test")
         except OSError as exc:
             log.Log("Extended attributes not supported by filesystem at "
                     "path {pa} due to exception '{ex}'".format(pa=rp, ex=exc),

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -150,12 +150,16 @@ class ExtendedAttributes:
                             log.DEBUG)
                     continue
                 except OSError as exc:
-                    # can happen because trusted.SGI_ACL_FILE is deleted
+                    # EINVAL is thrown on trying to remove system.nfs4_acl
+                    # ENODATA can happen because trusted.SGI_ACL_FILE is deleted
                     # together with system.posix_acl_access on XFS file systems.
-                    if exc.errno == errno.ENODATA:
+                    if exc.errno in (errno.EINVAL, errno.ENODATA):
                         continue
                     else:  # can be anything, just fail
-                        raise
+                        log.Log.FatalError(
+                            "Can't remove extended attribute '{ea}' from "
+                            "path '{pa}' due to unexpected "
+                            "exception '{ue}'".format(ea=name, pa=rp, ue=exc))
         except io.UnsupportedOperation:  # errno.EOPNOTSUPP or errno.EPERM
             return  # if not supported, consider empty
         except FileNotFoundError as exc:


### PR DESCRIPTION
## Changes done and why

FIX: failure when trying to remove Extended Attributes on an NFS share, closes #789

## Checklist

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC, FIX, NEW and/or CHG (see top of the changelog for details)

(no documentation change required, and can't be tested without an NFS share)