### PR TITLE
Fix message about renaming over same inode

### DIFF
--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -144,7 +144,9 @@ def rdiff_backup(source_local,
 def rdiff_backup_action(source_local, dest_local,
                         src_dir, dest_dir,
                         generic_opts, action, specific_opts,
-                        std_input=None, return_stdout=False):
+                        std_input=None,
+                        return_stdout=False,
+                        return_stderr=False):
     """
     Run rdiff-backup with the given action and options, faking remote locations
 
@@ -178,10 +180,15 @@ def rdiff_backup_action(source_local, dest_local,
     if dest_dir:
         cmdargs.append(dest_dir)
     print("Executing: ", " ".join(map(shlex.quote, map(os.fsdecode, cmdargs))))
-    if return_stdout:
+    if return_stdout or return_stderr:
         try:
-            ret_val = subprocess.check_output(cmdargs, input=std_input,
-                                              universal_newlines=False)
+            if return_stderr:  # add stderr to stdout
+                ret_val = subprocess.check_output(cmdargs, input=std_input,
+                                                  stderr=subprocess.STDOUT,
+                                                  universal_newlines=False)
+            else:
+                ret_val = subprocess.check_output(cmdargs, input=std_input,
+                                                  universal_newlines=False)
         except subprocess.CalledProcessError as exc:
             ret_val = exc.output
         # normalize line endings under Windows

--- a/testing/hardlinktest.py
+++ b/testing/hardlinktest.py
@@ -1,11 +1,15 @@
 import os
-import unittest
 import time
+import unittest
+
 from commontest import (
     abs_test_dir, abs_output_dir, old_test_dir, re_init_rpath_dir,
     compare_recursive, BackupRestoreSeries, InternalBackup, InternalRestore,
     MakeOutputDir, reset_hardlink_dicts, xcopytree
 )
+import commontest as comtst
+import fileset
+
 from rdiff_backup import Globals, Hardlink, rpath, selection
 from rdiffbackup.meta import stdattr
 
@@ -364,6 +368,63 @@ class HardlinkTest(unittest.TestCase):
         for rp in [hlrestore_file2, hlrestore_file3]:
             rp.setdata()
         self.assertEqual(hlrestore_file2.getinode(), hlrestore_file3.getinode())
+
+
+class BackupUnchangedHardlinksTest(unittest.TestCase):
+    """
+    Test that rdiff-backup doesn't moan about moving hardlinks over same inode
+    """
+
+    def setUp(self):
+        self.base_dir = os.path.join(comtst.abs_test_dir,
+                                     b"hardlink_unchanged")
+        self.from1_struct = {
+            "from1": {"contents": {
+                "fileA": {"content": "initial", "inode": "fileA"},
+                "linkA": {"inode": "fileA"},
+                "fileB": {},  # just as canary
+            }}
+        }
+        self.from1_path = os.path.join(self.base_dir, b"from1")
+        self.from2_struct = {
+            "from2": {"contents": {
+                "fileA": {"content": "initial", "inode": "fileA"},
+                "linkA": {"inode": "fileA"},
+                "fileB": {},  # just as canary
+            }}
+        }
+        self.from2_path = os.path.join(self.base_dir, b"from2")
+        fileset.create_fileset(self.base_dir, self.from1_struct)
+        fileset.create_fileset(self.base_dir, self.from2_struct)
+        fileset.remove_fileset(self.base_dir, {"bak": {"type": "dir"}})
+        fileset.remove_fileset(self.base_dir, {"to1": {"type": "dir"}})
+        fileset.remove_fileset(self.base_dir, {"to2": {"type": "dir"}})
+        self.bak_path = os.path.join(self.base_dir, b"bak")
+        self.to1_path = os.path.join(self.base_dir, b"to1")
+        self.to2_path = os.path.join(self.base_dir, b"to2")
+        self.success = False
+
+    def test_backup_unchanged_hardlinks(self):
+        # we backup twice to the same backup repository at different times
+        self.assertEqual(comtst.rdiff_backup_action(
+            False, False, self.from1_path, self.bak_path,
+            ("--api-version", "201", "--current-time", "10000"),
+            b"backup", ()), 0)
+        self.assertNotIn(
+            b"Attempt to rename over same inode:",
+            comtst.rdiff_backup_action(
+                False, True, self.from2_path, self.bak_path,
+                ("--api-version", "201", "--current-time", "20000"),
+                b"backup", (), return_stderr=True))
+
+    def tearDown(self):
+        # we clean-up only if the test was successful
+        if self.success:
+            fileset.remove_fileset(self.base_dir, self.from1_struct)
+            fileset.remove_fileset(self.base_dir, self.from2_struct)
+            fileset.remove_fileset(self.base_dir, {"bak": {"type": "dir"}})
+            fileset.remove_fileset(self.base_dir, {"to1": {"type": "dir"}})
+            fileset.remove_fileset(self.base_dir, {"to2": {"type": "dir"}})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

FIX: avoid message about renaming over same inode when hardlinks' metadata is modified but not content, closes #816

Added also an option `return_stderr` to commontest.rdiff_backup_action to capture stderr in test calls.
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
