### PR TITLE
Fix CloseConnections doesn't wait for child to die

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -35,10 +35,6 @@ from rdiffbackup.utils import safestr
 # The first is None because it is the local connection.
 __conn_remote_cmds = [None]
 
-# keep a list of sub-processes running; we don't use it, it's only to avoid
-# "ResourceWarning: subprocess N is still running" from subprocess library
-_processes = []
-
 
 class SetConnectionsException(Exception):
     pass
@@ -312,7 +308,6 @@ def _init_connection(remote_cmd):
     like global settings, its connection number, and verbosity.
 
     """
-    global _processes
     if not remote_cmd:
         return Globals.local_connection
 
@@ -335,12 +330,10 @@ def _init_connection(remote_cmd):
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE)
         (stdin, stdout) = (process.stdin, process.stdout)
-        # only to avoid resource warnings about subprocess still running
-        _processes.append(process)
     except OSError:
         (stdin, stdout) = (None, None)
     conn_number = len(Globals.connections)
-    conn = connection.PipeConnection(stdout, stdin, conn_number)
+    conn = connection.PipeConnection(stdout, stdin, conn_number, process)
 
     if not _validate_connection_version(conn, remote_cmd):
         return None


### PR DESCRIPTION
## Changes done and why

FIX: CloseConnections doesn't wait for child prcesses to die, losing output, Fixes #819

Keep track of the process object within the LowLevelPipeConnection so we can wait() for it properly when closing the connection, thus avoiding possibly lost output from commands run in the remote-schema after the rdiff-backup server process.

Remove the old _process global that tracked the process purely for avoiding the "ResourceWarning: subprocess N is still running". As long as we are pretty sure the process is dead/killed before the connection destructor, the warning should not recur.  The extra terminate/kill and sleeps should not run in the normal case, but if delays occur, should help to ensure the process is marked dead before destruction.

Note: I have started working on a test case but have no way to easily test it yet(?), so I will post the code ideas in the original bug https://github.com/rdiff-backup/rdiff-backup/issues/819 and request feedback before doing another PR for the testing.

## Self-Checklist

- [X] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [X] commit contains a description of changes
    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
    * relevant to the web-site prefixed by WEB:
    * relevant to developers prefixed by DEV:
