### PR TITLE
Streamline implementation of file system abilities

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1415,7 +1415,7 @@ class RPath(RORPath):
 
     def write_win_acl(self, acl_meta):
         """Change access control list of rp"""
-        acl_win.write_meta(self, acl_meta)
+        acl_meta.write_to_rp(self)
         self.data["win_acl"] = acl_meta
 
     def get_path_as_list(self):

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -1752,9 +1752,9 @@ information in it.
             # base dir can be _potentially_ writable but actually read-only
             # to map the actual rights of the root directory, whereas the
             # data dir is alway writable
-            return fs_abilities.FSAbilities(cls._data_dir, writable=True)
+            return fs_abilities.detect_fs_abilities(cls._data_dir, writable=True)
         else:
-            return fs_abilities.FSAbilities(cls._base_dir, writable=False)
+            return fs_abilities.detect_fs_abilities(cls._base_dir, writable=False)
 
     # @API(RepoShadow.get_config, 201)
     @classmethod

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -16,14 +16,14 @@
 # along with rdiff-backup; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA
-"""Determine the capabilities of given file system
+"""
+Determine the capabilities of given file system
 
 rdiff-backup needs to read and write to file systems with varying
 abilities.  For instance, some file systems and not others have ACLs,
 are case-sensitive, or can store ownership information.  The code in
 this module tests the file system for various features, and returns an
 FSAbilities object describing it.
-
 """
 
 import errno

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -765,7 +765,7 @@ def detect_fs_abilities(root_rp, writable=True):
     """
     Detect file system abilities of the given directory, either in read-only
     or write mode.
-    Returns an FSAbilities object if detection goes well, else a 
+    Returns an FSAbilities object if detection goes well, else None if it fails
     """
     assert (
         root_rp.conn is Globals.local_connection

--- a/src/rdiffbackup/locations/location.py
+++ b/src/rdiffbackup/locations/location.py
@@ -116,7 +116,9 @@ class LocationShadow:
 
     @classmethod
     def get_fs_abilities(cls):
-        return fs_abilities.FSAbilities(cls._base_dir, cls._must_be_writable)
+        return fs_abilities.detect_fs_abilities(
+            cls._base_dir, cls._must_be_writable
+        )
 
     @classmethod
     def _is_existing(cls):

--- a/src/rdiffbackup/locations/location.py
+++ b/src/rdiffbackup/locations/location.py
@@ -116,9 +116,7 @@ class LocationShadow:
 
     @classmethod
     def get_fs_abilities(cls):
-        return fs_abilities.detect_fs_abilities(
-            cls._base_dir, cls._must_be_writable
-        )
+        return fs_abilities.detect_fs_abilities(cls._base_dir, cls._must_be_writable)
 
     @classmethod
     def _is_existing(cls):

--- a/testing/fs_abilities_test.py
+++ b/testing/fs_abilities_test.py
@@ -47,6 +47,11 @@ try:
 except (ImportError, AttributeError):
     carbon_type = type(None)
 
+if os.name == "nt":  # because we ignore hardlinks under Windows
+    hardlinks_type = type(None)
+else:
+    hardlinks_type = bool
+
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -102,7 +107,7 @@ class FSAbilitiesTest(unittest.TestCase):
         print(fsa)
         self.assertTrue(fsa.writable)
         self.assertIsInstance(fsa.ownership, bool)
-        self.assertIsInstance(fsa.hardlinks, bool)
+        self.assertIsInstance(fsa.hardlinks, hardlinks_type)
         self.assertIsInstance(fsa.fsync_dirs, bool)
         self.assertIsInstance(fsa.dir_inc_perms, bool)
         self.assertIsInstance(fsa.high_perms, bool)

--- a/testing/fs_abilities_test.py
+++ b/testing/fs_abilities_test.py
@@ -11,6 +11,43 @@ import commontest as comtst
 from rdiff_backup import Globals, rpath
 from rdiffbackup.locations import fs_abilities
 
+# we don't need all these imports but we use them to decide which type will
+# have the corresponding attributes
+try:
+    import posix1e  # noqa F401
+
+    acl_posix_type = bool
+except ImportError:
+    acl_posix_type = type(None)
+
+try:
+    import xattr.pyxattr_compat as xattr  # noqa F401
+
+    ea_type = bool
+except ImportError:
+    try:
+        import xattr  # noqa F401
+
+        ea_type = bool
+    except ImportError:
+        ea_type = type(None)
+
+try:
+    import win32security  # noqa F401
+    import pywintypes  # noqa F401
+
+    acl_win_type = bool
+except ImportError:
+    acl_win_type = type(None)
+
+try:
+    import Carbon.File  # noqa F401
+
+    carbon_type = bool
+except (ImportError, AttributeError):
+    carbon_type = type(None)
+
+
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
 
@@ -23,30 +60,6 @@ class FSAbilitiesTest(unittest.TestCase):
     from the original test system, this test may/should fail. Change
     the expected values below.
     """
