### PR TITLE
Make sure tox.ini doesn't write if called without venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ MANIFEST
 *[._]local[._]*
 
 # setup.py installation files
-src/rdiff_backup.egg-info/
+*.egg-info/
 .eggs/
 
 # Windows build file

--- a/testing/api_test.py
+++ b/testing/api_test.py
@@ -17,17 +17,19 @@ class ApiVersionTest(unittest.TestCase):
         Globals.api_version["actual"] = 201
         info = Globals.get_runtime_info()
 
-        # because the current test will have a different call than rdiff-backup itself
-        # we can't compare certain keys
+        # because the current test will have a different call than rdiff-backup
+        # itself, we can't compare certain keys
         self.assertIn("exec", out_info)
         self.assertIn("argv", out_info["exec"])
         out_info["exec"].pop("argv")
         info["exec"].pop("argv")
-        # info['python']['executable'] could also be different but I think that
-        # our test environments make sure that it doesn't happen, unless Windows
-        if os.name == "nt":
-            info["python"]["executable"] = info["python"]["executable"].lower()
-            out_info["python"]["executable"] = out_info["python"]["executable"].lower()
+
+        # info['python'] could also be different, under special conditions
+        self.assertIn("python", out_info)
+        self.assertIn("executable", out_info["python"])
+        out_info.pop("python")
+        info.pop("python")
+
         self.assertEqual(info, out_info)
 
     def test_default_actual_api(self):
@@ -41,7 +43,7 @@ class ApiVersionTest(unittest.TestCase):
         self.assertEqual(out_info["exec"]["api_version"]["actual"], api_version["max"])
 
     def test_debug_output(self):
-        """we use verbosity 9 only to cover debug functions in logging"""
+        """Use verbosity 9 to cover debug functions in logging"""
         output = subprocess.check_output(
             [RBBin, b"-v", b"9", b"--terminal-verbosity", b"9", b"info"]
         )

--- a/testing/coverage_pth.py
+++ b/testing/coverage_pth.py
@@ -1,0 +1,31 @@
+# write the hook file which will make sure that coverage is loaded
+# also for sub-processes, like for "client/server" rdiff-backup
+
+import os
+import site
+import sys
+
+for site_path in sys.path:
+    coverage_pth = os.path.join(site_path, "coverage.pth")
+    if os.path.isfile(coverage_pth):
+        print("The file {} exists already".format(coverage_pth))
+        sys.exit(0)
+
+if site.ENABLE_USER_SITE:
+    site_packages = [site.getusersitepackages()]
+else:  # we're probably in a virtualenv
+    site_packages = site.getsitepackages()
+
+for site_path in site_packages:
+    coverage_pth = os.path.join(site_path, "coverage.pth")
+    try:
+        os.makedirs(site_path, exist_ok=True)
+        with open(coverage_pth, "w") as fd:
+            fd.write("import coverage; coverage.process_startup()\n")
+            print("The file {} has been written".format(coverage_pth))
+            sys.exit(0)
+    except OSError as exc:
+        print("Couldn't write the file {} due to {}".format(coverage_pth, exc))
+
+print("The coverage.pth file could be written nowhere")
+sys.exit(1)

--- a/testing/coverage_pth.py
+++ b/testing/coverage_pth.py
@@ -14,7 +14,7 @@ for site_path in sys.path:
 if site.ENABLE_USER_SITE:
     site_packages = [site.getusersitepackages()]
 else:  # we're probably in a virtualenv
-    site_packages = site.getsitepackages()
+    site_packages = reversed(site.getsitepackages())
 
 for site_path in site_packages:
     coverage_pth = os.path.join(site_path, "coverage.pth")

