### PR TITLE
allow user to use curly braces for shell purposes in remote-schema

### DIFF
--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -486,7 +486,9 @@ For example, if you have rdiff-backup 2.1.5 and 2.2.1 installed in virtual envir
 The client will then use the correct version of rdiff-backup based on its own version '[.code]``x.y.z``'.
 You'll find more explanations in the *migration* file in the documentation.
 
-And finally, to include a literal '[.code]``%``' in the string specified by *--remote-schema*, quote it with another '[.code]``%``', as in '[.code]``%%``' (this is due to the compatibility with the deprecated host placeholder '[.code]``%s``', which you shouldn't use anymore).
+If you need to include a literal '[.code]``%``' in the string specified by *--remote-schema*, quote it with another '[.code]``%``', as in '[.code]``%%``' (this is due to the compatibility with the deprecated host placeholder '[.code]``%s``', which you shouldn't use anymore).
+
+And finally, if you need to include literal '[.code]``{ }``' (curly braces) in the the string specified by *--remote-schema*, quote them (both) by doubling each of them up, as in '[.code]``{{ foo=0; }}``'.
 
 Although ssh itself may be secure, using rdiff-backup in the default way presents some security risks.
 For instance if the server is run as root, then an attacker who compromised the client could then use rdiff-backup to overwrite arbitrary server files by "backing up" over them.

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -279,8 +279,14 @@ def _fill_schema(host_info, cmd_schema):
     try:
         # for security reasons, we accept only specific format placeholders
         # h for host_info, Vx,Vy,Vz for version x.y.z
-        # and the host placeholder is mandatory
-        if ((re.findall(b"{[^}]*}", cmd_schema)
+        # and the host placeholder is mandatory;
+        # some shells allow use of curly braces for various purposes, so we
+        # must provide a way to allow the user to use them in their remote-
+        # schema: format() provides a ready-made way to do this with their
+        # escape mechanism of doubling-up the braces {{ }}, so our findall
+        # check must ignore the doubled-up ones in its validation check
+        # using a simple negative-lookbehind
+        if ((re.findall(b"(?<!{){[^{}]*}", cmd_schema)
              != re.findall(b"{h}|{V[xyz]}", cmd_schema))
                 or (b"{h}" not in cmd_schema
                     and b"%s" not in cmd_schema)):  # compat200


### PR DESCRIPTION
## Changes done and why

FIX allow user to use curly braces for shell purposes in remote-schema

Change the are-there-any-unrecognized-curly-braces test to exclude doubled-up curly braces so that the user can include in their remote-schema curly-braces that are meant to be passed as-is to the shell.

format() will then change the doubled-up curly braces into a single one, and that is what will be passed to the remote shell.

bash and tcsh allow curly braces in command lines for various purposes.  My main use is in bash to group commands for && conditional execution without starting a subshell, because I need to obtain the results of a variable within the group outside the group.  A subshell would not allow the return of variables, only an exit code.

The easiest test case that illustrates my goal is below.  The test case might be achieved without the {{}}, but it somewhat reflects what I need to do in any case.

rdiff-backup --remote-schema 'ssh -x -C {h} "( {{ ret=1; ls /tmp/dobackup >/dev/null 2>&1 && rdiff-backup server && ret=0; }} ; exit \$ret ) | pv -L 50000"' backup me@foo.baz::/tmp/Z /tmp/RD

Fixes #818


## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [X] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [X] commit contains a description of changes
    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
    * relevant to the web-site prefixed by WEB:
    * relevant to developers prefixed by DEV:
