### PR TITLE
[DOC] Improve commit messages documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,14 +40,8 @@
 
 - [ ] changes to the code have been reflected in the documentation
 - [ ] changes to the code have been covered by new/modified tests
-- [ ] commit contains a description of changes
-    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
-    * relevant to the web-site prefixed by WEB:
-    * relevant to developers prefixed by DEV:
+- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
 
 <!--
-    for details on this last point, check:
-
-    * either the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#22-branching-model-and-pull-requests)s
-    * or the top of the [changelog](https://github.com/rdiff-backup/rdiff-backup/blob/master/CHANGELOG.adoc)
+    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
 -->

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,8 +7,7 @@ The prefixes are to be understood as follows, in roughly decreasing order of imp
 
 * *CHG* marks changes in the behaviour of rdiff-backup, potentially _incompatible_ ones, which you will want to consider before you upgrade or use for the 1st time a new version.
 * *NEW* features and bug-**FIX**es are of course of interest as well.
-* **DOC**umentation and *WEB*-site changes are marked as such.
-* And **DEV**elopment changes are only of interest for developers and testers.
+* **DOC**umentation (and website) changes are marked as such.
 
 == New in v2.2.2 (2022-12-28)
 

--- a/docs/DEVELOP.adoc
+++ b/docs/DEVELOP.adoc
@@ -36,6 +36,38 @@ It might provide useful insight why the current state is as it is.
 Rdiff-backup is licensed with GNU General Public License v2.0 or later.
 By contributing to this repository you agree that your work is licensed using the chosen project license.
 
+[[commits]]
+=== Commit messages
+
+If something is of interest for the changelog, prefix the statement in the commit _body_ with a three uppercase letters and a colon:
+
+* FIX: for a bug fix
+* NEW: for a new feature
+* CHG: for a change requesting consideration when upgrading
+* DOC: for documentation and website aspects
+
+If the commit addresses a specific issue, end the statement with a `, closes #NNN` message, `NNN` being of course the number of the issue.
+
+Multiple entries might be required for one single change, e.g. `NEW` if you introduce a new feature, and `CHG` because this new features introduces some breaking changes on which the user needs to take actions at upgrade time.
+You don't need to notice that you've added documentation with `DOC` for a new feature, this is obvious and redundant; `DOC` should be reserved for solely documentation changes.
+
+TIP: make sure that your commit was properly formatted by calling `./tools/get_changelog_since.sh v2.2.2` (or whichever is the last released version), and checking that the _whole_ message is present.
+Beware that the interactive `git commit` command tends to split long lines, which is contraproductive in our use case.
+
+In summary, any commit message could look as follows:
+
+[code,shell]
+----
+git commit -m "Some commit title summarizing the change
+
+DOC: some understandable message on one single line explaining clearly the documentation change, closes #123
+
+Further development notes, important (and recommended) but not fit for end-user changelog"
+----
+
+TIP: check `git log` for earlier examples.
+Note that the `DEV` prefix has been deprecated.
+
 === Branching model and pull requests
 
 The _master_ branch is always kept in a clean state.
@@ -54,15 +86,6 @@ if not quickly merged) and overall to support the review process.
 
 Ideally each pull request gets some feedback within 24 hours from it having been filed, and is merged within days or a couple of weeks.
 Each author should facilitate quick reviews and merges by making clean and neat commits and pull requests that are quick to review and do not spiral out in long discussions.
-
-If something is of interest for the changelog, prefix the statement in the commit body with a three uppercase letters and a colon;
-which acronym is not that important but here is a list of recommended ones (see the release section to understand why it's important):
-
-* FIX: for a bug fix
-* NEW: for a new feature
-* CHG: for a change requesting consideration when upgrading
-* DOC: for documentation aspects
-* WEB: anything regarding the website
 
 ==== Merging changes to master
 


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

DOC: better describe what is expected from commit messages, get rid of DEV and WEB prefixes, as irrelevant to end-users changelog

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes
    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
    * relevant to the web-site prefixed by WEB:
    * relevant to developers prefixed by DEV:

<!--
    for details on this last point, check:

    * either the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#22-branching-model-and-pull-requests)s
    * or the top of the [changelog](https://github.com/rdiff-backup/rdiff-backup/blob/master/CHANGELOG.adoc)
-->
