### PR TITLE
Fix sdist creation with included manpages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0  # to have the correct version
+    - name: Install asciidoctor to generate manpages
+      run: |
+        sudo apt-get --assume-yes update
+        sudo apt-get --assume-yes install asciidoctor
     - name: create source dist package
       run: python setup.py sdist
     - name: Upload sdist artifact
@@ -96,7 +100,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: package-artifacts
-        path: dist/*.*
+        path: |
+          dist/*.zip
+          dist/*.whl
         if-no-files-found: error
 
   test-built-windows:


### PR DESCRIPTION


## Changes done and why

FIX: pipeline would create sdist without manpages because asciidoctor wasn't installed, closes #813

## Self-Checklist

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes
    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
    * relevant to the web-site prefixed by WEB:
    * relevant to developers prefixed by DEV:
