### PR TITLE
[DOC] Move repo format changes to API changelogs

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -41,7 +41,7 @@ Thus you can use rdiff-backup and ssh to securely back a hard drive up to a remo
 ** xref:Windows-DEVELOP.adoc[Windows specific Developer documentation]
 * xref:CODING.adoc[Coding conventions]
 * xref:DOCUMENTATION.adoc[Documentation guidelines]
-* link:./api[Client-server API documentation] (i.e. when used over SSH)
+* link:./api[Client-server API documentation] (i.e. when used over SSH), with repository format changelog
 * link:./arch[Architecture documentation], if you want/need to know the internas of rdiff-backup
 * http://www.w3.org/TR/NOTE-datetime[W3 note describing a time format rdiff-backup uses^]
 

--- a/docs/api/v200.adoc
+++ b/docs/api/v200.adoc
@@ -148,3 +148,9 @@ bytes).
 * `pow`
 * `str`
 * `tempfile.mktemp`
+
+== Repository format
+
+This list is most probably incomplete and covers  older changes:
+
+* SHA1 digest was added in v1.1.1

--- a/docs/api/v201.adoc
+++ b/docs/api/v201.adoc
@@ -196,3 +196,11 @@ toc::[]
 * `pow`
 * `str`
 * `tempfile.mktemp`
+
+== Repository format
+
+* the directory `rdiff-backup-data/increments` does always exist from the start
+* meta data files are now correctly _not_ compressed when using the `--no-compression` parameter during a backup or regression
+* introduction of the lock file `rdiff-backup-data/lock.yml`
+
+NOTE: to the best of my knowledge, none of those changes breaks the backward compatibility with older versions of rdiff-backup.

--- a/docs/arch/repository_format.adoc
+++ b/docs/arch/repository_format.adoc
@@ -132,21 +132,8 @@ it was at time *T*.
 
 == Changelog
 
-Changes to the repository format haven't been properly tracked in the past, so here is a tentative start.
-
-=== API 201 (v2.2.x)
-
-- the directory `rdiff-backup-data/increments` does always exist from the start
-- meta data files are now correctly _not_ compressed when using the `--no-compression` parameter during a backup or regression
-- introduction of the lock file `rdiff-backup-data/lock.yml`
-
-NOTE: to the best of my knowledge, none of those changes breaks the backward compatibility with older versions of rdiff-backup.
-
-=== Older changes
-
-This list is most probably incomplete:
-
-- SHA1 digest was added in v1.1.1
+Changes to the repository format have only since recently been tracked.
+They are now documented as part of the link:../api/[API changelogs].
 
 == Concluding remarks
 


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

DOC: repository format changes have been moved to API changelog documentation

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
