### PR TITLE
Move formatting of time string

### DIFF
--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -31,8 +31,8 @@ from rdiff_backup import Globals
 LOGFILE_ENCODING = "utf-8"
 
 # type definitions
-Verbosity: typing.TypeAlias = typing.Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-InputVerbosity: typing.TypeAlias = int | str
+Verbosity = typing.Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]  # : typing.TypeAlias
+InputVerbosity = typing.Union[int, str]  # : typing.TypeAlias
 
 # we need to define constants
 NONE: Verbosity = 0  # are always output as-is on stdout
@@ -185,7 +185,7 @@ class Logger:
     def set_verbosity(
         self,
         file_verbosity: InputVerbosity,
-        term_verbosity: InputVerbosity | None = None,
+        term_verbosity: typing.Union[InputVerbosity, None] = None,
     ) -> int:
         """
         Set verbosity levels, logfile and terminal.  Takes numbers or strings.

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -137,7 +137,7 @@ class BackupAction(actions.BaseAction):
         )
 
         if previous_time:
-            self.repo.touch_current_mirror(Time.getcurtimestr())
+            self.repo.touch_current_mirror(Time.getcurtime())
 
         source_rpiter = self.dir.get_select()
         dest_sigiter = self.repo.get_sigs(source_rpiter, previous_time)
@@ -147,7 +147,7 @@ class BackupAction(actions.BaseAction):
         if previous_time:
             self.repo.remove_current_mirror()
         else:
-            self.repo.touch_current_mirror(Time.getcurtimestr())
+            self.repo.touch_current_mirror(Time.getcurtime())
 
         self.repo.close_statistics(time.time())
 

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -647,7 +647,7 @@ class RepoShadow(location.LocationShadow):
 
     # @API(RepoShadow.touch_current_mirror, 201)
     @classmethod
-    def touch_current_mirror(cls, current_time_str):
+    def touch_current_mirror(cls, current_time):
         """
         Make a file like current_mirror.<datetime>.data to record time
 
@@ -659,8 +659,9 @@ class RepoShadow(location.LocationShadow):
         When doing the initial full backup, the file can be created after
         everything else is in place.
         """
+        current_time_bytes = Time.timetobytes(current_time)
         mirrorrp = cls._data_dir.append(
-            b".".join((b"current_mirror", os.fsencode(current_time_str), b"data"))
+            b".".join((b"current_mirror", current_time_bytes, b"data"))
         )
         log.Log("Writing mirror marker {mm}".format(mm=mirrorrp), log.INFO)
         try:
@@ -1517,7 +1518,7 @@ information in it.
                 log.WARNING,
             )
             return False
-        cls.touch_current_mirror(Time.timetostring(inc_times[-2]))
+        cls.touch_current_mirror(inc_times[-2])
         return True
 
     @classmethod

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -165,11 +165,11 @@ class Repo(location.Location):
         """
         return self._shadow.apply(source_diffiter, previous_time)
 
-    def touch_current_mirror(self, current_time_str):
+    def touch_current_mirror(self, current_time):
         """
         Shadow function for RepoShadow.touch_current_mirror
         """
-        return self._shadow.touch_current_mirror(current_time_str)
+        return self._shadow.touch_current_mirror(current_time)
 
     def remove_current_mirror(self):
         """

--- a/testing/action_regress_test.py
+++ b/testing/action_regress_test.py
@@ -8,7 +8,7 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals, rpath, Time
+from rdiff_backup import Globals, rpath
 from rdiffbackup.locations import _repo_shadow
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
@@ -133,7 +133,7 @@ class ActionRegressTest(unittest.TestCase):
             True,
             True,
         )
-        _repo_shadow.RepoShadow.touch_current_mirror(Time.timetostring(20000))
+        _repo_shadow.RepoShadow.touch_current_mirror(20000)
 
         # the current process (the test) is still running, hence it fails
         self.assertNotEqual(
@@ -176,7 +176,7 @@ class ActionRegressTest(unittest.TestCase):
         )
         self.assertFalse(fileset.compare_paths(self.from2_path, self.to2_path))
         # we again simulate a crash
-        _repo_shadow.RepoShadow.touch_current_mirror(Time.timetostring(10000))
+        _repo_shadow.RepoShadow.touch_current_mirror(10000)
         # and then try to backup, which fails because without force
         self.assertNotEqual(
             comtst.rdiff_backup_action(


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Move formatting of time string into touch_current_mirror to make a function of the repo shadow.

There is still one call to getcurtimestr outside of the repo shadow, in the meta mgr class, but getting rid of it requires splitting the meta file handling.

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
