### PR TITLE
Provide more information in tox calls

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@v4
       if: ${{ env.SKIP != 'true' }}
     - name: Set up Python ${{ matrix.python-version }}
+      id: inst-py
       if: ${{ env.SKIP != 'true' }}
       uses: actions/setup-python@v5
       with:
@@ -32,11 +33,11 @@ jobs:
       if: ${{ env.SKIP != 'true' }}
       run: |
         sudo apt install librsync-dev libacl1-dev rdiff asciidoctor
-        sudo pip3 install --upgrade -r requs/base.txt -r requs/optional.txt -r requs/test.txt
+        sudo ${{ steps.inst-py.outputs.python-path }} -m pip install --upgrade -r requs/base.txt -r requs/optional.txt -r requs/test.txt
     - name: Execute tests ${{ matrix.test-step }}
       if: ${{ env.SKIP != 'true' }}
       run: |
         export RUN_COMMAND=
-        export SUDO=sudo
+        export SUDO="sudo -E env PATH=$PATH"
         make test
       # the empty RUN_COMMAND avoids using docker

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps = -r{toxinidir}/requs/base.txt
        -r{toxinidir}/requs/test.txt
 allowlist_externals = sh
 commands_pre =
-	rdiff-backup --version
+	rdiff-backup info
 # must be the first command to setup the test environment
 	python testing/commontest.py
 	coverage erase

--- a/tox_root.ini
+++ b/tox_root.ini
@@ -23,7 +23,7 @@ deps = -r{toxinidir}/requs/base.txt
        -r{toxinidir}/requs/optional.txt
 #whitelist_externals = env
 commands_pre =
-    rdiff-backup --version
+    rdiff-backup info
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =

--- a/tox_slow.ini
+++ b/tox_slow.ini
@@ -15,7 +15,7 @@ deps = -r{toxinidir}/requs/base.txt
        -r{toxinidir}/requs/optional.txt
 # whitelist_externals =
 commands_pre =
-    rdiff-backup --version
+    rdiff-backup info
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =

--- a/tox_smoke.ini
+++ b/tox_smoke.ini
@@ -18,7 +18,7 @@ deps = -r{toxinidir}/requs/base.txt
        -r{toxinidir}/requs/test.txt
 allowlist_externals = sh
 commands_pre =
-	rdiff-backup --version
+	rdiff-backup info
 # must be the first command to setup the test environment
 	python testing/commontest.py
 commands =

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -18,7 +18,7 @@ deps = -r{toxinidir}/requs/base.txt
        -r{toxinidir}/requs/optional.txt
 whitelist_externals = cmd
 commands_pre =
-    rdiff-backup --version
+    rdiff-backup info
     # must be the first command to setup the test environment
     python testing/commontest.py
 commands =


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Replace rdiff-backup --version with rdiff-backup info, especially because I had some doubts which version of Python is actually used in our pipeline
