### PR TITLE
Get rid of global not_compressed_regexp variable

### DIFF
--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -22,5 +22,4 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - re-write security module to fit better new concepts around remote dir/repo, especially update-only doesn't block backup to a new directory anymore. Possibly split _Repo_Shadow into Read and Write variants.
 - rewrite QuotedRPath to be an RPath variant specific to repositories, to encapsulate the increment aspects & co (taking them out of the standard RPath class)
 - rewrite selection functions to directly use bytes loaded instead of files
-- does statistics really need direct access to the get_increment function?
-- remove the global not_compressed_regexp variable as it's actually local to locations.increment
+- does statistics really need direct access to the get_increment function? Or could it use the (shadow) repo as back-end like thought for logs?

--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -198,13 +198,6 @@ preserve_hardlinks = 1
 # increments.  Default is to compress based on regexp below.
 compression = 1
 
-# Increments based on files whose names match this
-# case-insensitive regular expression won't be compressed (applies
-# to .snapshots and .diffs).
-# The regexp is the compiled version of the argument provided by
-# --not-compressed-regexp (or its default value)
-not_compressed_regexp = None
-
 # If true, filelists and directory statistics will be split on
 # nulls instead of newlines.
 null_separator = None

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -180,6 +180,14 @@ class RepoShadow(location.LocationShadow):
                 log.NOTE,
             )
         ret_code |= cls._init_owners_mapping()
+        if ret_code & Globals.RET_CODE_ERR:
+            return ret_code
+        ret_code |= increment.init(
+            cls._values.get("compression"),
+            cls._values.get("not_compressed_regexp"),
+        )
+        if ret_code & Globals.RET_CODE_ERR:
+            return ret_code
         return ret_code
 
     # @API(RepoShadow.setup_finish, 300)

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -22,8 +22,6 @@ A location module to define repository classes as created by rdiff-backup
 """
 
 import io
-import os
-import re
 
 from rdiffbackup.locations import fs_abilities, location
 
@@ -100,13 +98,6 @@ class Repo(location.Location):
                 return ret_code
         self.base_dir = self.setup_finish()
 
-        if self.values.get("not_compressed_regexp") is not None:
-            ret_code |= self.setup_not_compressed_regexp(
-                self.values["not_compressed_regexp"]
-            )
-            if ret_code & Globals.RET_CODE_ERR:
-                return ret_code
-
         if ret_code & Globals.RET_CODE_ERR:
             return ret_code
 
@@ -133,26 +124,6 @@ class Repo(location.Location):
         Shadow function for RepoShadow.get_mirror_time
         """
         return self._shadow.get_mirror_time(must_exist, refresh)
-
-    @classmethod  # so that we can easily use in tests
-    def setup_not_compressed_regexp(cls, not_compressed_regexp=None):
-        """
-        Sets the not_compressed_regexp setting globally
-        """
-        not_compressed_regexp = os.fsencode(not_compressed_regexp)
-        try:
-            not_compressed_regexp = re.compile(not_compressed_regexp)
-        except re.error:
-            log.Log(
-                "No compression regular expression '{ex}' doesn't "
-                "compile".format(ex=not_compressed_regexp),
-                log.ERROR,
-            )
-            return Globals.RET_CODE_ERR
-
-        Globals.set_all("not_compressed_regexp", not_compressed_regexp)
-
-        return Globals.RET_CODE_OK
 
     def needs_regress(self):
         """

--- a/testing/increment_test.py
+++ b/testing/increment_test.py
@@ -9,7 +9,7 @@ import commontest as comtst
 
 from rdiff_backup import Globals, rpath, Time, Rdiff
 from rdiffbackup import actions
-from rdiffbackup.locations import increment, repository
+from rdiffbackup.locations import increment
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -42,8 +42,6 @@ else:
     prevtimestr = b"2001-09-02T02:48:33-07:00"
 t_diff = os.path.join(TEST_BASE_DIR, b"out.%s.diff" % prevtimestr)
 
-repository.Repo.setup_not_compressed_regexp(actions.DEFAULT_NOT_COMPRESSED_REGEXP)
-
 
 class inctest(unittest.TestCase):
     """Test the incrementRP function"""
@@ -59,7 +57,7 @@ class inctest(unittest.TestCase):
 
     def testreg(self):
         """Test increment of regular files"""
-        Globals.compression = None
+        increment.init(False, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
         target.setdata()
         if target.lstat():
             target.delete()
@@ -84,7 +82,7 @@ class inctest(unittest.TestCase):
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testsnapshot(self):
         """Test making of a snapshot"""
-        Globals.compression = None
+        increment.init(False, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
         snap_rp = increment.make_increment(rf, sym, target, prevtime)
         self.check_time(snap_rp)
         self.assertTrue(rpath._cmp_file_attribs(snap_rp, sym))
@@ -100,7 +98,7 @@ class inctest(unittest.TestCase):
     @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
     def testGzipsnapshot(self):
         """Test making a compressed snapshot"""
-        Globals.compression = 1
+        increment.init(True, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
         rp = increment.make_increment(rf, sym, target, prevtime)
         self.check_time(rp)
         self.assertTrue(rp._equal_verbose(sym, check_index=0, compare_size=0))
@@ -131,7 +129,7 @@ class inctest(unittest.TestCase):
 
     def testDiff(self):
         """Test making diffs"""
-        Globals.compression = None
+        increment.init(False, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
         rp = increment.make_increment(rf, rf2, target, prevtime)
         self.check_time(rp)
         self.assertTrue(rp._equal_verbose(rf2, check_index=0, compare_size=0))
@@ -142,7 +140,7 @@ class inctest(unittest.TestCase):
 
     def testGzipDiff(self):
         """Test making gzipped diffs"""
-        Globals.compression = 1
+        increment.init(True, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
         rp = increment.make_increment(rf, rf2, target, prevtime)
         self.check_time(rp)
         self.assertTrue(rp._equal_verbose(rf2, check_index=0, compare_size=0))
@@ -153,7 +151,7 @@ class inctest(unittest.TestCase):
 
     def testGzipRegexp(self):
         """Here a .gz file shouldn't be compressed"""
-        Globals.compression = 1
+        increment.init(True, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
         rpath.copy(rf, out_gz)
         self.assertTrue(out_gz.lstat())
 


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
Get rid of global not_compressed_regexp variable,
as it is only used by increment, we make it local to this module
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