--- a/tools/coverage_pth/MANIFEST.in
+++ b/tools/coverage_pth/MANIFEST.in
@@ -1,0 +1,1 @@
+include **/*.pth

--- a/tools/coverage_pth/pyproject.toml
+++ b/tools/coverage_pth/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "coverage-pth"
+version = "0.0.1"
+authors = [
+    {name = "The rdiff-backup project", email = "rdiff-backup-users@nongnu.org"}
+]
+description = "write the hook file which will make sure that coverage is loaded"
+
+[tool.setuptools]
+package-dir = {""="src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"*" = ["*.pth"]

--- a/tools/coverage_pth/src/coverage.pth
+++ b/tools/coverage_pth/src/coverage.pth
@@ -1,0 +1,1 @@
+import coverage; coverage.process_startup()

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ passenv = RDIFF_TEST_*, RDIFF_BACKUP_*
 setenv =
 # paths for coverage must be absolute so that sub-processes find them
 # even if they're started from another location.
-	COVERAGE_FILE = {envlogdir}/coverage.sqlite
+	COVERAGE_FILE = {envtmpdir}/coverage.sqlite
 	COVERAGE_PROCESS_START = {toxinidir}/tox.ini
 deps = -r{toxinidir}/requs/base.txt
        -r{toxinidir}/requs/optional.txt
@@ -30,7 +30,7 @@ commands_pre =
 	coverage erase
 # write the hook file which will make sure that coverage is loaded
 # also for sub-processes, like for "client/server" rdiff-backup
-	python -c 'with open("{envsitepackagesdir}/coverage.pth","w") as fd: fd.write("import coverage; coverage.process_startup()\n")'
+	python testing/coverage_pth.py
 commands =
 	coverage run testing/action_backuprestore_test.py --verbose --buffer
 	coverage run testing/action_calculate_test.py --verbose --buffer

--- a/tox_smoke.ini
+++ b/tox_smoke.ini
@@ -1,0 +1,51 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox -c tox_smoke.ini" from this directory.
+
+# Configuration file for smoke tests with no coverage.
+
+[tox]
+envlist = py
+
+[testenv]
+# make sure those variables are passed down; you should define 
+# either explicitly the RDIFF_TEST_* variables or rely on the current
+# user being correctly identified (which might not happen in a container)
+passenv = RDIFF_TEST_*, RDIFF_BACKUP_*
+deps = -r{toxinidir}/requs/base.txt
+       -r{toxinidir}/requs/optional.txt
+       -r{toxinidir}/requs/test.txt
+allowlist_externals = sh
+commands_pre =
+	rdiff-backup --version
+# must be the first command to setup the test environment
+	python testing/commontest.py
+commands =
+	python testing/action_backuprestore_test.py --verbose --buffer
+	python testing/action_calculate_test.py --verbose --buffer
+	python testing/action_compare_test.py --verbose --buffer
+	python testing/action_complete_test.py --verbose --buffer
+	python testing/action_list_test.py --verbose --buffer
+	python testing/action_regress_test.py --verbose --buffer
+	python testing/action_remove_test.py --verbose --buffer
+	python testing/action_test_test.py --verbose --buffer
+	python testing/action_verify_test.py --verbose --buffer
+	python testing/readonly_actions_test.py --verbose --buffer
+	python testing/api_test.py --verbose --buffer
+	python testing/location_map_filenames_test.py --verbose --buffer
+	python testing/location_map_hardlinks_test.py --verbose --buffer
+	python testing/location_lock_test.py --verbose --buffer
+	python testing/utils_simpleps_test.py --verbose --buffer
+
+	python testing/ctest.py --verbose --buffer
+	python testing/timetest.py --verbose --buffer
+	python testing/librsynctest.py --verbose --buffer
+	python testing/user_grouptest.py --verbose --buffer
+	python testing/setconnectionstest.py --verbose --buffer
+	python testing/iterfiletest.py --verbose --buffer
+	python testing/eas_aclstest.py --verbose --buffer
+	python testing/fs_abilitiestest.py --verbose --buffer
+	python testing/hashtest.py --verbose --buffer
+	python testing/errorsrecovertest.py --verbose --buffer
+	python testing/rdb_arguments.py --verbose --buffer


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
NEW: tox.ini supports --current-env as normal user, avoiding to write in root-protected paths, closes #949
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
