### PR TITLE
Fix test action for API 201

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -490,8 +490,12 @@ def _test_connection(conn_number, rp):
     # FIXME the tests don't sound right, the path given needs to pre-exist
     # on Windows but not on Linux? What are we exactly testing here?
     try:
-        assert conn.Globals.get('current_time') is None
-        assert type(conn.os.listdir(rp.path)) is list
+        remote_time = conn.Globals.get('current_time')
+        assert remote_time == Globals.current_time, (
+            "connection not returning current time {ct1} but {ct2}".format(
+                ct1=Globals.current_time, ct2=remote_time))
+        assert type(conn.os.listdir(rp.path)) is list, (
+            "connection not listing directory '{rp}'".format(rp=rp))
     except BaseException as exc:
         sys.stderr.write("- Server tests failed due to {exc}\n".format(exc=exc))
         return False

--- a/testing/action_test_test.py
+++ b/testing/action_test_test.py
@@ -18,21 +18,21 @@ class ActionTestTest(unittest.TestCase):
         # the test action works with one or two locations (or more)
         self.assertEqual(
             comtst.rdiff_backup_action(False, False, self.dir1, self.dir2,
-                                       (), b"test", ()),
+                                       ("--api-version", "201"), b"test", ()),
             0)
         self.assertEqual(
             comtst.rdiff_backup_action(False, True, self.dir1, None,
-                                       (), b"test", ()),
+                                       ("--api-version", "201"), b"test", ()),
             0)
         # but it doesn't work with a local one
         self.assertNotEqual(
             comtst.rdiff_backup_action(False, True, self.dir1, self.dir2,
-                                       (), b"test", ()),
+                                       ("--api-version", "201"), b"test", ()),
             0)
         # and it doesn't work without any location
         self.assertNotEqual(
             comtst.rdiff_backup_action(True, True, None, None,
-                                       (), b"test", ()),
+                                       ("--api-version", "201"), b"test", ()),
             0)
 
 


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

FIX: test action would fail with empty error message when using API 201

This was partially a consequence of the changes done regarding current time

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
