### PR TITLE
Fail gracefully in case of error during connection

### DIFF
--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -57,7 +57,7 @@ class BackupAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             self.dir = directory.ReadDir(self.connected_locations[0],
                                          self.values.force)
             self.repo = repository.Repo(

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -55,7 +55,7 @@ class CompareAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             self.dir = directory.ReadDir(self.connected_locations[0],
                                          self.values.force)
             self.repo = repository.Repo(

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -65,7 +65,7 @@ class ListAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0], self.values.force,
                 must_be_writable=False, must_exist=True, can_be_sub_path=True

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -47,7 +47,7 @@ class RegressAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0], self.values.force,
                 must_be_writable=True, must_exist=True

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -53,7 +53,7 @@ class RemoveAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0], self.values.force,
                 must_be_writable=True, must_exist=True

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -57,7 +57,7 @@ class RestoreAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0], self.values.force,
                 must_be_writable=False, must_exist=True, can_be_sub_path=True

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -51,7 +51,7 @@ class ServerAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             Security.initialize(self.get_security_class(), [],
                                 security_level=self.values.restrict_mode,
                                 restrict_path=self.values.restrict_path)

--- a/src/rdiffbackup/actions/verify.py
+++ b/src/rdiffbackup/actions/verify.py
@@ -50,7 +50,7 @@ class VerifyAction(actions.BaseAction):
 
     def connect(self):
         conn_value = super().connect()
-        if conn_value:
+        if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0], self.values.force,
                 must_be_writable=False, must_exist=True, can_be_sub_path=True

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -84,6 +84,11 @@ def main_run(arglist, security_override=False):
     # now start for real, conn_act and action are the same object
     with action.connect() as conn_act:
 
+        if not conn_act.is_connection_ok():
+            log.Log("Action {ac} failed on step {st}".format(
+                ac=parsed_args.action, st="connect"), log.ERROR)
+            return conn_act.conn_status
+
         # For test purposes only, hence we allow ourselves to overwrite a
         # "private" variable
         if security_override:

--- a/testing/action_backuprestore_test.py
+++ b/testing/action_backuprestore_test.py
@@ -279,5 +279,17 @@ class PreQuotingTest(unittest.TestCase):
             fileset.remove_fileset(self.base_dir, {"to2": {"type": "dir"}})
 
 
+class ConnectionHandlingTest(unittest.TestCase):
+    """
+    Test handling of wrong connection
+    """
+
+    def test_wrong_connection(self):
+        # we backup using a non existing destination location
+        self.assertNotEqual(comtst.rdiff_backup_action(
+            True, True, ".", "doesnotexist::/some_dir",
+            ("--api-version", "201"), b"backup", ()), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

FIX: fail gracefully when connection(s) can't be setup e.g. in case of network error, closes #868## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
