### PR TITLE
Flush stderr or stdout when logging

### DIFF
--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -121,6 +121,7 @@ class Logger:
             )
         else:
             termfp.write(tmpstr)
+        termfp.flush()
 
     def conn(self, direction, result, req_num):
         """Log some data on the connection

--- a/testing/server.py
+++ b/testing/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+from rdiffbackup.singletons import specifics
 
 __doc__ = """
 
@@ -26,5 +27,6 @@ except (OSError, ImportError):
     print_usage()
     raise
 
+specifics.server = True
 Security._security_level = "override"
 sys.exit(connection.PipeConnection(sys.stdin.buffer, sys.stdout.buffer).Server())


### PR DESCRIPTION
## Changes done and why

I have this scenario where output of rdiff-backup is scramble because, it seams, the stdout and stderr are printed to the console in different order. To get this fixed, I recommand to flush stderr and/or stdout on every log. This also push the lines to the console in real-time.

## Self-Checklist

- [-] changes to the code have been reflected in the documentation: N/A
- [-] changes to the code have been covered by new/modified tests: N/A
- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG: I'm open to recommendation.

