### PR TITLE
Save Python module versions under Windows

### DIFF
--- a/tools/get_pip_freeze.py
+++ b/tools/get_pip_freeze.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# because pip freeze doesn't offer a way to give an output file, and tox
+# doesn't have a shell for redirection, we need to write our own pip freeze
+# https://stackoverflow.com/questions/24321933/programmatically-generate-requirements-txt-file
+# Call with `./tools/get_pip_freeze.py <outputfile>`
+
+import sys
+import importlib.metadata as ilmd
+
+installed = {pkg for pkgs in ilmd.packages_distributions().values() for pkg in pkgs}
+req_str = "\n".join(f"{pkg}=={ilmd.version(pkg)}" for pkg in sorted(installed))
+
+with open(sys.argv[1], "w") as f:
+    f.write(req_str)

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -103,4 +103,4 @@ commands =
         --console {envsitepackagesdir}/rdiffbackup/run.py \
         --name rdiff-backup \
         --copy-metadata rdiff-backup
-    pip freeze --all > build/{env:RDIFF_BACKUP_VERSION}/pipfreeze.txt
+    python tools/get_pip_freeze.py build/{env:RDIFF_BACKUP_VERSION}/pipfreeze.txt

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -103,3 +103,4 @@ commands =
         --console {envsitepackagesdir}/rdiffbackup/run.py \
         --name rdiff-backup \
         --copy-metadata rdiff-backup
+    pip freeze --all > build/{env:RDIFF_BACKUP_VERSION}/pipfreeze.txt


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

NEW: Python module versions are saved as part of zip file for Windows using pip freeze, closes #957 

Add get_pip_freeze.py script to compensate for missing output capability of pip freeze

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
