### PR TITLE
Improve links handling under Windows

### DIFF
--- a/docs/Windows-DEVELOP.adoc
+++ b/docs/Windows-DEVELOP.adoc
@@ -175,6 +175,8 @@ With `icacls` you can list the (Windows) ACLs of a file.
 
 With `attrib` you can set the read-only attribute of a file.
 
+With `fsutil file queryfileid FILENAME` you can get the "inode" of a file.
+
 === Shells
 
 Different shells might be useful:

--- a/src/rdiff_backup/fs_abilities.py
+++ b/src/rdiff_backup/fs_abilities.py
@@ -1056,7 +1056,7 @@ def get_readonly_fsa(desc_string, rp):
 
     """
     if os.name == "nt":
-        log.Log("Hardlinks disabled by default on Windows", log.INFO)
+        log.Log("Hardlinks disabled on Windows", log.INFO)
         Globals.set_all('preserve_hardlinks', 0)
     return FSAbilities(desc_string, rp, read_only=True)
 

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -81,7 +81,7 @@ class ReadDir(Dir, locations.ReadLocation):
         # I suspect that not all users can read symlinks with os.readlink
         if (is_windows
                 and ("--exclude-symbolic-links", None) not in select_opts):
-            log.Log("Symbolic links excluded by default on Windows",
+            log.Log("Symbolic links excluded on Windows",
                     log.NOTE)
             select_opts.insert(0, ("--exclude-symbolic-links", None))
         if Globals.get_api_version() < 201:  # compat200

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -191,7 +191,11 @@ class FSAbilities:
         """
         Set self.hardlinks to true if hard linked files can be created
         """
-        if not Globals.preserve_hardlinks:
+        if os.name == "nt":
+            log.Log("Hardlinks disabled on Windows", log.INFO)
+            self.hardlinks = None
+            return
+        elif not Globals.preserve_hardlinks:
             log.Log("Hard linking test skipped as rdiff-backup was started "
                     "with --no-hard-links option", log.INFO)
             self.hardlinks = None


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
FIX: clarify that hard- and symlinks are not supported by rdiff-backup under Windows (see #484 for enhancement), closes #880
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
