### PR TITLE
Fix timezone for Russia & Co

### DIFF
--- a/src/rdiff_backup/Time.py
+++ b/src/rdiff_backup/Time.py
@@ -314,28 +314,15 @@ def _get_tzd(timeinseconds=None):
     """
     if timeinseconds is None:
         timeinseconds = time.time()
-    dst_in_effect = time.daylight and time.localtime(timeinseconds)[8]
-    if dst_in_effect:
-        offset = -time.altzone / 60
-    else:
-        offset = -time.timezone / 60
-    if offset > 0:
-        prefix = "+"
-    elif offset < 0:
-        prefix = "-"
-    else:
-        return "Z"  # time is already in UTC
-
+    tzd = time.strftime("%z", time.localtime(timeinseconds))
     if Globals.use_compatible_timestamps:
         time_separator = '-'
     else:
         time_separator = ':'
-    hours, minutes = list(map(abs, divmod(offset, 60)))
-    assert 0 <= hours <= 23, (
-        "Hours {hrs} must be between 0 and 23".format(hrs=hours))
-    assert 0 <= minutes <= 59, (
-        "Minutes {mins} must be between 0 and 59".format(mins=minutes))
-    return "%s%02d%s%02d" % (prefix, hours, time_separator, minutes)
+    if tzd == "+0000":
+        return "Z"
+    else:
+        return tzd[:3] + time_separator + tzd[3:]
 
 
 def _tzd_to_seconds(tzd):


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
FIX: timezone was not always correctly calculated in countries with historically changing DST, closes #902
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
