### PR TITLE
Call msvcrt.setmode only when main is called (#885)

### DIFF
--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -23,17 +23,15 @@ import sys
 from rdiff_backup import Globals, log
 from rdiffbackup import arguments, actions_mgr, actions
 
-try:
+if os.name == "nt":
     import msvcrt
-
-    # make sure line endings are kept under Windows like under Linux
-    msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
-    msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-except ImportError:
-    pass
 
 
 def main():
+    if os.name == "nt":
+        # make sure line endings are kept under Windows like under Linux
+        msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
+        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
     sys.exit(main_run(sys.argv[1:]))
 
 


### PR DESCRIPTION
## Changes done and why

When stdout and stderr are capture by testing framework like pytest, fileno is not implemented and raise an error. Which prevent the module to be loaded. To avoid this problem, make the call in main function.

Closes #885

## Self-Checklist

- [x] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