-
-    # Describes standard linux file system without acls/eas
-    dir_to_test = TEST_BASE_DIR
-    eas = acls = None
-    chars_to_quote = ""
-    extended_filenames = True
-    case_sensitive = True
-    ownership = os.getuid() == 0
-    hardlinks = fsync_dirs = True
-    dir_inc_perms = True
-    resource_forks = False
-    carbonfile = False
-    high_perms = True
-
-    # Describes MS-Windows style file system
-    # dir_to_test = "/mnt/fat"
-    # eas = acls = 0
-    # extended_filenames = 0
-    # chars_to_quote = "^a-z0-9_ -"
-    # ownership = hardlinks = 0
-    # fsync_dirs = 1
-    # dir_inc_perms = 0
-    # resource_forks = 0
-    # carbonfile = 0
 
     # A case insensitive directory (FIXME must currently be created by root)
     # mkdir build/testfiles/fs_insensitive
@@ -62,19 +75,22 @@ class FSAbilitiesTest(unittest.TestCase):
 
     def testReadOnly(self):
         """Test basic querying read only"""
-        base_dir = rpath.RPath(Globals.local_connection, self.dir_to_test)
+        base_dir = rpath.RPath(Globals.local_connection, TEST_BASE_DIR)
+        t = time.time()
         fsa = fs_abilities.detect_fs_abilities(base_dir, writable=False)
+        print("Time elapsed = ", time.time() - t)
         print(fsa)
         self.assertFalse(fsa.writable)
-        self.assertEqual(fsa.eas, self.eas)
-        self.assertEqual(fsa.acls, self.acls)
-        self.assertEqual(fsa.resource_forks, self.resource_forks)
-        self.assertEqual(fsa.carbonfile, self.carbonfile)
-        self.assertEqual(fsa.case_sensitive, self.case_sensitive)
+        self.assertIsInstance(fsa.eas, ea_type)
+        self.assertIsInstance(fsa.acls, acl_posix_type)
+        self.assertIsInstance(fsa.win_acls, acl_win_type)
+        self.assertIsInstance(fsa.resource_forks, bool)  # doesn't require module
+        self.assertIsInstance(fsa.carbonfile, carbon_type)
+        self.assertIsInstance(fsa.case_sensitive, bool)
 
     def testReadWrite(self):
         """Test basic querying read/write"""
-        base_dir = rpath.RPath(Globals.local_connection, self.dir_to_test)
+        base_dir = rpath.RPath(Globals.local_connection, TEST_BASE_DIR)
         new_dir = base_dir.append("fs_abilitiestest")
         if new_dir.lstat():
             comtst.remove_dir(new_dir.path)
@@ -85,16 +101,18 @@ class FSAbilitiesTest(unittest.TestCase):
         print("Time elapsed = ", time.time() - t)
         print(fsa)
         self.assertTrue(fsa.writable)
-        self.assertEqual(fsa.eas, self.eas)
-        self.assertEqual(fsa.acls, self.acls)
-        self.assertEqual(fsa.ownership, self.ownership)
-        self.assertEqual(fsa.hardlinks, self.hardlinks)
-        self.assertEqual(fsa.fsync_dirs, self.fsync_dirs)
-        self.assertEqual(fsa.dir_inc_perms, self.dir_inc_perms)
-        self.assertEqual(fsa.resource_forks, self.resource_forks)
-        self.assertEqual(fsa.carbonfile, self.carbonfile)
-        self.assertEqual(fsa.high_perms, self.high_perms)
-        self.assertEqual(fsa.extended_filenames, self.extended_filenames)
+        self.assertIsInstance(fsa.ownership, bool)
+        self.assertIsInstance(fsa.hardlinks, bool)
+        self.assertIsInstance(fsa.fsync_dirs, bool)
+        self.assertIsInstance(fsa.dir_inc_perms, bool)
+        self.assertIsInstance(fsa.high_perms, bool)
+        self.assertIsInstance(fsa.extended_filenames, bool)
+        self.assertIsInstance(fsa.eas, ea_type)
+        self.assertIsInstance(fsa.acls, acl_posix_type)
+        self.assertIsInstance(fsa.win_acls, acl_win_type)
+        self.assertIsInstance(fsa.resource_forks, bool)  # doesn't require module
+        self.assertIsInstance(fsa.carbonfile, carbon_type)
+        self.assertIsInstance(fsa.case_sensitive, bool)
 
         new_dir.delete()
 

--- a/testing/fs_abilities_test.py
+++ b/testing/fs_abilities_test.py
@@ -15,13 +15,13 @@ TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
 
 class FSAbilitiesTest(unittest.TestCase):
-    """Test testing of file system abilities
+    """
+    Test testing of file system abilities
 
     Some of these tests assume that the actual file system tested has
     the given abilities.  If the file system this is run on differs
     from the original test system, this test may/should fail. Change
     the expected values below.
-
     """
 
     # Describes standard linux file system without acls/eas
@@ -63,7 +63,7 @@ class FSAbilitiesTest(unittest.TestCase):
     def testReadOnly(self):
         """Test basic querying read only"""
         base_dir = rpath.RPath(Globals.local_connection, self.dir_to_test)
-        fsa = fs_abilities.FSAbilities(base_dir, writable=False)
+        fsa = fs_abilities.detect_fs_abilities(base_dir, writable=False)
         print(fsa)
         self.assertFalse(fsa.writable)
         self.assertEqual(fsa.eas, self.eas)
@@ -81,7 +81,7 @@ class FSAbilitiesTest(unittest.TestCase):
         new_dir.setdata()
         new_dir.mkdir()
         t = time.time()
-        fsa = fs_abilities.FSAbilities(new_dir)
+        fsa = fs_abilities.detect_fs_abilities(new_dir)
         print("Time elapsed = ", time.time() - t)
         print(fsa)
         self.assertTrue(fsa.writable)
@@ -105,7 +105,7 @@ class FSAbilitiesTest(unittest.TestCase):
     def test_case_sensitive(self):
         """Test a read-only case-INsensitive directory"""
         rp = rpath.RPath(Globals.local_connection, self.case_insensitive_path)
-        fsa = fs_abilities.FSAbilities(rp, writable=False)
+        fsa = fs_abilities.detect_fs_abilities(rp, writable=False)
         fsa._detect_case_sensitive_readonly(rp)
         self.assertEqual(fsa.case_sensitive, 0)
 


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Streamline fs abilities

- Detect whatever it can detect without considering Global variables        
- Introduce function fs_abilities.detect_fs_abilities to catch exceptions   
- Adapt tests to fs_ability changes, e.g. Adapt hardlinks type to Windows case

FIX: corrected comparaison of sub-directories under Windows (regression due 
to Windows ACL implementation).

win_acl comparaison was done based on bytes representation instead of object
itself, leading to wrong comparison under Windows

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
