### PR TITLE
[DOC] Clarify what kind of option is a generic option that must come before Action

### DIFF
--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -42,7 +42,7 @@ The rdiff-backup commands knows four types of parameters
 Note that this documents the _new_ command line interface of rdiff-backup since 2.1+;
 for the traditional one, check *rdiff-backup-old(1)* but consider that it is deprecated and will disappear.
 
-=== Options
+=== Generic options
 
 -h, --help::
 Prints brief usage information and exits.


### PR DESCRIPTION
## Changes done and why

This adds a clearer heading to the "Options" section so that a user knows that everything in that section is classified as "generic" and must come before the Action.

I think there's still room to better define what a "Sub-action" is, but that's not within the scope of this pull request.

This helps solve Issue #875 