### PR TITLE
Fix _initialize_restore setting

### DIFF
--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -717,7 +717,7 @@ class RepoShadow(location.LocationShadow):
         """
         Initialize repository for looping through the increments
         """
-        cls._initialize_restore(cls._data_dir, restore_to_time)
+        cls._initialize_restore(restore_to_time)
         cls._initialize_rf_cache(cls._ref_path, cls._ref_inc)
 
     # @API(RepoShadow.finish_loop, 201)
@@ -812,11 +812,10 @@ class RepoShadow(location.LocationShadow):
         return return_list
 
     @classmethod
-    def _initialize_restore(cls, data_dir, restore_to_time):
+    def _initialize_restore(cls, restore_to_time):
         """
         Set class variable _restore_time on mirror conn
         """
-        cls._data_dir = data_dir
         cls._set_restore_time(restore_to_time)
         # it's a bit ugly to set the values to another class, but less than
         # the other way around as it used to be


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why
_repo_shadow._initialize_restore was setting _base_dir from _base_dir so useless
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
