### PR TITLE
Fix cross-version issue with restrict_path

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -247,6 +247,10 @@ file_statistics = 1
 # object.  Access is provided to increment error counts.
 ITRB = None
 
+# If this is set, it indicates that the remote connection should only
+# deal with paths inside of restrict_path.
+restrict_path = None  # compat200
+
 # If set, a file will be marked as changed if its inode changes.  See
 # the man page under --no-compare-inode for more information.
 compare_inode = 1

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -114,6 +114,7 @@ def reset_restrict_path(rp):
         "Function works locally not over '{conn}'.".format(conn=rp.conn))
     global _restrict_path, _restrict_path_list
     _restrict_path = rp.normalize().path
+    Globals.restrict_path = _restrict_path  # compat200
     _restrict_path_list = _restrict_path.split(b"/")
 
 

--- a/tools/crossversion/playbook-smoke-test.yml
+++ b/tools/crossversion/playbook-smoke-test.yml
@@ -63,7 +63,7 @@
   - name: check that the remote rdiff-backup works
     command: >
       rdiff-backup --remote-schema '{{ remote_schema }}' --test-server
-      {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}/simplebackup
+      {{ test_user }}\@{{ test_server }}::{{ remote_base_dir }}
     delegate_to: localhost
 
   - name: make a simple backup from the local directory to remote repo


### PR DESCRIPTION


## Changes done and why

FIX: cross-version issue with 2.0.5 complaining about KeyError restrict_path, closes #872

## Self-Checklist



- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
