### PR TITLE
Fix CloseConnections doesn't wait for child to die

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -35,10 +35,6 @@ from rdiffbackup.utils import safestr
 # The first is None because it is the local connection.
 __conn_remote_cmds = [None]
 
-# keep a list of sub-processes running; we don't use it, it's only to avoid
-# "ResourceWarning: subprocess N is still running" from subprocess library
-_processes = []
-
 
 class SetConnectionsException(Exception):
     pass
@@ -312,7 +308,6 @@ def _init_connection(remote_cmd):
     like global settings, its connection number, and verbosity.
 
     """
-    global _processes
     if not remote_cmd:
         return Globals.local_connection
 
@@ -335,12 +330,10 @@ def _init_connection(remote_cmd):
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE)
         (stdin, stdout) = (process.stdin, process.stdout)
-        # only to avoid resource warnings about subprocess still running
-        _processes.append(process)
     except OSError:
         (stdin, stdout) = (None, None)
     conn_number = len(Globals.connections)
-    conn = connection.PipeConnection(stdout, stdin, conn_number)
+    conn = connection.PipeConnection(stdout, stdin, conn_number, process)
 
     if not _validate_connection_version(conn, remote_cmd):
         return None

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -29,6 +29,7 @@ import shutil  # noqa: F401
 import socket  # noqa: F401
 import tempfile  # noqa: F401
 import types  # noqa: F401
+import time
 
 # The following EA and ACL modules may be used if available
 try:  # compat200
@@ -157,10 +158,11 @@ class LowLevelPipeConnection(Connection):
 
     """
 
-    def __init__(self, inpipe, outpipe):
+    def __init__(self, inpipe, outpipe, process=None):
         """inpipe is a file-type open for reading, outpipe for writing"""
         self.inpipe = inpipe
         self.outpipe = outpipe
+        self.process = process
 
     def __str__(self):
         """Return string version
@@ -363,6 +365,23 @@ class LowLevelPipeConnection(Connection):
         """Close the pipes associated with the connection"""
         self.outpipe.close()
         self.inpipe.close()
+        # reap the pipe child with wait() to ensure any final output from
+        # the pipe by commands that run after rdiff-backup server; otherwise
+        # a race condition occurs where final output is sometimes lost;
+        # Python>=3.3 gives the timeout option to wait: set to a modestly
+        # small value here to minimize possibility of introducing bugs/delays
+        if self.process:
+            try:
+                self.process.wait(5)
+            except TimeoutExpired:
+                # if some longer delay occurred, just kill it, try hard so
+                # we avoid the ResourceWarning if it's still running when
+                # the subprocess destructors hit; yes ugly sleeps, but rare
+                self.process.terminate()
+                time.sleep(1)
+                if (self.process.poll() is None):
+                    self.process.kill()
+                    time.sleep(1)
 
 
 class PipeConnection(LowLevelPipeConnection):
@@ -377,7 +396,7 @@ class PipeConnection(LowLevelPipeConnection):
 
     """
 
-    def __init__(self, inpipe, outpipe, conn_number=0):
+    def __init__(self, inpipe, outpipe, conn_number=0, process=None):
         """Init PipeConnection
 
         conn_number should be a unique (to the session) integer to
@@ -386,7 +405,7 @@ class PipeConnection(LowLevelPipeConnection):
         number to route commands to the correct process.
 
         """
-        LowLevelPipeConnection.__init__(self, inpipe, outpipe)
+        LowLevelPipeConnection.__init__(self, inpipe, outpipe, process)
         self.conn_number = conn_number
         self.unused_request_numbers = set(range(256))
 


### PR DESCRIPTION
## Changes done and why

FIX: CloseConnections doesn't wait for child prcesses to die, losing output, fixes #819

Keep track of the process object within the LowLevelPipeConnection so we can wait() for it properly when closing the connection, thus avoiding possibly lost output from commands run in the remote-schema after the rdiff-backup server process.

Remove the old _process global that tracked the process purely for avoiding the "ResourceWarning: subprocess N is still running". As long as we are pretty sure the process is dead/killed before the connection destructor, the warning should not recur.  The extra terminate/kill and sleeps should not run in the normal case, but if delays occur, should help to ensure the process is marked dead before destruction.

Note: I have started working on a test case but have no way to easily test it yet(?), so I will post the code ideas in the original bug #819 and request feedback before doing another PR for the testing.

## Self-Checklist

- [X] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [X] commit contains a description of changes
    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
    * relevant to the web-site prefixed by WEB:
    * relevant to developers prefixed by DEV:
