### PR TITLE
Fix unstable testDirSizeComp in rpathtest

### DIFF
--- a/testing/rpathtest.py
+++ b/testing/rpathtest.py
@@ -435,7 +435,8 @@ class FileCopying(RPathTest):
             "1": {"type": "directory"},
             "2": {"contents": {"{}": {"range": 500}}},
         }
-        fileset.create_fileset(base_path, struct)
+        fileset.create_fileset(base_path, struct,
+                               recurse={"atime": 12345, "mtime": 12345})
         short_dir = rpath.RPath(Globals.local_connection,
                                 os.path.join(base_path, b"1"))
         long_dir = rpath.RPath(Globals.local_connection,


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Add option to add timestamps to fileset (access and/or modification). Use it to stabilize the comparaison test, which uses mtime to the second. Closes #852

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
