### PR TITLE
Restore users and groups in UTF-8

### DIFF
--- a/src/rdiffbackup/meta/stdattr.py
+++ b/src/rdiffbackup/meta/stdattr.py
@@ -78,10 +78,11 @@ class AttrExtractor(meta.FlatExtractor):
     }
     # mapping for metadata fields to transform into ascii strings
     _decode_mapping = {
-        'Type': 'type',
-        'SHA1Digest': 'sha1',
-        'Uname': 'uname',
-        'Gname': 'gname',
+        'Type': {'key': 'type', 'enc': 'ascii'},
+        'SHA1Digest': {'key': 'sha1', 'enc': 'ascii'},
+        # non-ascii users and groups are seldom and not recommended, but possible
+        'Uname': {'key': 'uname', 'enc': 'utf-8'},
+        'Gname': {'key': 'gname', 'enc': 'utf-8'},
     }
 
     @staticmethod
@@ -108,9 +109,10 @@ class AttrExtractor(meta.FlatExtractor):
                 data_dict[cls._integer_mapping[field]] = int(data)
             elif field in cls._decode_mapping:
                 if data == b":" or data == b"None":
-                    data_dict[cls._decode_mapping[field]] = None
+                    data_dict[cls._decode_mapping[field]['key']] = None
                 else:
-                    data_dict[cls._decode_mapping[field]] = data.decode('ascii')
+                    data_dict[cls._decode_mapping[field]['key']] = data.decode(
+                        cls._decode_mapping[field]['enc'])
             elif field == "File":
                 index = cls._filename_to_index(data)
             elif field == "ResourceFork":  # pragma: no cover

--- a/testing/user_grouptest.py
+++ b/testing/user_grouptest.py
@@ -1,6 +1,8 @@
-import unittest
-import pwd
 import code
+import getpass
+import os
+import pwd
+import unittest
 from rdiff_backup import Globals
 from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
@@ -51,7 +53,12 @@ root:bin
 bin:root
 500:501
 0:mail
-mail:0"""
+mail:0
+"""
+        curr_user_name = getpass.getuser()
+        curr_user_uid = os.getuid()
+        # testing UTF-8 user names
+        mapping_string += "éłephänt:" + curr_user_name
         Globals.isdest = 1
         rootid = 0
         binid = pwd.getpwnam('bin')[2]
@@ -61,6 +68,7 @@ mail:0"""
 
         self.assertEqual(map_owners._user_map(rootid, 'root'), binid)
         self.assertEqual(map_owners._user_map(binid, 'bin'), rootid)
+        self.assertEqual(map_owners._user_map(-1, 'éłephänt'), curr_user_uid)
         self.assertEqual(map_owners._user_map(0), mailid)
         self.assertEqual(map_owners._user_map(mailid, 'mail'), 0)
         self.assertEqual(map_owners._user_map(500), 501)


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
FIX: user and group names with UTF-8 characters can now be restored, closes #938
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
