### PR TITLE
Include latest actual build dependencies in Debian packaging control file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
     librsync-dev \
     python3-all-dev \
     python3-pylibacl \
+    python3-yaml \
     python3-pyxattr \
     asciidoctor
 

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,16 @@ Source: rdiff-backup
 Section: utils
 Priority: optional
 Maintainer: Otto Kekäläinen <otto@debian.org>
-Build-Depends: debhelper (>= 11),
+Build-Depends: asciidoctor,
+               debhelper (>= 11),
                dh-python,
                librsync-dev,
                python3-all-dev,
                python3-pylibacl,
                python3-pyxattr,
                python3-setuptools,
-               python3-setuptools-scm
+               python3-setuptools-scm,
+               python3-yaml
 Standards-Version: 4.4.0
 Homepage: http://rdiff-backup.net/
 Vcs-Git: https://github.com/rdiff-backup/rdiff-backup.git

--- a/docs/DEVELOP.adoc
+++ b/docs/DEVELOP.adoc
@@ -121,6 +121,7 @@ All of those should come packaged with your system or available from https://pyp
 * Pywin32 - https://github.com/mhammond/pywin32
 * Pylibacl - http://pylibacl.sourceforge.net/
 * Pyxattr - http://pyxattr.sourceforge.net/
+* PyYAML - https://github.com/yaml/pyyaml
 
 ==== Changing dependencies versions
 


### PR DESCRIPTION
DEV: Ensure the native Debian packaging correctly builds by including new build dependencies asciidoctor and PyYAML. Without these the man page generation would fail and program would fail to start with Python erroring about missing module 'yaml'.

## Testing

Before this the Debian/Ubuntu builds failed locally and at https://launchpad.net/~otto/+archive/ubuntu/ppa/+builds?build_text=&build_state=all

When this branch is pushed to Launchpad builds pass.

![image](https://user-images.githubusercontent.com/668724/212573703-91fe1758-afac-4302-8586-b5e66262ecce.png)

Same changes were also done downstream in
* https://salsa.debian.org/python-team/packages/rdiff-backup/-/commit/2338b1fc6083c0621cc701fe4a28120dd0d4c51c
* https://salsa.debian.org/python-team/packages/rdiff-backup/-/commit/b3789b60094f52fc6b7ecbdf606427421547a47b

## Self-Checklist

- [N/A] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes
    * relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
    * relevant to the web-site prefixed by WEB:
    * relevant to developers prefixed by DEV: