### PR TITLE
Get rid of statistics related global vars

### DIFF
--- a/src/rdiff_backup/Globals.py
+++ b/src/rdiff_backup/Globals.py
@@ -146,9 +146,6 @@ isbackup_writer = None  # compat201
 # Connection of the backup writer
 backup_writer = None  # compat201
 
-# Connection of the client
-client_conn = None
-
 # When backing up, issource should be true on the reader and isdest on
 # the writer.  When restoring, issource should be true on the mirror
 # and isdest should be true on the target.
@@ -201,13 +198,6 @@ compression = 1
 # If true, filelists and directory statistics will be split on
 # nulls instead of newlines.
 null_separator = None
-
-# If true, print statistics after successful backup
-print_statistics = None
-
-# Controls whether file_statistics file is written in
-# rdiff-backup-data dir.  These can sometimes take up a lot of space.
-file_statistics = 1
 
 # On the backup writer connection, holds the root incrementing branch
 # object.  Access is provided to increment error counts.

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -35,7 +35,7 @@ Verbosity: typing.TypeAlias = typing.Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 InputVerbosity: typing.TypeAlias = int | str
 
 # we need to define constants
-NONE: Verbosity = 0
+NONE: Verbosity = 0  # are always output as-is on stdout
 ERROR: Verbosity = 1
 WARNING: Verbosity = 2
 NOTE: Verbosity = 3
@@ -45,11 +45,12 @@ TIMESTAMP: Verbosity = 9  # for adding the timestamp
 
 # mapping from severity to prefix (must be less than 9 characters)
 _LOG_PREFIX: dict[Verbosity, str] = {
-    1: "ERROR:",
-    2: "WARNING:",
-    3: "NOTE:",
-    5: "*",
-    8: "DEBUG:",
+    NONE: "",
+    ERROR: "ERROR:",
+    WARNING: "WARNING:",
+    NOTE: "NOTE:",
+    INFO: "*",
+    DEBUG: "DEBUG:",
 }
 
 
@@ -99,7 +100,7 @@ class Logger:
 
     def log_to_term(self, message, verbosity):
         """Write message to stdout/stderr"""
-        if verbosity <= 2 or Globals.server:
+        if verbosity in {ERROR, WARNING} or Globals.server:
             termfp = sys.stderr
         else:
             termfp = sys.stdout
@@ -277,7 +278,7 @@ class Logger:
         """Format the message, possibly adding date information"""
         if verbosity <= DEBUG:
             # pre-formatted informative messages are returned as such
-            if msg_verbosity == INFO and "\n" in message[:-1]:
+            if msg_verbosity in {NONE, INFO} and "\n" in message[:-1]:
                 return "{msg}\n".format(msg=message)
             else:
                 return "{pre:<9}{msg}\n".format(

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -486,5 +486,4 @@ def print_active_stats(end_time=None):
     assert _active_statfileobj, "Stats object must be set before printing."
     _active_statfileobj.finish(end_time)
     statmsg = _active_statfileobj.get_stats_logstring("Session statistics")
-    log.Log.log_to_file(statmsg)
-    Globals.client_conn.sys.stdout.write(statmsg)
+    log.Log(statmsg, log.NONE)

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -634,7 +634,6 @@ class BaseAction:
             tempfile.tempdir = self.values["tempdir"]
         # Set default change ownership flag, umask, relay regexps
         os.umask(0o77)
-        Globals.set_all("client_conn", Globals.local_connection)
         for conn in Globals.connections:
             conn.robust.install_signal_handlers()
 

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -181,9 +181,6 @@ def _system_setup(arglist):
     Globals.set("never_drop_acls", arglist.get("never_drop_acls"))
     # if action in ("backup", "regress", "restore"):
     Globals.set("compression", arglist.get("compression"))
-    # if action in ("backup"):
-    Globals.set("file_statistics", arglist.get("file_statistics"))
-    Globals.set("print_statistics", arglist.get("print_statistics"))
     # if action in ("regress"):
     Globals.set("allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps"))
     # generic settings


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Got rid of statistics related global vars client_conn, print_statistics and file_statistics
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
