### PR TITLE
[DOC] Create changelog for unreleased v2.6.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,50 @@ The prefixes are to be understood as follows, in roughly decreasing order of imp
 * *NEW* features and bug-**FIX**es are of course of interest as well.
 * **DOC**umentation (and website) changes are marked as such.
 
+== New in v2.6.0 (never released)
+
+=== Changes
+
+* CHG: introduce pyproject.toml to comply with PEP517 and PEP621, 
+       normal users shouldn't notice a difference, packagers might need to 
+       adapt, closes #757
+* CHG: rdiff-backup executable under Windows is built with Python 
+       3.12.0 and librsync 2.3.4, there shouldn't be any noticeable difference 
+       for normal users
+* CHG: rdiff-backup supports and hence is being tested with Python 3.9 
+       to 3.12
+* CHG: Remove RPM spec files from repository as outdated, check your 
+       favourite distro if you need them, or ask us
+* CHG: the API 200 has been removed from the code and isn't supported 
+       anymore, i.e. rdiff-backup isn't compatible anymore with version 2.0
+* CHG: the placeholder '%s' isn't accepted anymore in remote schemas, 
+       use '{h}' instead
+* DOC: add FAQ example of script validating free disk space before 
+       starting a backup, increasing the chance to avoid a repository 
+       corruption
+* DOC: repository format changes have been moved to API changelog 
+       documentation
+* FIX: correct pyproject license to SPDX notation, closes #948
+* FIX: regression of repository with long filenames could fail because 
+       of wrong order, closes #869
+* FIX: user and group names with UTF-8 characters can now be restored, 
+       closes #938
+* NEW: Git archives, also from GitHub, get enough information for 
+       setuptools-scm resp.  setup.sh to properly identify the rdiff-backup 
+       version; this might make packaging slightly easier
+* NEW: Python module versions are saved as part of zip file for Windows 
+       using pip freeze, closes #957
+* NEW: rdiff-backup uses metadata like the checksum to validate the 
+       need for a regression, greatly improving speed of regression.
+* NEW: tox_smoke.ini for smoke tests with less dependencies, especially 
+       without coverage, avoiding to write in root-protected paths, closes #949
+
+=== Authors
+
+* Eric L
+* Patrik Dufresne
+
+
 == New in v2.4.0 (never released)
 
 === Changes


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

This is the last commit with the compatible API v201, before I start to modify the code more heavily.
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
