### PR TITLE
Move get_runtime_info from Globals to actions

### DIFF
--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -9,6 +9,5 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - replace return codes with IntFlag
 - split logging mechanism between front-end and back-end (writing to file, which is specific to the repository format)
 - replace own Logger implementation with standard one (in the background)
-- move get_runtime_info from Globals to a utils module
-- extend info to also check locations and output file system information
+- extend runtime info to also check locations and output file system information
 - set api version to 300

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -19,8 +19,6 @@
 """Hold a variety of constants usually set at initialization."""
 
 import os
-import platform
-import sys
 import yaml
 from importlib import metadata
 from rdiff_backup import log
@@ -344,26 +342,3 @@ def get_api_version():
     """Return the actual API version, either set explicitly or the default
     one"""
     return api_version["actual"] or api_version["default"]
-
-
-def get_runtime_info(parsed=None):
-    """Return a structure containing all relevant runtime information about
-    the executable, Python and the operating system.
-    Beware that additional information might be added at any time."""
-    return {
-        "exec": {
-            "version": version,
-            "api_version": api_version,
-            "argv": sys.argv,
-            "parsed": parsed,
-        },
-        "python": {
-            "name": sys.implementation.name,
-            "executable": sys.executable,
-            "version": platform.python_version(),
-        },
-        "system": {
-            "platform": platform.platform(),
-            "fs_encoding": sys.getfilesystemencoding(),
-        },
-    }

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -25,6 +25,7 @@ plugins can inheritate default behaviors.
 
 import argparse
 import os
+import platform
 import sys
 import tempfile
 import yaml
@@ -693,6 +694,31 @@ class BaseAction:
         else:
             log.Log("Given repository doesn't need to be regressed", regress_verbosity)
             return Globals.RET_CODE_OK
+
+    @classmethod
+    def get_runtime_info(cls, parsed=None):
+        """
+        Return a structure containing all relevant runtime information about
+        the executable, Python and the operating system.
+        Beware that additional information might be added at any time.
+        """
+        return {
+            "exec": {
+                "version": Globals.version,
+                "api_version": Globals.api_version,
+                "argv": sys.argv,
+                "parsed": parsed,
+            },
+            "python": {
+                "name": sys.implementation.name,
+                "executable": sys.executable,
+                "version": platform.python_version(),
+            },
+            "system": {
+                "platform": platform.platform(),
+                "fs_encoding": sys.getfilesystemencoding(),
+            },
+        }
 
 
 def get_plugin_class():

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -47,7 +47,7 @@ class InfoAction(actions.BaseAction):
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 
-        runtime_info = Globals.get_runtime_info(parsed=self.values)
+        runtime_info = self.get_runtime_info(parsed=self.values)
         print(yaml.safe_dump(runtime_info, explicit_start=True, explicit_end=True))
         return ret_code
 

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -74,7 +74,7 @@ def main_run(arglist, security_override=False):
 
     log.Log(
         "Runtime information =>{ri}<=".format(
-            ri=Globals.get_runtime_info(parsed=parsed_args)
+            ri=action.get_runtime_info(parsed=parsed_args)
         ),
         log.DEBUG,
     )

--- a/testing/api_test.py
+++ b/testing/api_test.py
@@ -10,6 +10,7 @@ import yaml
 import commontest as comtst
 
 from rdiff_backup import Globals
+from rdiffbackup import actions
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -28,7 +29,7 @@ class ApiVersionTest(unittest.TestCase):
 
         Globals.api_version["actual"] = latest_api
         # we make sure that the parsed info is the same
-        info = Globals.get_runtime_info(parsed=out_info["exec"]["parsed"])
+        info = actions.BaseAction.get_runtime_info(parsed=out_info["exec"]["parsed"])
 
         # because the current test will have a different call than rdiff-backup
         # itself, we can't compare certain keys


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Move get_runtime_info from Globals to actions, because I want a slimmer Globals.

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
