### PR TITLE
Fix str lstat missing attribute when using tempdir on full repository

### DIFF
--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -496,6 +496,9 @@ rdiff-backup --tempdir /somewherelse/tmp regress /mnt/bak
 The `--tempdir` option might spare some space on the file system where the repository lies.
 Similarly, you can use `--remote-tempdir` if the repository is remote.
 
+// FIXME remove the note once fixed in rpath
+NOTE: due to a current limitation, the tempdir options might not help as much as they could.
+
 If this fails due to lack of disk space, you're out of luck and need to increase further the file system size as described above.
 
 Then you can remove old increments, first listing them:


### PR DESCRIPTION
## Changes done and why

FIX: str object has no lstat attribute when using tempdir for full repository file system, closes #850
CHG: temp directory given by `--tempdir` isn't used as often as it could to avoid cross-filesystems renaming errors (impossible to address now)

Took the chance to restructure the function to make it more readable. The rename function in rpath.py fails if the temp directory isn't on the same file system as the target repository, which doesn't help, hence disabled.

## Self-Checklist

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG: