### PR TITLE
Fix bad /bin/sh header with bash

### DIFF
--- a/tools/get_changelog_since.sh
+++ b/tools/get_changelog_since.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # get a list of changes and authors since a given revision tag in Git
 # outputs changes marked with 'XYZ:' and a unique list of authors
 # if no tag is given, uses the latest valid one

--- a/tools/prepare_api_doc.sh
+++ b/tools/prepare_api_doc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # this function gathers all calls going through the client/server connection.
 # the result can only be used as a basis or validation for the actual API
 # documentation, especially because it can't make the difference between


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
script was failing in the Ubuntu pipeline because of bashism not supported by dash being /bin/sh
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [ ] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
