### PR TITLE
Fix implicit declaration of function ‘dup’ under Python 3.13

### DIFF
--- a/src/_librsyncmodule.c
+++ b/src/_librsyncmodule.c
@@ -35,6 +35,15 @@ static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
 #define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
 #endif
 
+/* ----------------------------------------------------------------------- *
+ * Update for Python 3.13/3.14 - Contributed by Victor Stinner in gh-108765
+ * https://docs.python.org/3.13/whatsnew/3.13.html#id8 - see issue #934
+ * The change was retracted but might come back in 3.14 so we keep this fix.
+ * ----------------------------------------------------------------------- */
+#if (defined(HAVE_UNISTD_H) && !defined(_UNISTD_H))
+#  include <unistd.h>
+#endif
+
 static PyObject *librsyncError;
 
 /* Sets python error string from result */


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

FIX: rdiff-backup can be compiled with 3.13 without error due to missing dup function from unistd.h, closes #934
<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
