### PR TITLE
[DOC] Add FAQ for No space left on device

### DIFF
--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -458,3 +458,61 @@ If the server side is v2.2+, then the warning message will appear.
 Call rdiff-backup with the higher API and the message will disappear.
 
 Calling for example `rdiff-backup --api-version 201 backup loc1 server2::loc2` will make sure that `rdiff-backup server` is being called, getting rid of the warning message.
+
+== How to handle a "No space left on device" message while doing a backup?
+
+If you're doing a backup and get an exception `[Errno 28] No space left on device: ...` (or something similar under Windows), it means exactly what it states, there is not enough space to create your backup.
+You need to first fix the issue, then recover, then make sure that it doesn't happen again.
+
+In the following lines, we'll assume you've called something like `rdiff-backup backup /from /mnt/bak`, which failed with a "No space left" error.
+
+=== Fixing
+
+Check the actual size left with `df -h /mnt/bak` under Linux or `dir /mnt/bak` under Windows.
+Under Linux, you might need to check as well the number of inodes with `df -i /mnt/bak`.
+
+TIP: if the file system doesn't seem to be full, it might be that the default temporary directory instead is full.
+In this case, obviously fix this one issue, check for example the `--tempdir` option in the man pages.
+
+If possible, the simplest approach is to increase the size of the underlying filesystem.
+There are too many ways to do it to describe here, so check the usual sources for your operating system.
+
+If this is not possible, you can create a new bigger partition using a _similar_ file system type (e.g. POSIX to POSIX, NTFS to NTFS, etc), and move the repository from one to the next file system.
+
+If this is also not an option, and you have nothing else outside of the repository that you can move away (or remove), then you can try to remove the following files:
+
+- `/mnt/bak/rdiff-backup-data/*.log`
+- `/mnt/bak/rdiff-backup-data/error_log*`
+- `/mnt/bak/rdiff-backup-data/*_statistics.*`
+
+=== Recovering
+
+First you need to regress the repository with something like:
+
+----
+rdiff-backup --tempdir /somewherelse/tmp regress /mnt/bak
+----
+
+The `--tempdir` option might spare some space on the file system where the repository lies.
+Similarly, you can use `--remote-tempdir` if the repository is remote.
+
+If this fails due to lack of disk space, you're out of luck and need to increase further the file system size as described above.
+
+Then you can remove old increments, first listing them:
+
+----
+rdiff-backup list increments [--size] /mnt/bak
+rdiff-backup remove increments [--force] \
+	--older-than 'Tue Feb  7 06:43:45 2023' /mnt/bak
+----
+
+The date/time can be copied & pasted from the output of the list increments command.
+The `--size` parameter can be used to assess the size of the individual increments, and the `--force` option is necessary if you want to remove more than one increment at once.
+
+=== Avoid
+
+There is no magic method, even databases get corrupt if their disk space dwindles.
+You need to monitor the disk space and regularly remove old increments, or increase the file system size.
+One simple measure can be to call `df -h /mnt/bak` at the end of each backup and keep an eye on space left.
+
+To avoid issues with inodes, use a file system format which doesn't have the issue like XFS, and avoid ones having the limitation like ext4.


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
DOC: add FAQ on how to handle 'No space left on device' messages, closes #838
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
