### PR TITLE
Reshuffle globals and hand-over values

### DIFF
--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -411,7 +411,6 @@ class PipeConnection(LowLevelPipeConnection):
 
     def Server(self):
         """Start server's read eval return loop"""
-        Globals.server = 1
         Globals.connections.append(self)
         log.Log("Starting server", log.INFO)
         self._get_response(-1)

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -58,12 +58,10 @@ class BackupAction(actions.BaseAction):
     def connect(self):
         conn_value = super().connect()
         if conn_value.is_connection_ok():
-            self.dir = directory.ReadDir(
-                self.connected_locations[0], self.values["force"]
-            )
+            self.dir = directory.ReadDir(self.connected_locations[0], self.values)
             self.repo = repository.Repo(
                 self.connected_locations[1],
-                self.values["force"],
+                self.values,
                 must_be_writable=True,
                 must_exist=False,
                 create_full_path=self.values["create_full_path"],

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -66,12 +66,10 @@ class CompareAction(actions.BaseAction):
     def connect(self):
         conn_value = super().connect()
         if conn_value.is_connection_ok():
-            self.dir = directory.ReadDir(
-                self.connected_locations[0], self.values["force"]
-            )
+            self.dir = directory.ReadDir(self.connected_locations[0], self.values)
             self.repo = repository.Repo(
                 self.connected_locations[1],
-                self.values["force"],
+                self.values,
                 must_be_writable=False,
                 must_exist=True,
                 can_be_sub_path=True,

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -82,7 +82,7 @@ class ListAction(actions.BaseAction):
         if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0],
-                self.values["force"],
+                self.values,
                 must_be_writable=False,
                 must_exist=True,
                 can_be_sub_path=True,

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -57,7 +57,7 @@ class RegressAction(actions.BaseAction):
         if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0],
-                self.values["force"],
+                self.values,
                 must_be_writable=True,
                 must_exist=True,
             )

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -65,7 +65,7 @@ class RemoveAction(actions.BaseAction):
         if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0],
-                self.values["force"],
+                self.values,
                 must_be_writable=True,
                 must_exist=True,
             )

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -68,14 +68,14 @@ class RestoreAction(actions.BaseAction):
         if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0],
-                self.values["force"],
+                self.values,
                 must_be_writable=False,
                 must_exist=True,
                 can_be_sub_path=True,
             )
             self.dir = directory.WriteDir(
                 self.connected_locations[1],
-                self.values["force"],
+                self.values,
                 self.values["create_full_path"],
             )
         return conn_value

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -49,6 +49,7 @@ class ServerAction(actions.BaseAction):
 
     def __init__(self, values):
         super().__init__(values)
+        Globals.server = True  # FIXME make local?
         if self.values.get("debug"):
             self._set_breakpoint()
 

