### PR TITLE
Simplify log verbosity

### DIFF
--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -1,0 +1,10 @@
+= Thoughts for code evolution
+
+As I go through a major rewrite and see things I don't like, or would like to improve, a place to store easily such thoughts:
+
+- renumber verbosities to avoid "holes" between 0 and 9
+- replace log verbosity with IntEnum
+- replace return codes with IntFlag
+- extend info to also check locations and output file system information
+- split logging mechanism between front-end and back-end (writing to file, which is specific to the repository format)
+- replace own Logger implementation with standard one (in the background)

--- a/docs/api/v300.adoc
+++ b/docs/api/v300.adoc
@@ -37,8 +37,7 @@ toc::[]
 * `log.Log.log_to_file`
 * `log.Log.open_logfile_allconn`
 * `log.Log.open_logfile_local`
-* `log.Log.setterm_verbosity`
-* `log.Log.setverbosity`
+* `log.Log.set_verbosity`  **new**
 * `robust.install_signal_handlers`
 * `rpath.copy_reg_file`
 * `rpath.delete_dir_no_files`

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -333,13 +333,13 @@ def _set_allowed_requests(sec_class, sec_level):
     if sec_class == "server":
         requests.update(
             [
-                "log.Log.setverbosity",
-                "log.Log.setterm_verbosity",
                 "SetConnections.init_connection_remote",
                 # API >= 201
                 "_repo_shadow.RepoShadow.init_owners_mapping",
                 "_dir_shadow.WriteDirShadow.init_owners_mapping",
                 "Globals.set_api_version",
+                # API >= 300
+                "log.Log.set_verbosity",  # FIXME can we pipe this through?
             ]
         )
     return requests

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -506,8 +506,7 @@ def _init_connection_routing(conn, conn_number, remote_cmd):
 
 def _init_connection_settings(conn):
     """Tell new conn about log settings and updated globals"""
-    conn.log.Log.setverbosity(log.Log.verbosity)
-    conn.log.Log.setterm_verbosity(log.Log.term_verbosity)
+    conn.log.Log.set_verbosity(log.Log.file_verbosity, log.Log.term_verbosity)
     for setting_name in Globals.changed_settings:
         conn.Globals.set_local(setting_name, Globals.get(setting_name))
 

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -523,7 +523,7 @@ class PipeConnection(LowLevelPipeConnection):
         """Return active exception"""
         if robust.is_routine_fatal(sys.exc_info()[1]):
             raise  # Fatal error--No logging necessary, but connection down
-        if log.Log.verbosity >= 5 or log.Log.term_verbosity >= 5:
+        if log.Log.file_verbosity >= log.INFO or log.Log.term_verbosity >= log.INFO:
             log.Log(
                 "Sending back exception '{ex}' of type {ty} with "
                 "traceback {tb}".format(

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -188,18 +188,23 @@ class Logger:
     ) -> int:
         """
         Set verbosity levels, logfile and terminal.  Takes numbers or strings.
+        The function makes sure that verbosities are only modified if both
+        input values are correct.
         If not provided, the terminal verbosity is set from the logfile one.
         Returns an integer code.
         """
         try:
-            self.file_verbosity = self.validate_verbosity(file_verbosity)
+            # we set a temporary verbosity to make sure we overwrite the
+            # actual one only if both values are correct
+            tmp_verbosity: Verbosity = self.validate_verbosity(file_verbosity)
             if term_verbosity is None:
-                self.term_verbosity = self.file_verbosity
+                self.term_verbosity = tmp_verbosity
             else:
                 self.term_verbosity = self.validate_verbosity(term_verbosity)
         except ValueError:
             return Globals.RET_CODE_ERR
         else:
+            self.file_verbosity = tmp_verbosity
             return Globals.RET_CODE_OK
 
     def open_logfile(self, log_rp):

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -191,7 +191,7 @@ class Repo(locations.Location):
             if ret_code & Globals.RET_CODE_ERR:
                 return ret_code
 
-        if log.Log.verbosity > 0 and action_name:
+        if log.Log.file_verbosity > 0 and action_name:
             ret_code |= self._open_logfile(action_name, self.must_be_writable)
             if ret_code & Globals.RET_CODE_ERR:
                 return ret_code

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -59,9 +59,11 @@ def main_run(arglist, security_override=False):
     )
 
     # we need verbosity set properly asap
-    if parsed_args.terminal_verbosity is not None:
-        log.Log.setterm_verbosity(parsed_args.terminal_verbosity)
-    log.Log.setverbosity(parsed_args.verbosity)
+    ret_val = log.Log.set_verbosity(
+        parsed_args.verbosity, parsed_args.terminal_verbosity
+    )
+    if ret_val & Globals.RET_CODE_ERR:
+        return ret_val
 
     # compatibility plug
     _parse_cmdlineoptions_compat201(parsed_args)
@@ -78,7 +80,7 @@ def main_run(arglist, security_override=False):
     )
 
     # validate that everything looks good before really starting
