### PR TITLE
Fix to address Inefficient regular expression

### DIFF
--- a/src/rdiffbackup/arguments.py
+++ b/src/rdiffbackup/arguments.py
@@ -47,6 +47,8 @@ def parse_args(parser, args):
         if exc.code != 0:
             exc.code = 1
         raise
+    except argparse.ArgumentError as exc:
+        sys.exit(exc)
     return parsed_args
 
 

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -142,11 +142,8 @@ def quote(path):
 
     # Escape first char of any special DOS device files even if filename has an
     # extension.  Special names are: aux, prn, con, nul, com0-9, and lpt1-9.
-    if not re.search(
-        rb"^aux(\..*)*$|^prn(\..*)*$|^con(\..*)*$|^nul(\..*)*$|"
-        rb"^com[0-9](\..*)*$|^lpt[1-9]{1}(\..*)*$",
-        quoted_path,
-        re.I,
+    if not re.match(  # match checks only at the beginning
+        rb"(aux|prn|con|nul|com[0-9]|lpt[1-9])(\.|$)", quoted_path, re.I
     ):
         return quoted_path
     return b"%b%03d" % (Globals.quoting_char, quoted_path[0]) + quoted_path[1:]


### PR DESCRIPTION

<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

It was a security warning from CodeQL hosted by GitHub

FIX: inefficient regular expression, could slightly improve performance and address potential vulnerability

Had also to fix a change in behaviour of argparse to pass the tests.
<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