--- a/src/rdiffbackup/actions/verify.py
+++ b/src/rdiffbackup/actions/verify.py
@@ -60,7 +60,7 @@ class VerifyAction(actions.BaseAction):
         if conn_value.is_connection_ok():
             self.repo = repository.Repo(
                 self.connected_locations[0],
-                self.values["force"],
+                self.values,
                 must_be_writable=False,
                 must_exist=True,
                 can_be_sub_path=True,

--- a/src/rdiffbackup/locations/__init__.py
+++ b/src/rdiffbackup/locations/__init__.py
@@ -35,9 +35,9 @@ class Location:
     Abstract location class representing a user@hostname::/dir location
     """
 
-    def __init__(self, base_dir, force):
+    def __init__(self, base_dir, values):
         self.base_dir = base_dir
-        self.force = force
+        self.values = values
 
     def __str__(self):
         return str(self.base_dir)
@@ -89,7 +89,7 @@ class Location:
         """
         # TODO The writable aspect hasn't yet been implemented
         if self.base_dir.lstat() and not self.base_dir.isdir():
-            if self.force:
+            if self.values["force"]:
                 log.Log(
                     "Target path {tp} exists but isn't a directory, "
                     "and will be force deleted".format(tp=self.base_dir),
@@ -110,7 +110,11 @@ class Location:
         """
         try:
             # if the target exists and isn't a directory, force delete it
-            if self.base_dir.lstat() and not self.base_dir.isdir() and self.force:
+            if (
+                self.base_dir.lstat()
+                and not self.base_dir.isdir()
+                and self.values["force"]
+            ):
                 self.base_dir.delete()
 
             # if the target doesn't exist, create it
@@ -162,8 +166,8 @@ class WriteLocation(Location):
     Abstract writable location class, possibly not pre-existing
     """
 
-    def __init__(self, base_dir, force, create_full_path):
-        super().__init__(base_dir, force)
+    def __init__(self, base_dir, values, create_full_path):
+        super().__init__(base_dir, values)
         self.create_full_path = create_full_path
 
     def check(self):

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -161,7 +161,7 @@ class WriteDir(Dir, locations.WriteLocation):
 
         # if the target is a non-empty existing directory
         if self.base_dir.lstat() and self.base_dir.isdir() and self.base_dir.listdir():
-            if self.force:
+            if self.values["force"]:
                 log.Log(
                     "Target path {tp} exists and isn't empty, content "
                     "might be force overwritten by restore".format(tp=self.base_dir),

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -43,7 +43,7 @@ class Repo(locations.Location):
     def __init__(
         self,
         base_dir,
-        force,
+        values,
         must_be_writable,
         must_exist,
         create_full_path=False,
@@ -70,7 +70,7 @@ class Repo(locations.Location):
             self.ref_type = None
 
         # Finish the initialization with the identified base_dir
-        super().__init__(base_dir, force)
+        super().__init__(base_dir, values)
         self.create_full_path = create_full_path
         self.must_be_writable = must_be_writable
         self.must_exist = must_exist
@@ -129,7 +129,7 @@ class Repo(locations.Location):
 
         lock_result = self.lock()
         if lock_result is False:
-            if self.force:
+            if self.values["force"]:
                 log.Log(
                     "Repository is locked by file {lf}, another "
                     "action is probably on-going. Enforcing anyway "
@@ -300,7 +300,7 @@ class Repo(locations.Location):
         Shadow function for RepoShadow.needs_regress
         """
         return self._shadow.needs_regress(
-            self.base_dir, self.data_dir, self.incs_dir, self.force
+            self.base_dir, self.data_dir, self.incs_dir, self.values["force"]
         )
 
     def force_regress(self):
@@ -645,7 +645,7 @@ class Repo(locations.Location):
             and self.base_dir.listdir()
             and not self.data_dir.lstat()
         ):
-            if self.force:
+            if self.values["force"]:
                 log.Log(
                     "Target path '{tp}' does not look like a rdiff-backup "
                     "repository but will be force overwritten".format(tp=self.base_dir),
@@ -672,7 +672,7 @@ class Repo(locations.Location):
             # independently from the API version
             self.lockfile.setdata()
             if self.lockfile.lstat():
-                if self.force:
+                if self.values["force"]:
                     log.Log(
                         "An initial backup in a strange state with "
                         "lockfile {lf}. Enforcing continuation, "

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -58,15 +58,10 @@ def main_run(arglist, security_override=False):
         discovered_actions,
     )
 
-    # we need verbosity set properly asap
-    ret_val = log.Log.set_verbosity(
-        parsed_args.get("verbosity"), parsed_args.get("terminal_verbosity")
-    )
+    # setup the system settings globally
+    ret_val = _system_setup(parsed_args)
     if ret_val & Globals.RET_CODE_ERR:
         return ret_val
-
-    # compatibility plug
-    _parse_cmdlineoptions_compat201(parsed_args)
 
     # instantiate the action object from the dictionary, handing over the
     # parsed arguments
@@ -161,11 +156,19 @@ def main_run(arglist, security_override=False):
     return ret_val
 
 
-def _parse_cmdlineoptions_compat201(arglist):  # noqa: C901
+def _system_setup(arglist):
     """
     Parse argument list and set global preferences, compatibility function
     between old and new way of parsing parameters.
     """
+    # we need verbosity set properly asap
+    ret_val = log.Log.set_verbosity(
+        arglist.get("verbosity"), arglist.get("terminal_verbosity")
+    )
+    if ret_val & Globals.RET_CODE_ERR:
+        return ret_val
+    if arglist.get("api_version") is not None:  # FIXME catch also env variable?
+        Globals.set_api_version(arglist.get("api_version"))
 
     # if action in ("backup", "restore"):
     Globals.set("acls_active", arglist.get("acls"))
@@ -183,17 +186,14 @@ def _parse_cmdlineoptions_compat201(arglist):  # noqa: C901
     Globals.set("print_statistics", arglist.get("print_statistics"))
     # if action in ("regress"):
     Globals.set("allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps"))
+    # generic settings
     Globals.set("null_separator", arglist.get("null_separator"))
     Globals.set("use_compatible_timestamps", arglist.get("use_compatible_timestamps"))
     Globals.set("do_fsync", arglist.get("fsync"))
-    if arglist["action"] in ("server"):
-        Globals.server = True
     if arglist.get("current_time") is not None:
         Globals.set_integer("current_time", arglist.get("current_time"))
     if arglist.get("chars_to_quote") is not None:
         Globals.set("chars_to_quote", os.fsencode(arglist.get("chars_to_quote")))
-    if arglist.get("api_version") is not None:  # FIXME catch also env variable?
-        Globals.set_api_version(arglist.get("api_version"))
 
 
 if __name__ == "__main__":

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -194,6 +194,7 @@ def _system_setup(arglist):
         Globals.set_integer("current_time", arglist.get("current_time"))
     if arglist.get("chars_to_quote") is not None:
         Globals.set("chars_to_quote", os.fsencode(arglist.get("chars_to_quote")))
+    return ret_val
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

This is one more step towards getting rid of most global variables.
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
