### PR TITLE
Little improvement to test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ all: clean container test build
 
 test: test-static test-runtime
 
+check:
+	@command -v rdiff >/dev/null && echo "rdiff is installed" || { echo "Error: rdiff is not installed"; exit 1; }
+
 test-static:
 	${RUN_COMMAND} tox -c tox.ini -e check-static
 
@@ -21,7 +24,7 @@ test-runtime-files:
 	@echo "=== Install files required by the tests ==="
 	${RUN_COMMAND} ./tools/setup-testfiles.sh  # This must run as root or sudo be available
 
-test-runtime-base: test-runtime-files
+test-runtime-base: check test-runtime-files
 	@echo "=== Base tests ==="
 	${RUN_COMMAND} tox -c tox.ini -e py
 

--- a/tools/setup-testfiles.sh
+++ b/tools/setup-testfiles.sh
@@ -15,7 +15,7 @@ then
 	echo "Test files found, not re-installing them..." >&2
 else
 	echo "Test files not found, installing them..." >&2
-	cd ..
+	pushd ..
 	if [ ! -f ${TESTREPODIR}/${TESTTARFILE} ]
 	then
 		rm -fr ${TESTREPODIR}  # Clean away potential cruft
@@ -36,7 +36,7 @@ else
 	${SUDO} tar xf ${TESTREPODIR}/${TESTTARFILE}
 	${SUDO} ${TESTREPODIR}/rdiff-backup_testfiles.fix.sh "${RDIFF_TEST_USER}" "${RDIFF_TEST_GROUP}"
 
-	cd rdiff-backup
+	popd
 fi
 
 echo "


### PR DESCRIPTION
## Changes done and why

Because I'm lazy and not reading the documentation, I'm adding a "check" in make file that should be expended to include more verification of the current environment to ensure the test will run successfully. First verification is a check for "rdiff" command.

Also adding support to alternate folder name. Mine is "rdiff-backup.git"

## Self-Checklist

- [ ] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
