### PR TITLE
Fix Windows build/test under Vagrant

### DIFF
--- a/testing/action_backuprestore_test.py
+++ b/testing/action_backuprestore_test.py
@@ -19,8 +19,8 @@ class ActionBackupRestoreTest(unittest.TestCase):
 
     def setUp(self):
         self.base_dir = os.path.join(TEST_BASE_DIR, b"action_backup_restore")
-        # Windows can't handle too long filenames
-        long_multi = 10 if os.name == "nt" else 25
+        # Windows can't handle too long filenames, FIXME issue #782
+        long_multi = 5 if os.name == "nt" else 25
         self.from1_struct = {
             "from1": {
                 "contents": {

--- a/testing/location_map_filenames_test.py
+++ b/testing/location_map_filenames_test.py
@@ -20,8 +20,8 @@ class LocationMapFilenamesTest(unittest.TestCase):
 
     def setUp(self):
         self.base_dir = os.path.join(TEST_BASE_DIR, b"location_map_filenames")
-        # Windows can't handle too long filenames
-        long_multi = 5 if os.name == "nt" else 25
+        # Windows can't handle too long filenames, FIXME issue #782
+        long_multi = 3 if os.name == "nt" else 25
         self.from1_struct = {
             "from1": {
                 "contents": {

--- a/tools/win_build_rdiffbackup.sh
+++ b/tools/win_build_rdiffbackup.sh
@@ -29,7 +29,7 @@ fi
 LIBRSYNC_DIR=${HOME}/librsync${bits}
 export LIBRSYNC_DIR
 
-RDIFF_BACKUP_VERSION=rdiff-backup-$(./tools/get_project_metadata.py Version)-${bits}
+RDIFF_BACKUP_VERSION=rdiff-backup-$(${PYEXE} ./tools/get_project_metadata.py Version)-${bits}
 export RDIFF_BACKUP_VERSION
 
 ${TOXEXE} -c tox_win.ini -e buildexe

--- a/tools/win_create_venv.bat
+++ b/tools/win_create_venv.bat
@@ -1,0 +1,17 @@
+@ECHO ON
+@REM create a Python virtualenv to test rdiff-backup
+IF "%1" EQU "" (
+	mkdir dist
+	SET venv_dir=dist/rdb
+) ELSE (
+	mkdir %~dp1
+	SET venv_dir=%1
+)
+python -m venv %venv_dir%
+timeout /t 1 /NOBREAK
+python -m venv --upgrade --upgrade-deps %venv_dir%
+CALL %venv_dir%\Scripts\activate
+pip install -r requirements.txt
+@REM this last command installs the currently developed version, repeat as needed!
+pip install .
+deactivate

--- a/tools/win_package_rdiffbackup.sh
+++ b/tools/win_package_rdiffbackup.sh
@@ -23,7 +23,7 @@ then
 	PYEXE=${py_dir}/${PYEXE}
 fi
 
-ver_name=rdiff-backup-$(./tools/get_project_metadata.py Version)
+ver_name=rdiff-backup-$(${PYEXE} ./tools/get_project_metadata.py Version)
 
 cp CHANGELOG.adoc COPYING README.adoc docs/*.adoc \
 	build/${ver_name}-${bits}

--- a/tools/win_test_rdiffbackup.sh
+++ b/tools/win_test_rdiffbackup.sh
@@ -27,7 +27,7 @@ fi
 LIBRSYNC_DIR=${HOME}/librsync${bits}
 export LIBRSYNC_DIR
 
-ver_name=rdiff-backup-$(./tools/get_project_metadata.py Version)
+ver_name=rdiff-backup-$(${PYEXE} ./tools/get_project_metadata.py Version)
 py_ver_brief=${PYTHON_VERSION%.[0-9]}
 
 # Extract the test files one directory higher

--- a/tools/windows/collections/requirements.yml
+++ b/tools/windows/collections/requirements.yml
@@ -1,6 +1,7 @@
 ---
 collections:
-- ansible.windows
-- chocolatey.chocolatey
-- community.windows
-- ansible.posix
+  - name: ansible.windows
+    version: ">=1.11.0"
+  - chocolatey.chocolatey
+  - community.windows
+  - ansible.posix

--- a/tools/windows/playbook-debug-rdiff-backup.yml
+++ b/tools/windows/playbook-debug-rdiff-backup.yml
@@ -3,23 +3,21 @@
   hosts: windows_builders
   gather_facts: false
   tasks:
-    - name: copy rsync.dll to build directory to call rdiff-backup from repo
-      win_copy:  # newer versions of rsync.dll are installed in bin not lib
-        src: "{{ librsync_install_dir }}/bin/rsync.dll"
-        remote_src: true  # file is already on the Windows machine
-        dest: "{{ rdiffbackup_dir }}/build/lib.{{ win_python_arch }}-{{ python_version | replace('.', '') }}/rdiff_backup/"
     - name: prepare variable backquote to avoid quoting issues
       set_fact:
         bq: \
-    - name: create a simple setup script to call rdiff-backup from the repo
+    - name: create virtualenv under dist/rdb
+      win_command:
+        cmd: tools\win_create_venv.bat
+      args:
+        chdir: "{{ rdiffbackup_dir }}"
+        creates: "{{ rdiffbackup_dir }}/dist/rdb"
+      environment:
+        LIBRSYNC_DIR: "{{ librsync_install_dir | replace('/', bq) }}"
+    - name: create dist\setup-rdiff-backup.bat to call rdiff-backup from the venv
       win_copy:
         content: |
           REM call this script to get the right environment variable and examples
-          SET PYTHONPATH={{ rdiffbackup_dir }}/build/lib.{{ win_python_arch }}-{{ python_version | replace('.', '') }}
-          SET PATH={{ rdiffbackup_dir | replace('/', bq) }}\build\scripts-{{ python_version }};%PATH%
           SET LIBRSYNC_DIR={{ librsync_install_dir | replace('/', bq) }}
-        dest: "{{ rdiffbackup_dir }}/build/setup-rdiff-backup.bat"
-    - name: create a wrapper script to call rdiff-backup from the repo
-      win_copy:
-        src: ../rdiff-backup.bat
-        dest: "{{ rdiffbackup_dir }}/build/scripts-{{ python_version }}/rdiff-backup.bat"
+          dist\rdb\scripts\activate
+        dest: "{{ rdiffbackup_dir }}/dist/setup-rdiff-backup.bat"


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

NEW: add virtualenv creation script for Windows tools/win_create_venv.bat

* use PYEXE to call the metadata script instead of relying on bang
* Add venv creation script for Windows
* Adapt accordingly playbook-debug-rdiff-backup.yml
* Define minimal version for collection ansible.windows
* Reduce filesize name in tests under Windows, had to do this after the paths lengths were made longer

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
