### PR TITLE
Fix recognition of remote Windows OS

### DIFF
--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -163,12 +163,13 @@ toc::[]
 * `os.mkdir`
 * `os.mkfifo`
 * `os.mknod`
-* `os.name`
+* `os.name`  **deprecated**  // never worked remotely
 * `os.rename`
 * `os.rmdir`
 * `os.symlink`
 * `os.unlink`
 * `os.utime`
+* `platform.system`  **new**
 * `shutil.rmtree`
 * `sys.stdout.write`
 * `win32security.ConvertSecurityDescriptorToStringSecurityDescriptor`  **unused**

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -249,9 +249,11 @@ def _set_allowed_requests(sec_class, sec_level):
             # System
             "os.getuid",
             "os.listdir",
-            "os.name",
             # API < 201
+            "os.name",  # doesn't work because not callable but attribute!
             "Hardlink.initialize_dictionaries",
+            # API >= 201
+            "platform.system",
         ])
     if sec_level == "read-only" or sec_level == "read-write":
         requests.update([

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -24,6 +24,7 @@ import traceback
 # we need those imports because they are used through the connection
 import gzip  # noqa: F401
 import os  # noqa: F401
+import platform  # noqa: F401
 import shutil  # noqa: F401
 import socket  # noqa: F401
 import tempfile  # noqa: F401
@@ -537,14 +538,14 @@ class EmulateCallable:
 
     def __init__(self, connection, name):
         self.connection = connection
-        self.name = name
+        self.call_name = name
 
     def __call__(self, *args):
-        return self.connection.reval(*(self.name, ) + args)
+        return self.connection.reval(*(self.call_name, ) + args)
 
     def __getattr__(self, attr_name):
         return EmulateCallable(self.connection,
-                               "%s.%s" % (self.name, attr_name))
+                               "%s.%s" % (self.call_name, attr_name))
 
 
 class EmulateCallableRedirected:
@@ -552,15 +553,15 @@ class EmulateCallableRedirected:
 
     def __init__(self, conn_number, routing_conn, name):
         self.conn_number, self.routing_conn = conn_number, routing_conn
-        self.name = name
+        self.call_name = name
 
     def __call__(self, *args):
         return self.routing_conn.reval(
-            *("RedirectedRun", self.conn_number, self.name) + args)
+            *("RedirectedRun", self.conn_number, self.call_name) + args)
 
     def __getattr__(self, attr_name):
         return EmulateCallableRedirected(self.conn_number, self.routing_conn,
-                                         "%s.%s" % (self.name, attr_name))
+                                         "%s.%s" % (self.call_name, attr_name))
 
 
 class VirtualFile:

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -766,7 +766,11 @@ class RPath(RORPath):
         except OSError:
             # It's not possible to set a modification time for
             # directories on Windows.
-            if self.conn.os.name != 'nt' or not self.isdir():
+            if Globals.get_api_version() < 201:  # compat200
+                is_windows = self.conn.os.name == "nt"
+            else:
+                is_windows = self.conn.platform.system() == "Windows"
+            if not (is_windows and self.isdir()):
                 raise
         else:
             self.data['mtime'] = modtime

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -766,12 +766,14 @@ class RPath(RORPath):
         except OSError:
             # It's not possible to set a modification time for
             # directories on Windows.
-            if Globals.get_api_version() < 201:  # compat200
-                is_windows = self.conn.os.name == "nt"
-            else:
-                is_windows = self.conn.platform.system() == "Windows"
-            if not (is_windows and self.isdir()):
+            if not self.isdir():
                 raise
