### PR TITLE
Fix action list increments regex

### DIFF
--- a/testing/action_list_test.py
+++ b/testing/action_list_test.py
@@ -39,11 +39,11 @@ class ActionListTest(unittest.TestCase):
         # we backup twice to the same backup repository at different times
         comtst.rdiff_backup_action(
             True, True, self.from1_path, self.bak_path,
-            ("--api-version", "201", "--current-time", "10000"),
+            ("--api-version", "201", "--current-time", "111111"),
             b"backup", ())
         comtst.rdiff_backup_action(
             True, True, self.from2_path, self.bak_path,
-            ("--api-version", "201", "--current-time", "20000"),
+            ("--api-version", "201", "--current-time", "222222"),
             b"backup", ())
 
     def test_action_listfilesattime(self):
@@ -61,7 +61,7 @@ fileUnchanged
         self.assertEqual(comtst.rdiff_backup_action(
             True, None, self.bak_path, None,
             ("--api-version", "201"),
-            b"list", ("files", "--at", "10000"), return_stdout=True),
+            b"list", ("files", "--at", "111111"), return_stdout=True),
             b""".
 fileChanged
 fileOld
@@ -100,7 +100,7 @@ fileUnchanged
         self.assertEqual(comtst.rdiff_backup_action(
             True, None, self.bak_path, None,
             ("--api-version", "201"),
-            b"list", ("files", "--changed-since", "10000"), return_stdout=True),
+            b"list", ("files", "--changed-since", "111111"), return_stdout=True),
             b"""changed fileChanged
 new     fileNew
 deleted fileOld
@@ -133,11 +133,11 @@ deleted fileOld
             ("--api-version", "201", "--parsable"),
             b"list", ("increments", ), return_stdout=True),
             b"""---
-- base: increments.1970-01-0[12]T[0-9][0-9][:-][14]6[:-]40.*.dir
-  time: 10000
+- base: increments.1970-01-0[12]T[0-9][0-9][:-][25]1[:-]51.*.dir
+  time: 111111
   type: directory
 - base: bak
-  time: 20000
+  time: 222222
   type: directory
 ...
 
@@ -150,10 +150,10 @@ deleted fileOld
             b"list", ("increments", "--size"), return_stdout=True),
             b"""---
 - size: [0-9]+
-  time: 10000
+  time: 111111
   total_size: [0-9]+
 - size: [0-9]+
-  time: 20000
+  time: 222222
   total_size: [0-9]+
 ...
 


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
Increased epoch to be sure to be in 1970 also in negative timezones, closes #892
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
