### PR TITLE
Fix return code when arguments can't be parsed

### DIFF
--- a/src/rdiffbackup/arguments.py
+++ b/src/rdiffbackup/arguments.py
@@ -35,6 +35,24 @@ DEPRECATION_MESSAGE = (
     "disappear, start using the new one as described with '--new --help'."
 )
 
+# === WORKAROUND ===
+
+
+def parse_args(parser, args):
+    """
+    Function overwriting the default exit code for parsing errors
+
+    Once we're only supporting Python 3.9+ we can use the exit_on_error=False
+    option and simply catch ArgumentError
+    """
+    try:
+        parsed_args = parser.parse_args(args)
+    except SystemExit as exc:
+        if exc.code != 0:
+            exc.code = 1
+        raise
+    return parsed_args
+
 # === FUNCTIONS ===
 
 
@@ -99,7 +117,7 @@ def _parse_new(args, version_string, parent_parsers, actions_dict):
         rdiff-backup <opt(ions)> <act(ion)> <sub(-options)> <paths>
     """
     parser = get_parser_new(version_string, parent_parsers, actions_dict)
-    parsed_args = parser.parse_args(args)
+    parsed_args = parse_args(parser, args)
 
     if not (sys.version_info.major >= 3 and sys.version_info.minor >= 7):
         # we need a work-around as long as Python 3.6 doesn't know about required
@@ -214,7 +232,7 @@ def _parse_compat200(args, version_string, parent_parsers=[]):
     """
 
     parser = get_parser_compat200(version_string, parent_parsers)
-    values = parser.parse_args(args)
+    values = parse_args(parser, args)
 
     _make_values_like_new_compat200(values)
     _validate_number_locations_compat200(values, parser)

--- a/testing/rdb_arguments.py
+++ b/testing/rdb_arguments.py
@@ -1,6 +1,7 @@
 import subprocess
 import unittest
 from commontest import RBBin
+from rdiff_backup import Globals
 from rdiffbackup import arguments, actions_mgr
 
 
@@ -13,11 +14,24 @@ class ArgumentsTest(unittest.TestCase):
         """
         - make sure that the new help is shown either with --new or by using an action
         """
-        output = subprocess.check_output([RBBin, b'--new', b'--help'])
-        self.assertIn(b"possible actions:", output)
+        output = subprocess.run([RBBin, b'--new', b'--help'],
+                                capture_output=True)
+        self.assertIn(b"possible actions:", output.stdout)
+        self.assertEqual(0, output.returncode)
 
-        output = subprocess.check_output([RBBin, b'info', b'--help'])
-        self.assertIn(b"Output information", output)
+        output = subprocess.run([RBBin, b'info', b'--help'],
+                                capture_output=True)
+        self.assertIn(b"Output information", output.stdout)
+        self.assertEqual(Globals.RET_CODE_OK, output.returncode)
+
+    def test_error_return_code(self):
+        """
+        - verify that a wrong arguments returns 1 instead of the standard 2
+        """
+        output = subprocess.run([RBBin, b'--thisdoesntexist'],
+                                capture_output=True)
+        self.assertIn(b"unrecognized arguments:", output.stderr)
+        self.assertEqual(Globals.RET_CODE_ERR, output.returncode)
 
     def test_parse_function(self):
         """


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

FIX: failed parsing of arguments would return code 2 for warnings instead of 1 for errors

Workaround is necessary because argparse doesn't allow for overwriting the return code.

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
