### PR TITLE
Remove passing of specific values

### DIFF
--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -11,3 +11,5 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - replace own Logger implementation with standard one (in the background)
 - extend runtime info to also check locations and output file system information
 - set api version to 300
+- move creation of self._shadow to __init__ of locations
+- make check and setup functions mostly remote to encapsulate repo structure

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -205,8 +205,8 @@ compression = 1
 # case-insensitive regular expression won't be compressed (applies
 # to .snapshots and .diffs).
 # The regexp is the compiled version of the argument provided by
-# --no-compression-regexp (or its default value)
-no_compression_regexp = None
+# --not-compressed-regexp (or its default value)
+not_compressed_regexp = None
 
 # If true, filelists and directory statistics will be split on
 # nulls instead of newlines.

--- a/src/rdiff_backup/increment.py
+++ b/src/rdiff_backup/increment.py
@@ -88,8 +88,8 @@ def _make_missing_increment(incpref, inc_time):
 def _is_compressed(mirror):
     """Return true if mirror's increments should be compressed"""
     return Globals.compression and (
-        Globals.no_compression_regexp is None
-        or not Globals.no_compression_regexp.match(mirror.path)
+        Globals.not_compressed_regexp is None
+        or not Globals.not_compressed_regexp.match(mirror.path)
     )
 
 

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -299,7 +299,6 @@ COMPRESSION_PARSER.add_argument(
 )
 COMPRESSION_PARSER.add_argument(
     "--not-compressed-regexp",
-    "--no-compression-regexp",
     metavar="REGEXP",
     default=DEFAULT_NOT_COMPRESSED_REGEXP,
     help="[sub] regexp to select files not being compressed "

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -64,7 +64,6 @@ class BackupAction(actions.BaseAction):
                 self.values,
                 must_be_writable=True,
                 must_exist=False,
-                create_full_path=self.values["create_full_path"],
             )
         return conn_value
 
@@ -91,17 +90,7 @@ class BackupAction(actions.BaseAction):
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 
-        owners_map = {
-            "users_map": self.values["user_mapping_file"],
-            "groups_map": self.values["group_mapping_file"],
-            "preserve_num_ids": self.values["preserve_numerical_ids"],
-        }
-        ret_code = self.repo.setup(
-            self.dir,
-            owners_map=owners_map,
-            action_name=self.name,
-            not_compressed_regexp=self.values["not_compressed_regexp"],
-        )
+        ret_code = self.repo.setup(self.dir, action_name=self.name)
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -81,16 +81,7 @@ class RegressAction(actions.BaseAction):
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 
-        owners_map = {
-            "users_map": self.values["user_mapping_file"],
-            "groups_map": self.values["group_mapping_file"],
-            "preserve_num_ids": self.values["preserve_numerical_ids"],
-        }
-        ret_code = self.repo.setup(
-            owners_map=owners_map,
-            action_name=self.name,
-            not_compressed_regexp=self.values["not_compressed_regexp"],
-        )
+        ret_code = self.repo.setup(action_name=self.name)
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -73,11 +73,7 @@ class RestoreAction(actions.BaseAction):
                 must_exist=True,
                 can_be_sub_path=True,
             )
-            self.dir = directory.WriteDir(
-                self.connected_locations[1],
-                self.values,
-                self.values["create_full_path"],
-            )
+            self.dir = directory.WriteDir(self.connected_locations[1], self.values)
         return conn_value
 
     def check(self):
@@ -156,19 +152,11 @@ class RestoreAction(actions.BaseAction):
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 
-        ret_code |= self.repo.setup(
-            action_name=self.name,
-            not_compressed_regexp=self.values["not_compressed_regexp"],
-        )
+        ret_code |= self.repo.setup(action_name=self.name)
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 
-        owners_map = {
-            "users_map": self.values["user_mapping_file"],
-            "groups_map": self.values["group_mapping_file"],
-            "preserve_num_ids": self.values["preserve_numerical_ids"],
-        }
-        ret_code |= self.dir.setup(self.repo, owners_map=owners_map)
+        ret_code |= self.dir.setup(self.repo)
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 

--- a/src/rdiffbackup/locations/__init__.py
+++ b/src/rdiffbackup/locations/__init__.py
@@ -56,9 +56,7 @@ class Location:
             users_map = users_map.read()
         if groups_map is not None:
             groups_map = groups_map.read()
-        self._shadow.init_owners_mapping(users_map, groups_map, preserve_num_ids)
-
-        return Globals.RET_CODE_OK
+        return self._shadow.init_owners_mapping(users_map, groups_map, preserve_num_ids)
 
     def exit(self):
         """
@@ -119,7 +117,7 @@ class Location:
 
             # if the target doesn't exist, create it
             if not self.base_dir.lstat():
-                if self.create_full_path:
+                if self.values["create_full_path"]:
                     self.base_dir.makedirs()
                 else:
                     self.base_dir.mkdir()
@@ -166,9 +164,8 @@ class WriteLocation(Location):
     Abstract writable location class, possibly not pre-existing
     """
 
-    def __init__(self, base_dir, values, create_full_path):
+    def __init__(self, base_dir, values):
         super().__init__(base_dir, values)
-        self.create_full_path = create_full_path
 
     def check(self):
         """

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -338,6 +338,7 @@ class WriteDirShadow:
     def init_owners_mapping(cls, users_map, groups_map, preserve_num_ids):
         map_owners.init_users_mapping(users_map, preserve_num_ids)
         map_owners.init_groups_mapping(groups_map, preserve_num_ids)
+        return Globals.RET_CODE_OK
 
 
 class _DirPatchITRB(rorpiter.ITRBranch):

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -1166,6 +1166,7 @@ information in it.
     def init_owners_mapping(cls, users_map, groups_map, preserve_num_ids):
         map_owners.init_users_mapping(users_map, preserve_num_ids)
         map_owners.init_groups_mapping(groups_map, preserve_num_ids)
+        return Globals.RET_CODE_OK
 
     # ### LOCKING ####
 

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -123,7 +123,7 @@ class ReadDir(Dir, locations.ReadLocation):
 
 
 class WriteDir(Dir, locations.WriteLocation):
-    def setup(self, src_repo, owners_map=None):
+    def setup(self, src_repo):
         ret_code = super().setup()
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
@@ -149,10 +149,13 @@ class WriteDir(Dir, locations.WriteLocation):
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 
-        if owners_map is not None:
-            ret_code |= self.init_owners_mapping(**owners_map)
-            if ret_code & Globals.RET_CODE_ERR:
-                return ret_code
+        ret_code |= self.init_owners_mapping(
+            users_map=self.values.get("user_mapping_file"),
+            groups_map=self.values.get("group_mapping_file"),
+            preserve_num_ids=self.values.get("preserve_numerical_ids", False),
+        )
+        if ret_code & Globals.RET_CODE_ERR:
+            return ret_code
 
         return ret_code
 


### PR DESCRIPTION

<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

not_compressed_regexp and create_full_path are passed with values. owners_mapping is managed within the repo/dir setup.

CHG: the compatibility plug --no-compression-regexp for --not-compressed-regexp has been removed

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
