### PR TITLE
[DOC] Fixed rdiff-backup-fs link.

### DIFF
--- a/docs/other/related.adoc
+++ b/docs/other/related.adoc
@@ -14,7 +14,7 @@ are competing backup programs.
 
 == Software written for rdiff-backup
 
-* Filip Gruszczyski has written a http://fuse.sourceforge.net/[FUSE] plugin named *archfs*, still present but unmaintained under the namehttps://github.com/rdiff-backup/rdiff-backup-fs[rdiff-backup-fs] which allows browsing through rdiff-backup increments directly as a filesystem.
+* Filip Gruszczyski has written a http://fuse.sourceforge.net/[FUSE] plugin named *archfs*, still present but unmaintained under the name https://github.com/rdiff-backup/rdiff-backup-fs[rdiff-backup-fs] which allows browsing through rdiff-backup increments directly as a filesystem.
 * http://safekeep.sourceforge.net/[SafeKeep] for Linux is a front-end for rdiff-backup providing LVM snapshots and easy configuration.
 * https://launchpad.net/gnomeeasybackup[EasyBackup] is a graphical backup solution for Gnome which is integrated with the Nautilus file manager and uses rdiff-backup as the backend.
 * https://packages.debian.org/sid/slbackup[Skolelinux Backup System]


### PR DESCRIPTION
## Changes done and why

Fixes the link to rdiff-backup-fs which wasn't rendering correctly due to a missing space between the word name and https. 

Closes #917 

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
Pure Documentation change. No code changed. 
- [x] changes to the code have been covered by new/modified tests
Pure Documentation change. No tests needed. 
- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
I did not prefix the commit information. I thought that was for the PR body on first read. 

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