-    ret_val = action.pre_check()
+    ret_val |= action.pre_check()
     if ret_val & Globals.RET_CODE_ERR:
         log.Log(
             "Action {ac} failed on step {st}".format(

--- a/testing/action_backuprestore_test.py
+++ b/testing/action_backuprestore_test.py
@@ -1,6 +1,7 @@
 """
 Test the basic backup and restore actions with api version >= 201
 """
+
 import glob
 import os
 import unittest

--- a/testing/action_calculate_test.py
+++ b/testing/action_calculate_test.py
@@ -1,6 +1,7 @@
 """
 Test the basic backup and restore actions with api version >= 201
 """
+
 import glob
 import os
 import shutil

--- a/testing/action_compare_test.py
+++ b/testing/action_compare_test.py
@@ -1,6 +1,7 @@
 """
 Test the compare action with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/action_complete_test.py
+++ b/testing/action_complete_test.py
@@ -1,6 +1,7 @@
 """
 Test the complete action with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/action_list_test.py
+++ b/testing/action_list_test.py
@@ -1,6 +1,7 @@
 """
 Test the list action with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/action_regress_test.py
+++ b/testing/action_regress_test.py
@@ -1,6 +1,7 @@
 """
 Test the remove action with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -1,6 +1,7 @@
 """
 Test the remove action with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/action_verify_test.py
+++ b/testing/action_verify_test.py
@@ -1,6 +1,7 @@
 """
 Test the verify action with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -1,5 +1,6 @@
 """commontest - Some functions and constants common to several test cases.
 Can be called also directly to setup the test environment"""
+
 import os
 import sys
 import code

--- a/testing/location_lock_test.py
+++ b/testing/location_lock_test.py
@@ -1,6 +1,7 @@
 """
 Test the handling of locking with api version >= 201
 """
+
 import os
 import shutil
 import unittest

--- a/testing/location_map_filenames_test.py
+++ b/testing/location_map_filenames_test.py
@@ -1,6 +1,7 @@
 """
 Test the quoting of characters in filenames with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/location_map_hardlinks_test.py
+++ b/testing/location_map_hardlinks_test.py
@@ -1,6 +1,7 @@
 """
 Test the handling of hardlinks with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/log_test.py
+++ b/testing/log_test.py
@@ -1,0 +1,56 @@
+"""
+Test the logging functionality
+"""
+import unittest
+
+from rdiff_backup import Globals, log
+
+
+class LogTest(unittest.TestCase):
+    """
+    Test that rdiff-backup properly logs messages
+    """
+
+    def test_log_validate_verbosity(self):
+        """test that verbosity validation works correctly"""
+        # happy path
+        self.assertEqual(log.Logger.validate_verbosity(log.NONE), log.NONE)
+        self.assertEqual(log.Logger.validate_verbosity(str(log.NOTE)), log.NOTE)
+        self.assertEqual(log.Logger.validate_verbosity(log.TIMESTAMP), log.TIMESTAMP)
+        # error cases
+        self.assertRaises(ValueError, log.Logger.validate_verbosity, log.NONE - 1)
+        self.assertRaises(
+            ValueError, log.Logger.validate_verbosity, str(log.TIMESTAMP + 1)
+        )
+        self.assertRaises(ValueError, log.Logger.validate_verbosity, "xxx")
+        self.assertRaises(ValueError, log.Logger.validate_verbosity, "NaN")
+
+    def test_log_set_verbosity(self):
+        """test that verbosity is correctly set"""
+        # happy path
+        testlog = log.Logger()
+        self.assertEqual(testlog.set_verbosity(log.NONE), Globals.RET_CODE_OK)
+        self.assertEqual(testlog.file_verbosity, log.NONE)
+        self.assertEqual(testlog.term_verbosity, log.NONE)
+        self.assertEqual(
+            testlog.set_verbosity(str(log.DEBUG), str(log.WARNING)),
+            Globals.RET_CODE_OK,
+        )
+        self.assertEqual(testlog.file_verbosity, log.DEBUG)
+        self.assertEqual(testlog.term_verbosity, log.WARNING)
+        # error cases
+        self.assertEqual(testlog.set_verbosity(str(log.NONE - 1)), Globals.RET_CODE_ERR)
+        # nothing changes
+        self.assertEqual(testlog.file_verbosity, log.DEBUG)
+        self.assertEqual(testlog.term_verbosity, log.WARNING)
+        self.assertEqual(
+            testlog.set_verbosity(str(log.ERROR), log.TIMESTAMP + 1),
+            Globals.RET_CODE_ERR,
+        )
+        # nothing changes even if only the 2nd value is wrong
+        self.assertEqual(testlog.file_verbosity, log.DEBUG)
+        self.assertEqual(testlog.term_verbosity, log.WARNING)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/log_test.py
+++ b/testing/log_test.py
@@ -1,6 +1,7 @@
 """
 Test the logging functionality
 """
+
 import unittest
 
 from rdiff_backup import Globals, log

--- a/testing/readonly_actions_test.py
+++ b/testing/readonly_actions_test.py
@@ -1,6 +1,7 @@
 """
 Test the ability to regress/remove read-only paths with api version >= 201
 """
+
 import os
 import unittest
 

--- a/testing/utils_simpleps_test.py
+++ b/testing/utils_simpleps_test.py
@@ -1,6 +1,7 @@
 """
 Test the simpleps alternative implementation
 """
+
 import os
 import unittest
 import sys

--- a/tox.ini
+++ b/tox.ini
@@ -120,5 +120,5 @@ source =
 
 [coverage:report]
 skip_empty = True
-fail_under = 80
+fail_under = 85
 sort = Cover

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands =
 	sh ./testing/verbosity_actions_test.sh 9 --verbose --buffer
 	coverage run testing/readonly_actions_test.py --verbose --buffer
 	coverage run testing/api_test.py --verbose --buffer
+	coverage run testing/log_test.py --verbose --buffer
 	coverage run testing/location_map_filenames_test.py --verbose --buffer
 	coverage run testing/location_map_hardlinks_test.py --verbose --buffer
 	coverage run testing/location_lock_test.py --verbose --buffer


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Simplfiy log verbosity with one function for both (file) verbosity and terminal verbosity.
    
Taking the chance to try out typing with mypy.
Following check passes:
    
    mypy --implicit-optional --ignore-missing-imports --follow-imports skip src/rdiff_backup/log.py

* Add unit tests for new logging functions
* Raise minimal coverage level from 80 to 85%
* Add informal document to keep thoughts as I develop

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