+            if Globals.get_api_version() < 201:  # compat200
+                if self.conn.os.name != "nt":  # doesn't work, just historical
+                    raise
+            else:
+                if self.conn.platform.system() != "Windows":
+                    raise
         else:
             self.data['mtime'] = modtime
 

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -69,12 +69,17 @@ class ReadDir(Dir, locations.ReadLocation):
         side over its connection.
         """
 
+        if Globals.get_api_version() < 201:  # compat200
+            is_windows = self.base_dir.conn.os.name == "nt"
+        else:
+            is_windows = self.base_dir.conn.platform.system() == "Windows"
+
         # FIXME not sure we couldn't support symbolic links nowadays on Windows
         # knowing that it would require specific handling when reading the link:
         #   File "rdiff_backup\rpath.py", line 771, in symlink
         #   TypeError: symlink: src should be string, bytes or os.PathLike, not NoneType
         # I suspect that not all users can read symlinks with os.readlink
-        if (self.base_dir.conn.os.name == 'nt'
+        if (is_windows
                 and ("--exclude-symbolic-links", None) not in select_opts):
             log.Log("Symbolic links excluded by default on Windows",
                     log.NOTE)

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -157,10 +157,10 @@ class ExtendedAttributes:
                     if exc.errno in (errno.EINVAL, errno.ENODATA):
                         continue
                     else:  # can be anything, just fail
-                        log.Log.FatalError(
+                        log.Log(
                             "Can't remove extended attribute '{ea}' from "
-                            "path '{pa}' due to unexpected "
-                            "exception '{ue}'".format(ea=name, pa=rp, ue=exc))
+                            "path '{pa}'".format(ea=name, pa=rp), log.ERROR)
+                        raise
         except io.UnsupportedOperation:  # errno.EOPNOTSUPP or errno.EPERM
             return  # if not supported, consider empty
         except FileNotFoundError as exc:

--- a/testing/comparetest.py
+++ b/testing/comparetest.py
@@ -2,6 +2,7 @@ import unittest
 import os
 from commontest import rdiff_backup, abs_output_dir, abs_test_dir, \
     old_inc2_dir, old_inc3_dir, re_init_subdir
+import commontest as comtst
 from rdiff_backup import Globals, rpath
 """Test the compare.py module and overall compare functionality"""
 
@@ -15,113 +16,115 @@ class CompareTest(unittest.TestCase):
         rdiff_backup(1, 1, old_inc2_dir, self.outdir, current_time=10000)
         rdiff_backup(1, 1, old_inc3_dir, self.outdir, current_time=20000)
 
-    def generic_test(self, local, compare_option):
+    def generic_test(self, local, compare_method):
         """Used for 6 tests below"""
-        rdiff_backup(local,
-                     local,
-                     old_inc3_dir,
-                     self.outdir,
-                     extra_options=compare_option)
-        self.assertTrue(rdiff_backup(local,
-                                     local,
-                                     old_inc2_dir,
-                                     self.outdir,
-                                     extra_options=compare_option,
-                                     expected_ret_code=None))
-        rdiff_backup(local,
-                     local,
-                     old_inc2_dir,
-                     self.outdir,
-                     extra_options=compare_option + b"-at-time 10000")
-        self.assertTrue(
-            rdiff_backup(local,
-                         local,
-                         old_inc3_dir,
-                         self.outdir,
-                         extra_options=compare_option + b"-at-time 10000",
-                         expected_ret_code=None))
+        if not local:  # need a fix for Windows only present in API 201
+            options = ("--api-version", "201")
+        else:
+            options = ()  # just to also test the old API
+        compare_options = ("--method", compare_method)
+
+        self.assertEqual(comtst.rdiff_backup_action(
+            local, local, old_inc3_dir, self.outdir, options,
+            b"compare", compare_options), Globals.RET_CODE_OK)
+        self.assertNotEqual(comtst.rdiff_backup_action(
+            local, local, old_inc2_dir, self.outdir, options,
+            b"compare", compare_options), Globals.RET_CODE_OK)
+
+        compare_options += ("--at", "10000")
+
+        self.assertEqual(comtst.rdiff_backup_action(
+            local, local, old_inc2_dir, self.outdir, options,
+            b"compare", compare_options), Globals.RET_CODE_OK)
+        self.assertNotEqual(comtst.rdiff_backup_action(
+            local, local, old_inc3_dir, self.outdir, options,
+            b"compare", compare_options), Globals.RET_CODE_OK)
 
     def testBasicLocal(self):
         """Test basic --compare and --compare-at-time modes"""
-        self.generic_test(1, b"--compare")
+        self.generic_test(1, b"meta")
 
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testBasicRemote(self):
         """Test basic --compare and --compare-at-time modes, both remote"""
-        self.generic_test(0, b"--compare")
+        self.generic_test(0, b"meta")
 
     def testHashLocal(self):
         """Test --compare-hash and --compare-hash-at-time modes local"""
-        self.generic_test(1, b"--compare-hash")
+        self.generic_test(1, b"hash")
 
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testHashRemote(self):
         """Test --compare-hash and -at-time remotely"""
-        self.generic_test(0, b"--compare-hash")
+        self.generic_test(0, b"hash")
 
     def testFullLocal(self):
         """Test --compare-full and --compare-full-at-time"""
-        self.generic_test(1, b"--compare-full")
+        self.generic_test(1, b"full")
 
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testFullRemote(self):
         """Test full file compare remotely"""
-        self.generic_test(0, b"--compare-full")
+        self.generic_test(0, b"full")
 
-    def generic_selective_test(self, local, compare_option):
+    def generic_selective_test(self, local, compare_method):
         """Used for selective tests--just compare part of a backup"""
-        rdiff_backup(local,
-                     local,
-                     os.path.join(old_inc3_dir, b'various_file_types'),
-                     os.path.join(abs_output_dir, b'various_file_types'),
-                     extra_options=compare_option)
-        self.assertTrue(
-            rdiff_backup(local,
-                         local,
-                         os.path.join(old_inc2_dir, b'increment1'),
-                         os.path.join(abs_output_dir, b'increment1'),
-                         extra_options=compare_option,
-                         expected_ret_code=None))
+        if not local:  # need a fix for Windows only present in API 201
+            options = ("--api-version", "201")
+        else:
+            options = ()  # just to also test the old API
+        compare_options = ("--method", compare_method)
 
-        rdiff_backup(local,
-                     local,
-                     os.path.join(old_inc2_dir, b'newdir'),
-                     os.path.join(abs_output_dir, b'newdir'),
-                     extra_options=compare_option + b"-at-time 10000")
-        self.assertTrue(
-            rdiff_backup(local,
-                         local,
-                         os.path.join(old_inc3_dir, b'newdir'),
-                         os.path.join(abs_output_dir, b'newdir'),
-                         extra_options=compare_option + b"-at-time 10000",
-                         expected_ret_code=None))
+        self.assertEqual(comtst.rdiff_backup_action(
+            local, local,
+            os.path.join(old_inc3_dir, b'various_file_types'),
+            os.path.join(abs_output_dir, b'various_file_types'),
+            options, b"compare", compare_options), Globals.RET_CODE_OK)
+        self.assertNotEqual(comtst.rdiff_backup_action(
+            local, local,
+            os.path.join(old_inc2_dir, b'increment1'),
+            os.path.join(abs_output_dir, b'increment1'),
+            options, b"compare", compare_options), Globals.RET_CODE_OK)
+
+        compare_options += ("--at", "10000")
+
+        self.assertEqual(comtst.rdiff_backup_action(
+            local, local,
+            os.path.join(old_inc2_dir, b'newdir'),
+            os.path.join(abs_output_dir, b'newdir'),
+            options, b"compare", compare_options), Globals.RET_CODE_OK)
+        self.assertNotEqual(comtst.rdiff_backup_action(
+            local, local,
+            os.path.join(old_inc3_dir, b'newdir'),
+            os.path.join(abs_output_dir, b'newdir'),
+            options, b"compare", compare_options), Globals.RET_CODE_OK)
 
     def testSelLocal(self):
         """Test basic local compare of single subdirectory"""
-        self.generic_selective_test(1, b"--compare")
+        self.generic_selective_test(1, b"meta")
 
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelRemote(self):
         """Test --compare of single directory, remote"""
-        self.generic_selective_test(0, b"--compare")
+        self.generic_selective_test(0, b"meta")
 
     def testSelHashLocal(self):
         """Test --compare-hash of subdirectory, local"""
-        self.generic_selective_test(1, b"--compare-hash")
+        self.generic_selective_test(1, b"hash")
 
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelHashRemote(self):
         """Test --compare-hash of subdirectory, remote"""
-        self.generic_selective_test(0, b"--compare-hash")
+        self.generic_selective_test(0, b"hash")
 
     def testSelFullLocal(self):
         """Test --compare-full of subdirectory, local"""
-        self.generic_selective_test(1, b"--compare-full")
+        self.generic_selective_test(1, b"full")
 
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelFullRemote(self):
         """Test --compare-full of subdirectory, remote"""
-        self.generic_selective_test(0, b"--compare-full")
+        self.generic_selective_test(0, b"full")
 
     def verify(self, local):
         """Used for the verify tests"""

--- a/testing/comparetest.py
+++ b/testing/comparetest.py
@@ -44,7 +44,6 @@ class CompareTest(unittest.TestCase):
         """Test basic --compare and --compare-at-time modes"""
         self.generic_test(1, b"meta")
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testBasicRemote(self):
         """Test basic --compare and --compare-at-time modes, both remote"""
         self.generic_test(0, b"meta")
@@ -53,7 +52,6 @@ class CompareTest(unittest.TestCase):
         """Test --compare-hash and --compare-hash-at-time modes local"""
         self.generic_test(1, b"hash")
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testHashRemote(self):
         """Test --compare-hash and -at-time remotely"""
         self.generic_test(0, b"hash")
@@ -62,7 +60,6 @@ class CompareTest(unittest.TestCase):
         """Test --compare-full and --compare-full-at-time"""
         self.generic_test(1, b"full")
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testFullRemote(self):
         """Test full file compare remotely"""
         self.generic_test(0, b"full")
@@ -103,7 +100,6 @@ class CompareTest(unittest.TestCase):
         """Test basic local compare of single subdirectory"""
         self.generic_selective_test(1, b"meta")
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelRemote(self):
         """Test --compare of single directory, remote"""
         self.generic_selective_test(0, b"meta")
@@ -112,7 +108,6 @@ class CompareTest(unittest.TestCase):
         """Test --compare-hash of subdirectory, local"""
         self.generic_selective_test(1, b"hash")
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelHashRemote(self):
         """Test --compare-hash of subdirectory, remote"""
         self.generic_selective_test(0, b"hash")
@@ -121,7 +116,6 @@ class CompareTest(unittest.TestCase):
         """Test --compare-full of subdirectory, local"""
         self.generic_selective_test(1, b"full")
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testSelFullRemote(self):
         """Test --compare-full of subdirectory, remote"""
         self.generic_selective_test(0, b"full")

--- a/tox.ini
+++ b/tox.ini
@@ -92,8 +92,10 @@ commands =
 
 [flake8]
 ignore =
-	E501 # line too long (86 > 79 characters)
-	W503 # line break before binary operator
+	# line too long (86 > 79 characters)
+	E501
+	# line break before binary operator
+	W503
 filename =
 	*.py,
 	src/rdiff-backup*

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -78,8 +78,10 @@ commands =
 
 [flake8]
 ignore =
-    E501 # line too long (86 > 79 characters)
-    W503 # line break before binary operator
+    # line too long (86 > 79 characters)
+    E501
+    # line break before binary operator
+    W503
 exclude =
     .git
     .tox


### PR DESCRIPTION
## Changes done and why

FIX: failed to properly recognize remote OS as being Windows, closes #788
    
Also reduced a bit the impact of the previous change, because a normal exception might be catched at the file level, whereas FatalError would always exit

Modify comparetest.py to use new feature. Allow remote parts of comparetest to work under Windows

## Checklist

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC, FIX, NEW and/or CHG (see top of the changelog for details)