### PR TITLE
Add timeout when reading files not on disk

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -47,6 +47,8 @@ from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
 from rdiffbackup.meta import acl_posix, acl_win, ea
 
+import signal
+
 try:
     import win32api
     import win32con
@@ -1126,6 +1128,8 @@ class RPath(RORPath):
         if self.conn is Globals.local_connection:
             if compress:
                 return gzip.GzipFile(self.path, mode)
+            elif mode == "rb":
+                return open_local_read(self)
             else:
                 return open(self.path, mode)
 
@@ -1919,13 +1923,38 @@ def gzip_open_local_read(rpath):
     return gzip.GzipFile(rpath.path, "rb")
 
 
+def timeout_handler(signum, frame):
+    raise RPathException("File read operation timed out.")
+
+
+def read_timeout(self, size, timeout=300):
+    signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm(timeout)
+    data = self.orig_read(size)
+    signal.alarm(0)
+    self.read = self.orig_read
+    return data
+
+
 # @API(open_local_read, 200)
 def open_local_read(rpath):
     """Return open file (provided for security reasons)"""
     assert (
         rpath.conn is Globals.local_connection
     ), "Function works locally not over '{conn}'.".format(conn=rpath.conn)
-    return open(rpath.path, "rb")
+    fp = open(rpath.path, "rb")
+    # When file is not present on disk, it's most likely a file to be fetch from cloud.
+    # Add timeout of 5min to `read` function when it's the case to avoid getting blocked
+    # by buggy cloud software.
+    if (
+        os.name != "nt"
+        and rpath.isreg()
+        and rpath.data.get("size", 0) > 0
+        and os.lstat(rpath.path).st_blocks == 0
+    ):
+        fp.orig_read = fp.read
+        fp.read = read_timeout.__get__(fp)
+    return fp
 
 
 def get_incfile_info(basename):


### PR DESCRIPTION
## Changes done and why

When using cloud file storage, some time the file is not present on disk and the software is supposed to fetch the data from the cloud in real-time. When this process is failing, this cause rdiff-backup to be stuck trying to read a file indefinitely. To avoid this, a timeout is added to read the first bytes of the file.

I'm creating this pull request to start a discussion about the change. Technically, the change I've done is working. Rdiff-backup is no longer stuck on file read when OneDrive on MacOS is failing. But:

1. The additional os.lstat() double the number of IO call which I would prefer to avoid, but when I try adding "blocks" to `make_file_dict` everything fall apart in comparison. And I'm not 100% sure if adding "blocks" to the dict is backward compatible.
2. I think we could make this timeout value a settings. What do you suggest ? 300sec (5min) might not be enough in all condition. If the file is large and OneDrive need to download the file, it might take more then 5 min. Not sure how to detect this. We could do some timeout calculation based on the file-size reported. 

## Self-Checklist

- [ ] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
