### PR TITLE
[DOC] docs/examples.adoc: fix typo: --print-statistics comes after backup.

### DIFF
--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -50,7 +50,7 @@ Below we have also added the `-v5` switch for greater verbosity (verbosity setti
 ----
 rdiff-backup -v5 --print-statistics user1@host1::/source-dir user2@host2::/dest-dir
 
-rdiff-backup -v5 --print-statistics backup user1@host1::/source-dir user2@host2::/dest-dir
+rdiff-backup -v5 backup --print-statistics user1@host1::/source-dir user2@host2::/dest-dir
 ----
 
 == Restoring


### PR DESCRIPTION
## Changes done and why

The option `--print-statistics` should come *after* the `backup` command.  In the Examples, [Section 2](https://rdiff-backup.net/examples.html#backing_up) of the documentation, this is shown as `--print-statistics backup`.  This is the wrong way around; a typo in the documentation.  This typo has been addressed in `docs/examples.adoc` in this PR and should fix Issue #820.

## Self-Checklist

- [x] changes to the code have been reflected in the documentation;  *Irrelevant: change in documentation only.*
- [X] changes to the code have been covered by new/modified tests;  *Irrelevant: change in documentation only.*
- [X] commit contains a description of changes
    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
    * relevant to the web-site prefixed by WEB:
    * relevant to developers prefixed by DEV: