### PR TITLE
Split Globals into different singletons

### DIFF
--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -29,3 +29,4 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - generic variable preserve_atime isn't modified anywhere
 - simplify usage of connections and connection_dict (get rid of one of both?)
 - get rid of the backup_writer variables (in singleton/specifics), replace with log/stats access to repository
+- get rid of mixing input parameters and global/generic parameters in run._system_setup

--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -27,3 +27,4 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - get rid of usage of selection module in fs_abilities
 - specific variable change_mirror_perms doesn't seem to be used anywhere
 - generic variable preserve_atime isn't modified anywhere
+- simplify usage of connections and connection_dict (get rid of one of both?)

--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -25,7 +25,6 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - add https://docs.python.org/3/library/argparse.html#argument-groups to arguments coming from actions
 - pass null_separator to selection functions
 - get rid of usage of selection module in fs_abilities
-- specific variable change_mirror_perms doesn't seem to be used anywhere
 - generic variable preserve_atime isn't modified anywhere
 - simplify usage of connections and connection_dict (get rid of one of both?)
 - get rid of the backup_writer variables (in singleton/specifics), replace with log/stats access to repository

--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -30,3 +30,5 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - simplify usage of connections and connection_dict (get rid of one of both?)
 - get rid of the backup_writer variables (in singleton/specifics), replace with log/stats access to repository
 - get rid of mixing input parameters and global/generic parameters in run._system_setup
+- get rid of compression as generics variable, replacing with usage of values.
+- replace null_separator with something like line_separator, directly having the character

--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -25,3 +25,5 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - add https://docs.python.org/3/library/argparse.html#argument-groups to arguments coming from actions
 - pass null_separator to selection functions
 - get rid of usage of selection module in fs_abilities
+- specific variable change_mirror_perms doesn't seem to be used anywhere
+- generic variable preserve_atime isn't modified anywhere

--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -28,3 +28,4 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - specific variable change_mirror_perms doesn't seem to be used anywhere
 - generic variable preserve_atime isn't modified anywhere
 - simplify usage of connections and connection_dict (get rid of one of both?)
+- get rid of the backup_writer variables (in singleton/specifics), replace with log/stats access to repository

--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -30,3 +30,4 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - get rid of the backup_writer variables (in singleton/specifics), replace with log/stats access to repository
 - get rid of compression as generics variable, replacing with usage of values.
 - replace null_separator with something like line_separator, directly having the character
+- replace all usage of print through log.Log

--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -29,6 +29,5 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - generic variable preserve_atime isn't modified anywhere
 - simplify usage of connections and connection_dict (get rid of one of both?)
 - get rid of the backup_writer variables (in singleton/specifics), replace with log/stats access to repository
-- get rid of mixing input parameters and global/generic parameters in run._system_setup
 - get rid of compression as generics variable, replacing with usage of values.
 - replace null_separator with something like line_separator, directly having the character

--- a/src/rdiff_backup/Rdiff.py
+++ b/src/rdiff_backup/Rdiff.py
@@ -18,7 +18,8 @@
 # 02110-1301, USA
 """Invoke rdiff utility to make signatures, deltas, or patch"""
 
-from rdiff_backup import Globals, log, rpath, hash, librsync
+from rdiff_backup import log, rpath, hash, librsync
+from rdiffbackup.singletons import specifics
 
 
 def get_signature(rp, blocksize=None):

--- a/src/rdiff_backup/Rdiff.py
+++ b/src/rdiff_backup/Rdiff.py
@@ -82,7 +82,7 @@ def patch_local(rp_basis, rp_delta, outrp=None, delta_compressed=None):
     used to produce hashes.
     """
     assert (
-        rp_basis.conn is Globals.local_connection
+        rp_basis.conn is specifics.local_connection
     ), "This function must run locally and not over '{conn}'.".format(
         conn=rp_basis.conn
     )

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -20,7 +20,8 @@
 
 import os
 import tempfile
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
+from rdiffbackup.singletons import specifics
 
 
 class Violation(Exception):

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -343,7 +343,7 @@ def _set_allowed_requests(sec_class, sec_level):
             [
                 "SetConnections.init_connection_remote",
                 # API >= 201
-                "Globals.set_api_version",
+                "specifics.set_api_version",
                 # API >= 300
                 "log.Log.set_verbosity",  # FIXME can we pipe this through?
             ]

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -82,7 +82,8 @@ _file_requests = {
 
 # functions to set global values
 _globals_requests = {
-    "Globals.set_local",
+    "generics.set_local",
+    "specifics.set",
 }
 
 
@@ -212,7 +213,7 @@ def _set_allowed_requests(sec_class, sec_level):
         "RedirectedRun",  # connection.RedirectedRun
         "VirtualFile.readfromid",  # connection.VirtualFile.readfromid
         "VirtualFile.closebyid",  # connection.VirtualFile.closebyid
-        "Globals.get",
+        "specifics.get",
         "log.Log.open_logfile_allconn",
         "log.Log.close_logfile_allconn",
         "log.Log.log_to_file",

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -101,7 +101,7 @@ def initialize(
     )
     _security_level = security_level
     if restrict_path:
-        reset_restrict_path(rpath.RPath(Globals.local_connection, restrict_path))
+        reset_restrict_path(rpath.RPath(specifics.local_connection, restrict_path))
     _allowed_requests = _set_allowed_requests(security_class, security_level)
 
 
@@ -114,7 +114,7 @@ def reset_restrict_path(rp):
     It is assumed that the new path is a proper path, else function will fail.
     """
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "Function works locally not over '{conn}'.".format(conn=rp.conn)
     global _restrict_path, _restrict_path_list
     _restrict_path = rp.normalize().path
@@ -362,12 +362,12 @@ def _vet_filename(request, arglist):
             "argument %d doesn't look like a filename" % i, request, arglist
         )
 
-    _vet_rpath(rpath.RPath(Globals.local_connection, filename), request, arglist)
+    _vet_rpath(rpath.RPath(specifics.local_connection, filename), request, arglist)
 
 
 def _vet_rpath(rp, request, arglist):
     """Internal function to validate that a specific path isn't restricted"""
-    if _restrict_path and rp.conn is Globals.local_connection:
+    if _restrict_path and rp.conn is specifics.local_connection:
         norm_path = rp.normalize().path
         components = norm_path.split(b"/")
         # we can't properly assess paths with parent directory, so we reject

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -522,23 +522,28 @@ def _test_connection(conn_number, rp):
     print("Testing server started by: ", __conn_remote_cmds[conn_number])
     conn = specifics.connections[conn_number]
     if conn is None:
-        sys.stderr.write("- Connection failed, server tests skipped\n")
+        log.Log("Connection failed, server tests skipped", log.ERROR)
         return False
-    # FIXME the tests don't sound right, the path given needs to pre-exist
-    # on Windows but not on Linux? What are we exactly testing here?
     try:
-        remote_time = conn.Globals.get("current_time")
-        assert (
-            remote_time == generics.current_time
-        ), "connection not returning current time {ct1} but {ct2}".format(
-            ct1=generics.current_time, ct2=remote_time
-        )
-        assert (
-            type(conn.os.listdir(rp.path)) is list
-        ), "connection not listing directory '{rp}'".format(rp=rp)
+        transfer_value = "xyz123"
+        conn.specifics.set("test_variable", transfer_value)
+        return_value = conn.specifics.get("test_variable")
+        if transfer_value != test_value:
+            log.Log(
+                "Returned value '{rv}' of test variable is not the same as "
+                "transferred value '{tv}'".format(
+                    rv=return_value, tv=transfer_value
+                ), log.ERROR)
+            return False
+        if type(conn.os.listdir(rp.path)) is not list:
+            log.Log(
+                "Connection not listing directory '{rp}'".format(rp=rp),
+                log.ERROR,
+            )
+            return False
     except BaseException as exc:
-        sys.stderr.write("- Server tests failed due to {exc}\n".format(exc=exc))
+        log.Log("Server tests failed due to {exc}".format(exc=exc), log.ERROR)
         return False
     else:
-        print("- Server OK")
+        log.Log("Server OK", log.NOTE)
         return True

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -129,7 +129,9 @@ def init_connection_remote(conn_number):
 # @API(add_redirected_conn, 200)
 def add_redirected_conn(conn_number):
     """Run on server side - tell about redirected connection"""
-    specifics.connection_dict[conn_number] = connection.RedirectedConnection(conn_number)
+    specifics.connection_dict[conn_number] = connection.RedirectedConnection(
+        conn_number
+    )
 
 
 def CloseConnections():
@@ -414,7 +416,9 @@ which should only print out the text: rdiff-backup <version>""".format(
                 "Remote version {rv} isn't compatible with local "
                 "API version {av}".format(
                     rv=remote_version,
-                    av=(specifics.api_version["actual"] or specifics.api_version["min"]),
+                    av=(
+                        specifics.api_version["actual"] or specifics.api_version["min"]
+                    ),
                 ),
                 log.ERROR,
             )

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -26,7 +26,6 @@ the related connections.
 
 import os
 import re
-import sys
 import subprocess
 from rdiff_backup import connection, log, rpath
 from rdiffbackup.singletons import consts, generics, specifics
@@ -528,12 +527,12 @@ def _test_connection(conn_number, rp):
         transfer_value = "xyz123"
         conn.specifics.set("test_variable", transfer_value)
         return_value = conn.specifics.get("test_variable")
-        if transfer_value != test_value:
+        if transfer_value != return_value:
             log.Log(
                 "Returned value '{rv}' of test variable is not the same as "
-                "transferred value '{tv}'".format(
-                    rv=return_value, tv=transfer_value
-                ), log.ERROR)
+                "transferred value '{tv}'".format(rv=return_value, tv=transfer_value),
+                log.ERROR,
+            )
             return False
         if type(conn.os.listdir(rp.path)) is not list:
             log.Log(

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -529,9 +529,9 @@ def _test_connection(conn_number, rp):
     try:
         remote_time = conn.Globals.get("current_time")
         assert (
-            remote_time == Globals.current_time
+            remote_time == generics.current_time
         ), "connection not returning current time {ct1} but {ct2}".format(
-            ct1=Globals.current_time, ct2=remote_time
+            ct1=generics.current_time, ct2=remote_time
         )
         assert (
             type(conn.os.listdir(rp.path)) is list

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -28,7 +28,7 @@ import os
 import re
 import sys
 import subprocess
-from rdiff_backup import connection, Globals, log, rpath
+from rdiff_backup import connection, log, rpath
 from rdiffbackup.singletons import consts, generics, specifics
 from rdiffbackup.utils import safestr
 
@@ -136,7 +136,7 @@ def add_redirected_conn(conn_number):
 
 def CloseConnections():
     """Close all connections.  Run by client"""
-    assert not Globals.server, "Connections can't be closed by server"
+    assert not specifics.server, "Connections can't be closed by server"
     for conn in specifics.connections:
         if conn:  # could be None, if the connection failed
             conn.quit()
@@ -425,7 +425,7 @@ which should only print out the text: rdiff-backup <version>""".format(
             return False
 
     # servers don't validate the API version, client does
-    if Globals.server:
+    if specifics.server:
         return True
 
     # Now compare the remote and local API versions and agree actual version

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -157,7 +157,7 @@ def test_connections(rpaths):
         log.Log("No remote connections specified, only local one available", log.ERROR)
         return consts.RET_CODE_FILE_ERR
     elif conn_len != len(rpaths) + 1:
-        print(
+        log.Log(
             "All {pa} parameters must be remote of the form "
             "'server::path'".format(pa=len(rpaths)),
             log.ERROR,
@@ -518,7 +518,10 @@ def _test_connection(conn_number, rp):
     depending on test results."""
     # the function doesn't use the log functions because it might not have
     # an error or log file to use.
-    print("Testing server started by: ", __conn_remote_cmds[conn_number])
+    log.Log(
+        "Testing server started by: {rc}".format(rc=__conn_remote_cmds[conn_number]),
+        log.NOTE,
+    )
     conn = specifics.connections[conn_number]
     if conn is None:
         log.Log("Connection failed, server tests skipped", log.ERROR)

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -111,7 +111,7 @@ def get_connected_rpath(cmd_pair):
     if cmd:
         conn = _init_connection(cmd)
     else:
-        conn = Globals.local_connection
+        conn = specifics.local_connection
     if conn:
         return rpath.RPath(conn, filename).normalize()
     else:
@@ -122,9 +122,9 @@ def get_connected_rpath(cmd_pair):
 def init_connection_remote(conn_number):
     """Run on server side to tell self that have given conn_number"""
     Globals.connection_number = conn_number
-    Globals.local_connection.conn_number = conn_number
+    specifics.local_connection.conn_number = conn_number
     Globals.connection_dict[0] = Globals.connections[1]
-    Globals.connection_dict[conn_number] = Globals.local_connection
+    Globals.connection_dict[conn_number] = specifics.local_connection
 
 
 # @API(add_redirected_conn, 200)
@@ -140,7 +140,7 @@ def CloseConnections():
         if conn:  # could be None, if the connection failed
             conn.quit()
     del Globals.connections[1:]  # Only leave local connection
-    Globals.connection_dict = {0: Globals.local_connection}
+    Globals.connection_dict = {0: specifics.local_connection}
 
 
 def test_connections(rpaths):
@@ -319,7 +319,7 @@ def _init_connection(remote_cmd):
 
     """
     if not remote_cmd:
-        return Globals.local_connection
+        return specifics.local_connection
 
     log.Log(
         "Executing remote command {rc}".format(rc=safestr.to_str(remote_cmd)), log.INFO

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -29,7 +29,7 @@ import re
 import sys
 import subprocess
 from rdiff_backup import connection, Globals, log, rpath
-from rdiffbackup.singletons import consts, specifics
+from rdiffbackup.singletons import consts, generics, specifics
 from rdiffbackup.utils import safestr
 
 # This is a list of remote commands used to start the connections.
@@ -507,8 +507,7 @@ def _init_connection_routing(conn, conn_number, remote_cmd):
 def _init_connection_settings(conn):
     """Tell new conn about log settings and updated globals"""
     conn.log.Log.set_verbosity(log.Log.file_verbosity, log.Log.term_verbosity)
-    for setting_name in Globals.changed_settings:
-        conn.Globals.set_local(setting_name, Globals.get(setting_name))
+    generics.dispatch_settings(conn)
 
 
 def _test_connection(conn_number, rp):

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -29,6 +29,7 @@ import re
 import sys
 import subprocess
 from rdiff_backup import connection, Globals, log, rpath
+from rdiffbackup.singletons import consts
 from rdiffbackup.utils import safestr
 
 # This is a list of remote commands used to start the connections.
@@ -154,22 +155,22 @@ def test_connections(rpaths):
     conn_len = len(Globals.connections)
     if conn_len == 1:
         log.Log("No remote connections specified, only local one available", log.ERROR)
-        return Globals.RET_CODE_FILE_ERR
+        return consts.RET_CODE_FILE_ERR
     elif conn_len != len(rpaths) + 1:
         print(
             "All {pa} parameters must be remote of the form "
             "'server::path'".format(pa=len(rpaths)),
             log.ERROR,
         )
-        return Globals.RET_CODE_FILE_ERR
+        return consts.RET_CODE_FILE_ERR
 
     # we create a list of all test results, skipping the connection 0, which
     # is the local one.
     results = map(lambda i: _test_connection(i, rpaths[i - 1]), range(1, conn_len))
     if all(results):
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
     else:
-        return Globals.RET_CODE_ERR
+        return consts.RET_CODE_ERR
 
 
 def parse_location(file_desc):

--- a/src/rdiff_backup/Time.py
+++ b/src/rdiff_backup/Time.py
@@ -22,6 +22,7 @@ import calendar
 import re
 import time
 from rdiff_backup import Globals
+from rdiffbackup.singletons import generics
 
 
 _interval_conv_dict = {
@@ -61,8 +62,8 @@ def set_current_time(reftime=None):
     """
     if reftime is None:
         reftime = time.time()
-    Globals.set_all("current_time", reftime)
-    Globals.set_all("current_time_string", timetostring(reftime))
+    generics.set("current_time", reftime)
+    generics.set("current_time_string", timetostring(reftime))
 
 
 def getcurtime():

--- a/src/rdiff_backup/Time.py
+++ b/src/rdiff_backup/Time.py
@@ -21,7 +21,6 @@
 import calendar
 import re
 import time
-from rdiff_backup import Globals
 from rdiffbackup.singletons import generics
 
 
@@ -67,11 +66,11 @@ def set_current_time(reftime=None):
 
 
 def getcurtime():
-    return Globals.current_time
+    return generics.current_time
 
 
 def getcurtimestr():
-    return Globals.current_time_string
+    return generics.current_time_string
 
 
 def timetostring(timeinseconds):

--- a/src/rdiff_backup/Time.py
+++ b/src/rdiff_backup/Time.py
@@ -79,7 +79,7 @@ def timetostring(timeinseconds):
     Return w3 datetime compliant listing of timeinseconds, or one in
     which :'s have been replaced with -'s
     """
-    if not Globals.use_compatible_timestamps:
+    if not generics.use_compatible_timestamps:
         format_string = TIMEDATE_FORMAT_STRING
     else:
         format_string = TIMEDATE_FORMAT_COMPAT
@@ -283,7 +283,7 @@ def _get_tzd(timeinseconds=None):
     if timeinseconds is None:
         timeinseconds = time.time()
     tzd = time.strftime("%z", time.localtime(timeinseconds))
-    if Globals.use_compatible_timestamps:
+    if generics.use_compatible_timestamps:
         time_separator = "-"
     else:
         time_separator = ":"

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -26,7 +26,6 @@ import time
 import traceback
 
 from rdiff_backup import (
-    Globals,
     iterfile,
     log,
     robust,
@@ -94,7 +93,6 @@ class Connection:
             # "socket": "socket",
             # "tempfile": "tempfile",
             # "types": "types",
-            "Globals": "rdiff_backup.Globals",
             # "increment": "rdiff_backup.increment",
             # "iterfile": "rdiff_backup.iterfile",
             # "librsync": "rdiff_backup.librsync",
@@ -111,6 +109,9 @@ class Connection:
             "_dir_shadow": "rdiffbackup.locations._dir_shadow",
             "_repo_shadow": "rdiffbackup.locations._repo_shadow",
             "map_filenames": "rdiffbackup.locations.map.filenames",
+            "consts": "rdiffbackup.singletons.consts",
+            "generics": "rdiffbackup.singletons.generics",
+            "specifics": "rdiffbackup.singletons.specifics",
         }
         for name, module in modules.items():
             cls.globals[name] = importlib.import_module(module)
@@ -496,7 +497,7 @@ class PipeConnection(LowLevelPipeConnection):
 
     def quit(self):
         """Close the associated pipes and tell server side to quit"""
-        assert not Globals.server, "This function shouldn't run as server."
+        assert not specifics.server, "This function shouldn't run as server."
         self._putquit()
         self._get()
         self._close()

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -34,6 +34,7 @@ from rdiff_backup import (
     Security,
 )
 from rdiffbackup.locations.map import filenames as map_filenames
+from rdiffbackup.singletons import consts
 
 
 class ConnectionError(Exception):
@@ -260,7 +261,7 @@ class LowLevelPipeConnection(Connection):
 
     def _putobj(self, obj, req_num):
         """Send a generic python obj down the outpipe"""
-        self._write("o", pickle.dumps(obj, Globals.PICKLE_PROTOCOL), req_num)
+        self._write("o", pickle.dumps(obj, consts.PICKLE_PROTOCOL), req_num)
 
     def _putbuf(self, buf, req_num):
         """Send buffer buf down the outpipe"""
@@ -284,12 +285,12 @@ class LowLevelPipeConnection(Connection):
 
         """
         rpath_repr = (rpath.conn.conn_number, rpath.base, rpath.index, rpath.data)
-        self._write("R", pickle.dumps(rpath_repr, Globals.PICKLE_PROTOCOL), req_num)
+        self._write("R", pickle.dumps(rpath_repr, consts.PICKLE_PROTOCOL), req_num)
 
     def _putqrpath(self, qrpath, req_num):
         """Put a quoted rpath into the pipe (similar to _putrpath above)"""
         qrpath_repr = (qrpath.conn.conn_number, qrpath.base, qrpath.index, qrpath.data)
-        self._write("Q", pickle.dumps(qrpath_repr, Globals.PICKLE_PROTOCOL), req_num)
+        self._write("Q", pickle.dumps(qrpath_repr, consts.PICKLE_PROTOCOL), req_num)
 
     def _putrorpath(self, rorpath, req_num):
         """Put an rorpath into the pipe
@@ -299,7 +300,7 @@ class LowLevelPipeConnection(Connection):
 
         """
         rorpath_repr = (rorpath.index, rorpath.data)
-        self._write("r", pickle.dumps(rorpath_repr, Globals.PICKLE_PROTOCOL), req_num)
+        self._write("r", pickle.dumps(rorpath_repr, consts.PICKLE_PROTOCOL), req_num)
 
     def _putconn(self, pipeconn, req_num):
         """Put a connection into the pipe
@@ -468,7 +469,7 @@ class PipeConnection(LowLevelPipeConnection):
         Globals.connections.append(self)
         log.Log("Starting server", log.INFO)
         self._get_response(-1)
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def reval(self, function_string, *args):
         """

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -34,7 +34,7 @@ from rdiff_backup import (
     Security,
 )
 from rdiffbackup.locations.map import filenames as map_filenames
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 
 class ConnectionError(Exception):

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -156,9 +156,9 @@ class LocalConnection(Connection):
     def __init__(self):
         """This prevents two instances of LocalConnection"""
         assert (
-            not Globals.local_connection
+            not specifics.local_connection
         ), "Local connection has already been initialized with {conn}.".format(
-            conn=Globals.local_connection
+            conn=specifics.local_connection
         )
         super().__init__()
         self.conn_number = 0  # changed by SetConnections for server
@@ -732,14 +732,14 @@ def RedirectedRun(conn_number, func, *args):
     """
     conn = Globals.connection_dict[conn_number]
     assert (
-        conn is not Globals.local_connection
+        conn is not specifics.local_connection
     ), "A redirected run shouldn't be required locally for {fnc}.".format(
         fnc=func.__name__
     )
     return conn.reval(func, *args)
 
 
-Globals.local_connection = LocalConnection()
-Globals.connections.append(Globals.local_connection)
+specifics.local_connection = LocalConnection()
+Globals.connections.append(specifics.local_connection)
 # Following changed by server in SetConnections
-Globals.connection_dict[0] = Globals.local_connection
+Globals.connection_dict[0] = specifics.local_connection

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -388,7 +388,7 @@ class LowLevelPipeConnection(Connection):
         elif format_string == b"Q":
             result = self._getqrpath(data)
         elif format_string == b"c":
-            result = Globals.connection_dict[self._b2i(data)]
+            result = specifics.connection_dict[self._b2i(data)]
         else:
             raise ConnectionReadError(
                 "Format character '{form}' invalid in <{hdr}> "
@@ -408,13 +408,13 @@ class LowLevelPipeConnection(Connection):
     def _getrpath(self, raw_rpath_buf):
         """Return RPath object indicated by raw_rpath_buf"""
         conn_number, base, index, data = pickle.loads(raw_rpath_buf)
-        return rpath.RPath(Globals.connection_dict[conn_number], base, index, data)
+        return rpath.RPath(specifics.connection_dict[conn_number], base, index, data)
 
     def _getqrpath(self, raw_qrpath_buf):
         """Return QuotedRPath object from raw buffer"""
         conn_number, base, index, data = pickle.loads(raw_qrpath_buf)
         return map_filenames.QuotedRPath(
-            Globals.connection_dict[conn_number], base, index, data
+            specifics.connection_dict[conn_number], base, index, data
         )
 
     def _close(self):
@@ -466,7 +466,7 @@ class PipeConnection(LowLevelPipeConnection):
 
     def Server(self):
         """Start server's read eval return loop"""
-        Globals.connections.append(self)
+        specifics.connections.append(self)
         log.Log("Starting server", log.INFO)
         self._get_response(-1)
         return consts.RET_CODE_OK
@@ -618,7 +618,7 @@ class RedirectedConnection(Connection):
         super().__init__()
         self.conn_number = conn_number
         self.routing_number = routing_number
-        self.routing_conn = Globals.connection_dict[routing_number]
+        self.routing_conn = specifics.connection_dict[routing_number]
 
     def reval(self, function_string, *args):
         """Evaluation function_string on args on remote connection"""
@@ -730,7 +730,7 @@ def RedirectedRun(conn_number, func, *args):
     available).
 
     """
-    conn = Globals.connection_dict[conn_number]
+    conn = specifics.connection_dict[conn_number]
     assert (
         conn is not specifics.local_connection
     ), "A redirected run shouldn't be required locally for {fnc}.".format(
@@ -740,6 +740,6 @@ def RedirectedRun(conn_number, func, *args):
 
 
 specifics.local_connection = LocalConnection()
-Globals.connections.append(specifics.local_connection)
+specifics.connections.append(specifics.local_connection)
 # Following changed by server in SetConnections
-Globals.connection_dict[0] = specifics.local_connection
+specifics.connection_dict[0] = specifics.local_connection

--- a/src/rdiff_backup/hash.py
+++ b/src/rdiff_backup/hash.py
@@ -73,7 +73,7 @@ class Report:
 def compute_sha1(rp, compressed=0):
     """Return the hex sha1 hash of given rpath"""
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "It's inefficient to calculate hash remotely."
     digest = compute_sha1_fp(rp.open("rb", compressed))
     rp.set_sha1(digest)

--- a/src/rdiff_backup/hash.py
+++ b/src/rdiff_backup/hash.py
@@ -19,8 +19,7 @@
 """Contains a file wrapper that returns a hash on close"""
 
 import hashlib
-from rdiff_backup import Globals
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 
 class FileWrapper:

--- a/src/rdiff_backup/hash.py
+++ b/src/rdiff_backup/hash.py
@@ -20,6 +20,7 @@
 
 import hashlib
 from rdiff_backup import Globals
+from rdiffbackup.singletons import consts
 
 
 class FileWrapper:
@@ -81,8 +82,7 @@ def compute_sha1(rp, compressed=0):
 
 def compute_sha1_fp(fp, compressed=0):
     """Return hex sha1 hash of given file-like object"""
-    blocksize = Globals.blocksize
     fw = FileWrapper(fp)
-    while fw.read(blocksize):
+    while fw.read(consts.BLOCKSIZE):
         pass  # we rely on FileWrapper to calculate the checksum
     return fw.close().sha1_digest

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -27,6 +27,7 @@ import textwrap
 import typing
 import traceback
 from rdiff_backup import Globals
+from rdiffbackup.singletons import consts
 
 LOGFILE_ENCODING = "utf-8"
 
@@ -203,10 +204,10 @@ class Logger:
             else:
                 self.term_verbosity = self.validate_verbosity(term_verbosity)
         except ValueError:
-            return Globals.RET_CODE_ERR
+            return consts.RET_CODE_ERR
         else:
             self.file_verbosity = tmp_verbosity
-            return Globals.RET_CODE_OK
+            return consts.RET_CODE_OK
 
     def open_logfile(self, log_rp):
         """Inform all connections of an open logfile.

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -373,7 +373,9 @@ class ErrorLog:
     def write_if_open(cls, error_type, rp, exc):
         """Call cls._write(...) if error log open, only log otherwise"""
         if not specifics.is_backup_writer and generics.backup_writer:
-            return generics.backup_writer.log.ErrorLog.write_if_open(error_type, rp, exc)
+            return generics.backup_writer.log.ErrorLog.write_if_open(
+                error_type, rp, exc
+            )
         if cls.isopen():
             cls._write(error_type, rp, exc)
         else:

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -26,7 +26,6 @@ import sys
 import textwrap
 import typing
 import traceback
-from rdiff_backup import Globals
 from rdiffbackup.singletons import consts, generics, specifics
 
 LOGFILE_ENCODING = "utf-8"
@@ -101,7 +100,7 @@ class Logger:
 
     def log_to_term(self, message, verbosity):
         """Write message to stdout/stderr"""
-        if verbosity in {ERROR, WARNING} or Globals.server:
+        if verbosity in {ERROR, WARNING} or specifics.server:
             termfp = sys.stderr
         else:
             termfp = sys.stdout
@@ -140,7 +139,7 @@ class Logger:
             result_repr = str(result)
         # shorten the result to a max size of 720 chars with ellipsis if needed
         # result_repr = result_repr[:720] + (result_repr[720:] and '[...]')  # noqa: E265
-        if Globals.server:
+        if specifics.server:
             conn_str = "Server"
         else:
             conn_str = "Client"
@@ -291,7 +290,7 @@ class Logger:
                 .astimezone()
                 .strftime("%F %H:%M:%S.%f %z")
             )
-            if Globals.server:
+            if specifics.server:
                 role = "SERVER"
             else:
                 role = "CLIENT"

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -231,7 +231,7 @@ class Logger:
     def open_logfile_local(self, log_rp):
         """Open logfile locally - should only be run on one connection"""
         assert (
-            log_rp.conn is Globals.local_connection
+            log_rp.conn is specifics.local_connection
         ), "Action only foreseen locally and not over {conn}".format(conn=log_rp.conn)
         try:
             self.logfp = log_rp.open("ab")
@@ -258,7 +258,7 @@ class Logger:
     def close_logfile_local(self):
         """Run by logging connection - close logfile"""
         assert (
-            self.log_file_conn is Globals.local_connection
+            self.log_file_conn is specifics.local_connection
         ), "Action only foreseen locally and not over {lc}".format(
             lc=self.log_file_conn
         )

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -218,7 +218,7 @@ class Logger:
         """
         assert not self.log_file_open, "Can't open an already opened logfile"
         log_rp.conn.log.Log.open_logfile_local(log_rp)
-        for conn in Globals.connections:
+        for conn in specifics.connections:
             conn.log.Log.open_logfile_allconn(log_rp.conn)
 
     # @API(Log.open_logfile_allconn, 200)
@@ -245,7 +245,7 @@ class Logger:
     def close_logfile(self):
         """Close logfile and inform all connections"""
         if self.log_file_open:
-            for conn in Globals.connections:
+            for conn in specifics.connections:
                 conn.log.Log.close_logfile_allconn()
             self.log_file_conn.log.Log.close_logfile_local()
 

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -27,7 +27,7 @@ import textwrap
 import typing
 import traceback
 from rdiff_backup import Globals
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, generics, specifics
 
 LOGFILE_ENCODING = "utf-8"
 
@@ -363,17 +363,17 @@ class ErrorLog:
     # @API(ErrorLog.isopen, 200)
     def isopen(cls):
         """True if the error log file is currently open"""
-        if specifics.is_backup_writer or not specifics.backup_writer:
+        if specifics.is_backup_writer or not generics.backup_writer:
             return cls._log_fileobj is not None
         else:
-            return specifics.backup_writer.log.ErrorLog.isopen()
+            return generics.backup_writer.log.ErrorLog.isopen()
 
     @classmethod
     # @API(ErrorLog.write_if_open, 200)
     def write_if_open(cls, error_type, rp, exc):
         """Call cls._write(...) if error log open, only log otherwise"""
-        if not specifics.is_backup_writer and specifics.backup_writer:
-            return specifics.backup_writer.log.ErrorLog.write_if_open(error_type, rp, exc)
+        if not specifics.is_backup_writer and generics.backup_writer:
+            return generics.backup_writer.log.ErrorLog.write_if_open(error_type, rp, exc)
         if cls.isopen():
             cls._write(error_type, rp, exc)
         else:

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -363,17 +363,17 @@ class ErrorLog:
     # @API(ErrorLog.isopen, 200)
     def isopen(cls):
         """True if the error log file is currently open"""
-        if Globals.isbackup_writer or not Globals.backup_writer:
+        if specifics.is_backup_writer or not specifics.backup_writer:
             return cls._log_fileobj is not None
         else:
-            return Globals.backup_writer.log.ErrorLog.isopen()
+            return specifics.backup_writer.log.ErrorLog.isopen()
 
     @classmethod
     # @API(ErrorLog.write_if_open, 200)
     def write_if_open(cls, error_type, rp, exc):
         """Call cls._write(...) if error log open, only log otherwise"""
-        if not Globals.isbackup_writer and Globals.backup_writer:
-            return Globals.backup_writer.log.ErrorLog.write_if_open(error_type, rp, exc)
+        if not specifics.is_backup_writer and specifics.backup_writer:
+            return specifics.backup_writer.log.ErrorLog.write_if_open(error_type, rp, exc)
         if cls.isopen():
             cls._write(error_type, rp, exc)
         else:

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -403,7 +403,7 @@ class ErrorLog:
         """Add line to log file indicating error exc with file rp"""
         logstr = cls._get_log_string(error_type, rp, exc)
         Log(logstr, WARNING)
-        if Globals.null_separator:
+        if generics.null_separator:
             logstr += "\0"
         else:
             logstr = re.sub("\n", " ", logstr)

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -22,6 +22,7 @@ import errno
 import signal
 import zlib
 from rdiff_backup import librsync, C, rpath, Globals, log, connection
+from rdiffbackup.singletons import generics
 
 
 # Those are the signals we want to catch because they relate to conditions
@@ -111,8 +112,8 @@ def check_common_error(error_handler, function, args=[]):
     except (Exception, KeyboardInterrupt, SystemExit) as exc:
         if catch_error(exc):
             log.Log.exception()
-            if specifics.backup_writer is not None:
-                specifics.backup_writer.statistics.record_error()
+            if generics.backup_writer is not None:
+                generics.backup_writer.statistics.record_error()
             if error_handler:
                 return error_handler(exc, *args)
             else:

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -21,7 +21,7 @@
 import errno
 import signal
 import zlib
-from rdiff_backup import librsync, C, rpath, Globals, log, connection
+from rdiff_backup import librsync, C, rpath, log, connection
 from rdiffbackup.singletons import generics
 
 

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -111,8 +111,8 @@ def check_common_error(error_handler, function, args=[]):
     except (Exception, KeyboardInterrupt, SystemExit) as exc:
         if catch_error(exc):
             log.Log.exception()
-            if Globals.backup_writer is not None:
-                Globals.backup_writer.statistics.record_error()
+            if specifics.backup_writer is not None:
+                specifics.backup_writer.statistics.record_error()
             if error_handler:
                 return error_handler(exc, *args)
             else:

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -961,7 +961,7 @@ class RPath(RORPath):
             try:
                 self.rmdir()
             except os.error:
-                if Globals.fsync_directories:
+                if generics.fsync_directories:
                     self.fsync()
                 self.conn.shutil.rmtree(self.path)
         else:
@@ -1298,7 +1298,7 @@ class RPath(RORPath):
     def fsync_with_dir(self, fp=None):
         """fsync self and directory self is under"""
         self.fsync(fp)
-        if Globals.fsync_directories:
+        if generics.fsync_directories:
             self.get_parent_rp().fsync()
 
     def get_bytes(self, compressed=None):

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -752,7 +752,7 @@ class RPath(RORPath):
     def chmod(self, permissions, loglevel=log.WARNING):
         """Wrapper around os.chmod"""
         try:
-            self.conn.os.chmod(self.path, permissions & Globals.permission_mask)
+            self.conn.os.chmod(self.path, permissions & generics.permission_mask)
         except OSError as e:
             if e.strerror == "Inappropriate file type or format" and not self.isdir():
                 # Some systems throw this error if try to set sticky bit
@@ -765,7 +765,7 @@ class RPath(RORPath):
                     loglevel,
                 )
                 self.conn.os.chmod(
-                    self.path, permissions & 0o6777 & Globals.permission_mask
+                    self.path, permissions & 0o6777 & generics.permission_mask
                 )
             else:
                 raise

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -152,7 +152,7 @@ class RORPath:
             not self.isreg()
             or self.getnumlinks() == 1
             or not Globals.compare_inode
-            or not Globals.preserve_hardlinks
+            or not generics.preserve_hardlinks
         ):
             ignored_keys.add("inode")
             ignored_keys.add("devloc")

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1259,12 +1259,9 @@ class RPath(RORPath):
                 os.fsync(fp.fileno())
 
     # @API(RPath.fsync_local, 200)
-    def fsync_local(self, thunk=None):
-        """fsync current file, run locally
-
-        If thunk is given, run it before syncing but after gathering
-        the file's file descriptor.
-
+    def fsync_local(self):
+        """
+        fsync current file, run locally
         """
         assert (
             self.conn is specifics.local_connection
@@ -1295,8 +1292,6 @@ class RPath(RORPath):
             fd = os.open(self.path, os.O_RDWR)
             if oldperms is not None:
                 self.chmod(oldperms)
-            if thunk:
-                thunk()
             os.fsync(fd)  # Sync after we switch back permissions!
             os.close(fd)
 

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -42,7 +42,7 @@ import shutil
 import stat
 import tempfile
 import time
-from rdiff_backup import Globals, Time, log, C
+from rdiff_backup import Time, log, C
 from rdiffbackup.locations.map import owners as map_owners
 from rdiffbackup.meta import acl_posix, acl_win, ea
 from rdiffbackup.singletons import consts, generics, specifics
@@ -950,7 +950,7 @@ class RPath(RORPath):
 
     def isgroup(self):
         """Return true if process has group of rp"""
-        return "gid" in self.data and self.data["gid"] in self.conn.Globals.get(
+        return "gid" in self.data and self.data["gid"] in self.conn.specifics.get(
             "process_groups"
         )
 
@@ -1976,7 +1976,7 @@ def setdata_local(rp):
         rp.conn is specifics.local_connection
     ), "Function must be called locally not over {conn}.".format(conn=rp.conn)
     reset_perms = False
-    if Globals.process_uid != 0 and not rp.readable() and rp.isowner():
+    if specifics.process_uid != 0 and not rp.readable() and rp.isowner():
         if rp.lstat() == "sym":
             # a symlink which isn't readable is strange, hence better not backup
             # only case known is 'C:\Users\All Users' mounted over Samba

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1252,7 +1252,7 @@ class RPath(RORPath):
         This can be useful for directories.
 
         """
-        if Globals.do_fsync:
+        if generics.do_fsync:
             if not fp:
                 self.conn.rpath.RPath.fsync_local(self)
             else:

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -43,9 +43,10 @@ import stat
 import tempfile
 import time
 from rdiff_backup import Globals, Time, log, C
-from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
 from rdiffbackup.meta import acl_posix, acl_win, ea
+from rdiffbackup.singletons import consts
+from rdiffbackup.utils import usrgrp
 
 try:
     import win32api
@@ -467,7 +468,7 @@ class RORPath:
     def close_if_necessary(self):
         """If file is present, discard data and close"""
         if self.file:
-            while self.file.read(Globals.blocksize):
+            while self.file.read(consts.BLOCKSIZE):
                 pass
             self.file.close()
             self._file_already_open = False
@@ -1537,7 +1538,6 @@ class _RPathFileHook:
 
 def copyfileobj(inputfp, outputfp):
     """Copies file inputfp to outputfp in blocksize intervals"""
-    blocksize = Globals.blocksize
 
     sparse = False
     """Negative seeks are not supported by GzipFile"""
@@ -1546,7 +1546,7 @@ def copyfileobj(inputfp, outputfp):
         compressed = True
 
     while 1:
-        inbuf = inputfp.read(blocksize)
+        inbuf = inputfp.read(consts.BLOCKSIZE)
         if not inbuf:
             break
 
@@ -2082,10 +2082,9 @@ def _cmp_file_attribs(rp1, rp2):
 
 def _cmp_file_obj(fp1, fp2):
     """True if file objects fp1 and fp2 contain same data, used for testing"""
-    blocksize = Globals.blocksize
     while 1:
-        buf1 = fp1.read(blocksize)
-        buf2 = fp2.read(blocksize)
+        buf1 = fp1.read(consts.BLOCKSIZE)
+        buf2 = fp2.read(consts.BLOCKSIZE)
         if buf1 != buf2:
             return None
         elif not buf1:

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1598,10 +1598,10 @@ def copy(rpin, rpout, compress=0):
     elif rpin.issym():
         # some systems support permissions for symlinks, but
         # only by setting at creation via the umask
-        if Globals.symlink_perms:
+        if generics.symlink_perms:
             orig_umask = os.umask(0o777 & ~rpin.getperms())
         rpout.symlink(rpin.readlink())
-        if Globals.symlink_perms:
+        if generics.symlink_perms:
             os.umask(orig_umask)  # restore previous umask
     elif rpin.isdev():
         dev_type, major, minor = rpin.getdevnums()

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -151,7 +151,7 @@ class RORPath:
         if (
             not self.isreg()
             or self.getnumlinks() == 1
-            or not Globals.compare_inode
+            or not generics.compare_inode
             or not generics.preserve_hardlinks
         ):
             ignored_keys.add("inode")

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1090,7 +1090,7 @@ class RPath(RORPath):
     def get_temp_rpath(self, sibling=False):
         """Return new temp rpath in given or parent directory"""
         assert (
-            self.conn is Globals.local_connection
+            self.conn is specifics.local_connection
         ), "Function must be called locally not over {conn}.".format(conn=self.conn)
 
         # recursion if current rpath isn't a directory or if explicitly asked
@@ -1124,7 +1124,7 @@ class RPath(RORPath):
         risk apparent from the remote call.
 
         """
-        if self.conn is Globals.local_connection:
+        if self.conn is specifics.local_connection:
             if compress:
                 return gzip.GzipFile(self.path, mode)
             else:
@@ -1267,7 +1267,7 @@ class RPath(RORPath):
 
         """
         assert (
-            self.conn is Globals.local_connection
+            self.conn is specifics.local_connection
         ), "Function must be called locally not over {conn}.".format(conn=self.conn)
         try:
             fd = os.open(self.path, os.O_RDONLY)
@@ -1623,7 +1623,7 @@ def copy(rpin, rpout, compress=0):
 def copy_reg_file(rpin, rpout, compress=0):
     """Copy regular file rpin to rpout, possibly avoiding connection"""
     try:
-        if rpout.conn is rpin.conn and rpout.conn is not Globals.local_connection:
+        if rpout.conn is rpin.conn and rpout.conn is not specifics.local_connection:
             v = rpout.conn.rpath.copy_reg_file(rpin.path, rpout.path, compress)
             rpout.setdata()
             return v
@@ -1690,7 +1690,7 @@ def copy_attribs(rpin, rpout):
         "or input be special.".format(irp=rpin, orp=rpout)
     )
     assert (
-        rpout.conn is Globals.local_connection
+        rpout.conn is specifics.local_connection
     ), "Function works locally not over '{conn}'.".format(conn=rpout.conn)
     if generics.change_ownership:
         rpout.chown(*map_owners.map_rpath_owner(rpin))
@@ -1905,7 +1905,7 @@ def make_socket_local(rpath):
     (Miscellaneous strings will not be.)
     """
     assert (
-        rpath.conn is Globals.local_connection
+        rpath.conn is specifics.local_connection
     ), "Function works locally not over '{conn}'.".format(conn=rpath.conn)
     rpath.conn.os.mknod(rpath.path, stat.S_IFSOCK)
 
@@ -1914,7 +1914,7 @@ def make_socket_local(rpath):
 def gzip_open_local_read(rpath):
     """Return open GzipFile.  See security note directly above"""
     assert (
-        rpath.conn is Globals.local_connection
+        rpath.conn is specifics.local_connection
     ), "Function works locally not over '{conn}'.".format(conn=rpath.conn)
     return gzip.GzipFile(rpath.path, "rb")
 
@@ -1923,7 +1923,7 @@ def gzip_open_local_read(rpath):
 def open_local_read(rpath):
     """Return open file (provided for security reasons)"""
     assert (
-        rpath.conn is Globals.local_connection
+        rpath.conn is specifics.local_connection
     ), "Function works locally not over '{conn}'.".format(conn=rpath.conn)
     return open(rpath.path, "rb")
 
@@ -1978,7 +1978,7 @@ def setdata_local(rp):
     these features may exist or not depending on the connection.
     """
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "Function must be called locally not over {conn}.".format(conn=rp.conn)
     reset_perms = False
     if Globals.process_uid != 0 and not rp.readable() and rp.isowner():

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -740,7 +740,7 @@ class RPath(RORPath):
     def __setstate__(self, rpath_state):
         """Reproduce RPath from __getstate__ output"""
         conn_number, self.base, self.index, self.data = rpath_state
-        self.conn = Globals.connection_dict[conn_number]
+        self.conn = specifics.connection_dict[conn_number]
         self.path = self.path_join(self.base, *self.index)
 
     def setdata(self):

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -25,14 +25,9 @@ import re
 import subprocess
 import sys
 
-from rdiff_backup import (
-    Globals,
-    robust,
-    rpath,
-    Time,
-)
+from rdiff_backup import robust, rpath, Time
 from rdiffbackup.locations.map import filenames as map_filenames
-from rdiffbackup.singletons import generics, specifics
+from rdiffbackup.singletons import consts, generics, specifics
 from rdiffbackup.utils import safestr
 
 data_dir = None  # directory where statistics are written
@@ -564,10 +559,10 @@ def set_chars_to_quote():
     global data_dir
     ctq_rp = data_dir.append("chars_to_quote")
     if ctq_rp.lstat():
-        Globals.chars_to_quote = ctq_rp.get_bytes()
-    if Globals.chars_to_quote:
+        generics.set("chars_to_quote", ctq_rp.get_bytes())
+    if generics.chars_to_quote:
         regexp, unregexp = map_filenames.get_quoting_regexps(
-            Globals.chars_to_quote, Globals.quoting_char
+            generics.chars_to_quote, consts.QUOTING_CHAR
         )
 
         generics.set("chars_to_quote_regexp", regexp)

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -84,7 +84,7 @@ def parse_args():
         usage(1)
 
     data_dir = rpath.RPath(
-        Globals.local_connection,
+        specifics.local_connection,
         os.path.join(os.fsencode(args[0]), b"rdiff-backup-data"),
     )
     if not data_dir.isdir():

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -32,7 +32,7 @@ from rdiff_backup import (
     Time,
 )
 from rdiffbackup.locations.map import filenames as map_filenames
-from rdiffbackup.singletons import specifics
+from rdiffbackup.singletons import generics, specifics
 from rdiffbackup.utils import safestr
 
 data_dir = None  # directory where statistics are written
@@ -570,8 +570,8 @@ def set_chars_to_quote():
             Globals.chars_to_quote, Globals.quoting_char
         )
 
-        Globals.set_all("chars_to_quote_regexp", regexp)
-        Globals.set_all("chars_to_quote_unregexp", unregexp)
+        generics.set("chars_to_quote_regexp", regexp)
+        generics.set("chars_to_quote_unregexp", unregexp)
 
         data_dir = map_filenames.get_quotedrpath(data_dir)
 

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -32,6 +32,7 @@ from rdiff_backup import (
     Time,
 )
 from rdiffbackup.locations.map import filenames as map_filenames
+from rdiffbackup.singletons import specifics
 from rdiffbackup.utils import safestr
 
 data_dir = None  # directory where statistics are written
@@ -108,7 +109,7 @@ See the rdiff-backup-statistics man page for more information.
 
 
 def version(rc):
-    print("{cmd} {ver}".format(cmd=sys.argv[0], ver=Globals.version))
+    print("{cmd} {ver}".format(cmd=sys.argv[0], ver=specifics.version))
     sys.exit(rc)
 
 

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -25,7 +25,8 @@ documentation on what this code does can be found on the man page.
 
 import os
 import re
-from rdiff_backup import Globals, log, robust, rorpiter, rpath
+from rdiff_backup import log, robust, rorpiter, rpath
+from rdiffbackup.singletons import generics
 from rdiffbackup.utils import safestr
 
 
@@ -383,7 +384,7 @@ probably isn't what you meant""".format(
                     log.Log("Future prefix errors will not be logged", log.WARNING)
 
         something_excluded, tuple_list = None, []
-        separator = Globals.null_separator and b"\0" or b"\n"
+        separator = generics.null_separator and b"\0" or b"\n"
         for line in list_content.split(separator):
             line = line.rstrip(b"\r")  # for Windows/DOS endings
             if not line:
@@ -460,7 +461,7 @@ probably isn't what you meant""".format(
 
         """
         log.Log("Reading globbing filelist {gf}".format(gf=list_name), log.INFO)
-        separator = Globals.null_separator and b"\0" or b"\n"
+        separator = generics.null_separator and b"\0" or b"\n"
         for line in list_content.split(separator):
             line = line.rstrip(b"\r")  # for Windows/DOS endings
             if not line:

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -377,7 +377,7 @@ class FileStats:
         )
         cls._fileobj = cls._rp.open("wb", compress=generics.compression)
 
-        cls._line_sep = Globals.null_separator and b"\0" or b"\n"
+        cls._line_sep = generics.null_separator and b"\0" or b"\n"
         cls._write_docstring()
         cls._line_buffer = []
 

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -22,6 +22,7 @@ import time
 from functools import reduce
 from rdiff_backup import Globals, log, Time
 from rdiffbackup.locations import increment
+from rdiffbackup.singletons import generics
 from rdiffbackup.utils import quoting
 
 
@@ -369,12 +370,12 @@ class FileStats:
         """Open file stats object and prepare to write"""
         assert not (cls._fileobj or cls._rp), "FileStats has already been initialized."
         rpbase = data_dir.append(b"file_statistics")
-        suffix = Globals.compression and "data.gz" or "data"
+        suffix = generics.compression and "data.gz" or "data"
         cls._rp = increment.get_increment(rpbase, suffix, Time.getcurtime())
         assert not cls._rp.lstat(), "Path '{rp}' shouldn't be existing.".format(
             rp=cls._rp
         )
-        cls._fileobj = cls._rp.open("wb", compress=Globals.compression)
+        cls._fileobj = cls._rp.open("wb", compress=generics.compression)
 
         cls._line_sep = Globals.null_separator and b"\0" or b"\n"
         cls._write_docstring()

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -20,7 +20,7 @@
 
 import time
 from functools import reduce
-from rdiff_backup import Globals, log, Time
+from rdiff_backup import log, Time
 from rdiffbackup.locations import increment
 from rdiffbackup.singletons import generics
 from rdiffbackup.utils import quoting

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -30,7 +30,7 @@ import sys
 import tempfile
 import yaml
 from rdiff_backup import Globals, log, Security, SetConnections, Time
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 from rdiffbackup.utils.argopts import BooleanOptionalAction, SelectAction
 
 # The default regexp for not compressing those files
@@ -701,8 +701,8 @@ class BaseAction:
         """
         return {
             "exec": {
-                "version": Globals.version,
-                "api_version": Globals.api_version,
+                "version": specifics.version,
+                "api_version": specifics.api_version,
                 "argv": sys.argv,
                 "parsed": parsed,
             },

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -635,7 +635,7 @@ class BaseAction:
             tempfile.tempdir = self.values["tempdir"]
         # Set default change ownership flag, umask, relay regexps
         os.umask(0o77)
-        for conn in Globals.connections:
+        for conn in specifics.connections:
             conn.robust.install_signal_handlers()
 
         return consts.RET_CODE_OK

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -30,6 +30,7 @@ import sys
 import tempfile
 import yaml
 from rdiff_backup import Globals, log, Security, SetConnections, Time
+from rdiffbackup.singletons import consts
 from rdiffbackup.utils.argopts import BooleanOptionalAction, SelectAction
 
 # The default regexp for not compressing those files
@@ -391,7 +392,7 @@ class BaseAction:
     parent_parsers = []
 
     # connection status
-    conn_status = Globals.RET_CODE_OK
+    conn_status = consts.RET_CODE_OK
 
     @classmethod
     def get_name(cls):
@@ -547,7 +548,7 @@ class BaseAction:
                 "'{ac}'.".format(av=self.values["action"], ac=self.name),
                 log.ERROR,
             )
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
         if self.values["tempdir"] and not os.path.isdir(self.values["tempdir"]):
             log.Log(
                 "Temporary directory '{td}' doesn't exist.".format(
@@ -555,7 +556,7 @@ class BaseAction:
                 ),
                 log.ERROR,
             )
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
         if (
             self.security is None
             and "locations" in self.values
@@ -566,7 +567,7 @@ class BaseAction:
                 "locations".format(ac=self.name),
                 log.ERROR,
             )
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
         return ret_code
 
     def connect(self):
@@ -600,7 +601,7 @@ class BaseAction:
                         "Location '{lo}' couldn't be connected.".format(lo=loc),
                         log.ERROR,
                     )
-                    self.conn_status = Globals.RET_CODE_ERR
+                    self.conn_status = consts.RET_CODE_ERR
         else:
             Security.initialize(self.get_security_class(), [])
             self.connected_locations = []
@@ -637,7 +638,7 @@ class BaseAction:
         for conn in Globals.connections:
             conn.robust.install_signal_handlers()
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def run(self):
         """
@@ -645,13 +646,13 @@ class BaseAction:
 
         Return 0 if everything looked good, else an error code.
         """
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def is_connection_ok(self):
         """
         Return True if connection is OK, False else
         """
-        return not self.conn_status & Globals.RET_CODE_ERR
+        return not self.conn_status & consts.RET_CODE_ERR
 
     def _operate_regress(self, try_regress=True, noticeable=False, force=False):
         """
@@ -666,12 +667,12 @@ class BaseAction:
 
         if self.repo.needs_regress():
             if not try_regress:
-                return Globals.RET_CODE_ERR
+                return consts.RET_CODE_ERR
             log.Log(
                 "Previous backup seems to have failed, regressing " "destination now",
                 log.WARNING,
             )
-            return self.repo.regress() | Globals.RET_CODE_WARN
+            return self.repo.regress() | consts.RET_CODE_WARN
         elif force:
             if self.repo.force_regress():
                 log.Log(
@@ -686,10 +687,10 @@ class BaseAction:
                     "regressed even if forced",
                     log.WARNING,
                 )
-                return Globals.RET_CODE_WARN
+                return consts.RET_CODE_WARN
         else:
             log.Log("Given repository doesn't need to be regressed", regress_verbosity)
-            return Globals.RET_CODE_OK
+            return consts.RET_CODE_OK
 
     @classmethod
     def get_runtime_info(cls, parsed=None):

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -29,7 +29,7 @@ import platform
 import sys
 import tempfile
 import yaml
-from rdiff_backup import Globals, log, Security, SetConnections, Time
+from rdiff_backup import log, Security, SetConnections, Time
 from rdiffbackup.singletons import consts, specifics
 from rdiffbackup.utils.argopts import BooleanOptionalAction, SelectAction
 

--- a/src/rdiffbackup/actions/backup.py
+++ b/src/rdiffbackup/actions/backup.py
@@ -23,9 +23,10 @@ A built-in rdiff-backup action plug-in to backup a source to a target directory.
 
 import time
 
-from rdiff_backup import Globals, log, Time
+from rdiff_backup import log, Time
 from rdiffbackup import actions
 from rdiffbackup.locations import directory, repository
+from rdiffbackup.singletons import consts
 
 
 class BackupAction(actions.BaseAction):
@@ -84,15 +85,15 @@ class BackupAction(actions.BaseAction):
         # in setup we return as soon as we detect an issue to avoid changing
         # too much
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.dir.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.repo.setup(self.dir)
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         self.dir.set_select()
@@ -105,12 +106,12 @@ class BackupAction(actions.BaseAction):
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         # do regress the target directory if necessary
         ret_code |= self._operate_regress()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             # regress was necessary and failed
             return ret_code
         previous_time = self.repo.get_mirror_time(refresh=True)
@@ -120,7 +121,7 @@ class BackupAction(actions.BaseAction):
                 "the last backup is not in the past. Aborting.",
                 log.ERROR,
             )
-            return ret_code | Globals.RET_CODE_ERR
+            return ret_code | consts.RET_CODE_ERR
 
         ret_code |= self._operate_backup(previous_time)
 
@@ -151,7 +152,7 @@ class BackupAction(actions.BaseAction):
 
         self.repo.close_statistics(time.time())
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def _warn_if_infinite_recursion(self, rpin, rpout):
         """
@@ -159,11 +160,11 @@ class BackupAction(actions.BaseAction):
         """
         # Just a few heuristics, we don't have to get every case
         if rpout.conn is not rpin.conn:
-            return Globals.RET_CODE_OK
+            return consts.RET_CODE_OK
         if len(rpout.path) <= len(rpin.path) + 1:
-            return Globals.RET_CODE_OK
+            return consts.RET_CODE_OK
         if rpout.path[: len(rpin.path) + 1] != rpin.path + b"/":
-            return Globals.RET_CODE_OK
+            return consts.RET_CODE_OK
 
         log.Log(
             "The target directory '{td}' may be contained in the "
@@ -173,7 +174,7 @@ class BackupAction(actions.BaseAction):
             "(which you might already have done).".format(td=rpout, sd=rpin),
             log.WARNING,
         )
-        return Globals.RET_CODE_WARN
+        return consts.RET_CODE_WARN
 
 
 def get_plugin_class():

--- a/src/rdiffbackup/actions/calculate.py
+++ b/src/rdiffbackup/actions/calculate.py
@@ -22,8 +22,9 @@ A built-in rdiff-backup action plug-in to calculate average across multiple
 statistics files.
 """
 
-from rdiff_backup import Globals, statistics
+from rdiff_backup import statistics
 from rdiffbackup import actions
+from rdiffbackup.singletons import consts
 
 
 class CalculateAction(actions.BaseAction):
@@ -57,7 +58,7 @@ class CalculateAction(actions.BaseAction):
         to calculation method.
         """
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         statobjs = [

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -24,7 +24,7 @@ Comparaison can be done using metadata, file content or hashes.
 """
 
 import yaml
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup import actions
 from rdiffbackup.locations import directory, repository
 from rdiffbackup.singletons import consts
@@ -166,7 +166,7 @@ class CompareAction(actions.BaseAction):
 
         Output a list in YAML format if parsable is True.
         """
-        assert not Globals.server, "This function shouldn't run as server."
+        assert not specifics.server, "This function shouldn't run as server."
         changed_files_found = 0
         reason_verify_list = []
         for report in report_iter:

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -27,6 +27,7 @@ import yaml
 from rdiff_backup import Globals, log
 from rdiffbackup import actions
 from rdiffbackup.locations import directory, repository
+from rdiffbackup.singletons import consts
 
 
 class CompareAction(actions.BaseAction):
@@ -92,28 +93,28 @@ class CompareAction(actions.BaseAction):
         # in setup we return as soon as we detect an issue to avoid changing
         # too much
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.dir.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.repo.setup(self.dir)
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         self.dir.set_select()
 
         self.action_time = self.repo.get_parsed_time(self.values["at"])
         if self.action_time is None:
-            return ret_code & Globals.RET_CODE_ERR
+            return ret_code & consts.RET_CODE_ERR
 
         return ret_code
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         compare_funcs = {
@@ -185,7 +186,7 @@ class CompareAction(actions.BaseAction):
             )
         if not changed_files_found:
             log.Log("No changes found. Directory matches backup data", log.NOTE)
-            return Globals.RET_CODE_OK
+            return consts.RET_CODE_OK
         else:
             log.Log(
                 "Directory has {fd} file differences to backup".format(
@@ -193,7 +194,7 @@ class CompareAction(actions.BaseAction):
                 ),
                 log.WARNING,
             )
-            return Globals.RET_CODE_FILE_WARN
+            return consts.RET_CODE_FILE_WARN
 
 
 def get_plugin_class():

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -27,7 +27,7 @@ import yaml
 from rdiff_backup import log
 from rdiffbackup import actions
 from rdiffbackup.locations import directory, repository
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 
 class CompareAction(actions.BaseAction):

--- a/src/rdiffbackup/actions/complete.py
+++ b/src/rdiffbackup/actions/complete.py
@@ -24,7 +24,7 @@ so that they can be used for e.g. bash completion
 
 import argparse
 
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup import actions, actions_mgr, arguments
 from rdiffbackup.singletons import consts, specifics
 from rdiffbackup.utils.argopts import BooleanOptionalAction

--- a/src/rdiffbackup/actions/complete.py
+++ b/src/rdiffbackup/actions/complete.py
@@ -26,7 +26,7 @@ import argparse
 
 from rdiff_backup import Globals, log
 from rdiffbackup import actions, actions_mgr, arguments
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 from rdiffbackup.utils.argopts import BooleanOptionalAction
 
 
@@ -99,7 +99,7 @@ class CompleteAction(actions.BaseAction):
         # get a dictionary of discovered action plugins
         discovered_actions = actions_mgr.get_actions_dict()
         generic_parsers = actions_mgr.get_generic_parsers()
-        version_string = "rdiff-backup {ver}".format(ver=Globals.version)
+        version_string = "rdiff-backup {ver}".format(ver=specifics.version)
 
         parser = arguments.get_parser(
             version_string, generic_parsers, discovered_actions

--- a/src/rdiffbackup/actions/complete.py
+++ b/src/rdiffbackup/actions/complete.py
@@ -24,9 +24,10 @@ so that they can be used for e.g. bash completion
 
 import argparse
 
-from rdiffbackup import actions, actions_mgr, arguments
-from rdiffbackup.utils.argopts import BooleanOptionalAction
 from rdiff_backup import Globals, log
+from rdiffbackup import actions, actions_mgr, arguments
+from rdiffbackup.singletons import consts
+from rdiffbackup.utils.argopts import BooleanOptionalAction
 
 
 class CompleteAction(actions.BaseAction):
@@ -70,7 +71,7 @@ class CompleteAction(actions.BaseAction):
                 "the command rdiff-backup itself, to complete",
                 log.ERROR,
             )
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
 
         try:
             self.values["words"][self.values["cword"]]
@@ -82,17 +83,17 @@ class CompleteAction(actions.BaseAction):
                 ),
                 log.ERROR,
             )
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
 
         return ret_code
 
     def setup(self):
         # there is nothing to setup for the complete action
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         # get a dictionary of discovered action plugins

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -25,7 +25,7 @@ for documenting an issue.
 import yaml
 
 from rdiffbackup import actions
-from rdiff_backup import Globals
+from rdiffbackup.singletons import consts
 
 
 class InfoAction(actions.BaseAction):
@@ -40,11 +40,11 @@ class InfoAction(actions.BaseAction):
 
     def setup(self):
         # there is nothing to setup for the info action
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         runtime_info = self.get_runtime_info(parsed=self.values)

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -26,9 +26,10 @@ builtin 'list' class.
 """
 
 import yaml
-from rdiff_backup import Globals, statistics, Time
+from rdiff_backup import statistics, Time
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
+from rdiffbackup.singletons import consts
 from rdiffbackup.utils.argopts import BooleanOptionalAction
 
 
@@ -104,11 +105,11 @@ class ListAction(actions.BaseAction):
         # in setup we return as soon as we detect an issue to avoid changing
         # too much
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.repo.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         if self.values["entity"] == "files":
@@ -116,13 +117,13 @@ class ListAction(actions.BaseAction):
                 self.values["changed_since"] or self.values["at"]
             )
             if self.action_time is None:
-                return ret_code | Globals.RET_CODE_ERR
+                return ret_code | consts.RET_CODE_ERR
 
         return ret_code
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         if self.values["entity"] == "increments":
@@ -167,7 +168,7 @@ class ListAction(actions.BaseAction):
                     stat_obj.get_byte_summary_string(triples[-1]["total_size"]),
                 )
             )
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def _list_increments(self):
         """
@@ -187,21 +188,21 @@ class ListAction(actions.BaseAction):
             print(
                 "Current mirror: {ti}".format(ti=Time.timetopretty(incs[-1]["time"]))
             )  # time of the mirror
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def _list_files_changed_since(self):
         """List all the files under rp that have changed since restoretime"""
         rorp_iter = self.repo.list_files_changed_since(self.action_time)
         for rorp in rorp_iter:
             print(str(rorp))  # this is a hack to transfer information
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def _list_files_at_time(self):
         """List files in archive under rp that are present at restoretime"""
         rorp_iter = self.repo.list_files_at_time(self.action_time)
         for rorp in rorp_iter:
             print(str(rorp))  # this is a hack to transfer information
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
 
 def get_plugin_class():

--- a/src/rdiffbackup/actions/regress.py
+++ b/src/rdiffbackup/actions/regress.py
@@ -22,9 +22,9 @@ A built-in rdiff-backup action plug-in to regress a failed back-up from a
 back-up repository.
 """
 
-from rdiff_backup import Globals
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
+from rdiffbackup.singletons import consts
 
 
 class RegressAction(actions.BaseAction):
@@ -78,11 +78,11 @@ class RegressAction(actions.BaseAction):
         # in setup we return as soon as we detect an issue to avoid changing
         # too much
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.repo.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         return ret_code
@@ -92,7 +92,7 @@ class RegressAction(actions.BaseAction):
         Check the given repository and regress it if necessary
         """
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code |= self._operate_regress(noticeable=True, force=self.values["force"])

--- a/src/rdiffbackup/actions/remove.py
+++ b/src/rdiffbackup/actions/remove.py
@@ -22,9 +22,10 @@ A built-in rdiff-backup action plug-in to remove increments from a back-up
 repository.
 """
 
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
+from rdiffbackup.singletons import consts
 from rdiffbackup.utils.argopts import BooleanOptionalAction
 
 
@@ -91,7 +92,7 @@ class RemoveAction(actions.BaseAction):
                 ),
                 log.ERROR,
             )
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
 
         return ret_code
 
@@ -99,11 +100,11 @@ class RemoveAction(actions.BaseAction):
         # in setup we return as soon as we detect an issue to avoid changing
         # too much
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.repo.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         return ret_code
@@ -113,7 +114,7 @@ class RemoveAction(actions.BaseAction):
         Check the given repository and remove old increments
         """
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code |= self.repo.remove_increments_older_than()

--- a/src/rdiffbackup/actions/restore.py
+++ b/src/rdiffbackup/actions/restore.py
@@ -22,9 +22,10 @@ A built-in rdiff-backup action plug-in to restore a certain state of a back-up
 repository to a directory.
 """
 
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup import actions
 from rdiffbackup.locations import directory, repository
+from rdiffbackup.singletons import consts
 
 
 class RestoreAction(actions.BaseAction):
@@ -95,7 +96,7 @@ class RestoreAction(actions.BaseAction):
                     "restore at the same time.",
                     log.ERROR,
                 )
-                ret_code |= Globals.RET_CODE_ERR
+                ret_code |= consts.RET_CODE_ERR
             elif not self.values["increment"]:
                 self.values["increment"] = True
         elif self.repo.ref_type in ("base", "subpath"):
@@ -105,7 +106,7 @@ class RestoreAction(actions.BaseAction):
                     "give an increment file",
                     log.ERROR,
                 )
-                ret_code |= Globals.RET_CODE_ERR
+                ret_code |= consts.RET_CODE_ERR
             elif not self.values["at"]:
                 self.values["at"] = "now"
 
@@ -141,7 +142,7 @@ class RestoreAction(actions.BaseAction):
                     "could lead to data loss",
                     log.ERROR,
                 )
-                ret_code |= Globals.RET_CODE_ERR
+                ret_code |= consts.RET_CODE_ERR
 
         return ret_code
 
@@ -149,15 +150,15 @@ class RestoreAction(actions.BaseAction):
         # in setup we return as soon as we detect an issue to avoid changing
         # too much
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code |= self.repo.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code |= self.dir.setup(self.repo)
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         # TODO validate how much of the following lines and methods
@@ -166,7 +167,7 @@ class RestoreAction(actions.BaseAction):
         if self.values["at"]:
             self.action_time = self.repo.get_parsed_time(self.values["at"])
             if self.action_time is None:
-                return ret_code | Globals.RET_CODE_ERR
+                return ret_code | consts.RET_CODE_ERR
         elif self.values["increment"]:
             self.action_time = self.repo.orig_path.getinctime()
         else:  # this should have been catched in the check method
@@ -175,7 +176,7 @@ class RestoreAction(actions.BaseAction):
                 "an increment have been identified so far",
                 log.ERROR,
             )
-            return ret_code | Globals.RET_CODE_ERR
+            return ret_code | consts.RET_CODE_ERR
         # We must set both sides because restore filtering is different from
         # select filtering.  For instance, if a file is excluded it should
         # not be deleted from the target directory.
@@ -186,13 +187,13 @@ class RestoreAction(actions.BaseAction):
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         # This is more a check than a part of run, but because backup does
         # the regress in the run section, we also do the check here...
         ret_code |= self._operate_regress(try_regress=False)
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             # source could be read-only, so we don't try to regress it
             log.Log(
                 "Previous backup to {rp} seems to have failed. "
@@ -208,9 +209,9 @@ class RestoreAction(actions.BaseAction):
                 "Could not complete restore due to exception '{ex}'".format(ex=exc),
                 log.ERROR,
             )
-            return ret_code | Globals.RET_CODE_ERR
+            return ret_code | consts.RET_CODE_ERR
         else:
-            if ret_code & Globals.RET_CODE_ERR:
+            if ret_code & consts.RET_CODE_ERR:
                 log.Log("Restore somehow failed", log.ERROR)
             else:
                 log.Log("Restore successfully finished", log.INFO)
@@ -232,7 +233,7 @@ class RestoreAction(actions.BaseAction):
         self.dir.apply(src_diff_iter)
         self.repo.finish_loop()
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
 
 def get_plugin_class():

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -26,7 +26,7 @@ import sys
 
 from rdiff_backup import connection, log, Security
 from rdiffbackup import actions
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 
 class ServerAction(actions.BaseAction):

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -24,7 +24,7 @@ A built-in rdiff-backup action plug-in to start a remote server process.
 import os
 import sys
 
-from rdiff_backup import connection, Globals, log, Security
+from rdiff_backup import connection, log, Security
 from rdiffbackup import actions
 from rdiffbackup.singletons import consts
 
@@ -50,7 +50,7 @@ class ServerAction(actions.BaseAction):
 
     def __init__(self, values):
         super().__init__(values)
-        Globals.server = True  # FIXME make local?
+        specifics.server = True
         if self.values.get("debug"):
             self._set_breakpoint()
 

--- a/src/rdiffbackup/actions/server.py
+++ b/src/rdiffbackup/actions/server.py
@@ -24,8 +24,9 @@ A built-in rdiff-backup action plug-in to start a remote server process.
 import os
 import sys
 
-from rdiffbackup import actions
 from rdiff_backup import connection, Globals, log, Security
+from rdiffbackup import actions
+from rdiffbackup.singletons import consts
 
 
 class ServerAction(actions.BaseAction):
@@ -66,7 +67,7 @@ class ServerAction(actions.BaseAction):
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code |= connection.PipeConnection(

--- a/src/rdiffbackup/actions/test.py
+++ b/src/rdiffbackup/actions/test.py
@@ -24,8 +24,9 @@ This plug-in tests that all remote locations are properly reachable and
 usable for a back-up.
 """
 
+from rdiff_backup import log, SetConnections
 from rdiffbackup import actions
-from rdiff_backup import Globals, log, SetConnections
+from rdiffbackup.singletons import consts
 
 
 class TestAction(actions.BaseAction):
@@ -54,14 +55,14 @@ class TestAction(actions.BaseAction):
             (file_host, file_path, err) = SetConnections.parse_location(location)
             if err:
                 log.Log(err, log.ERROR)
-                ret_code |= Globals.RET_CODE_ERR
+                ret_code |= consts.RET_CODE_ERR
             elif not file_host:
                 log.Log(
                     "Only remote locations can be tested but location "
                     "'{lo}' isn't remote".format(lo=location),
                     log.ERROR,
                 )
-                ret_code |= Globals.RET_CODE_ERR
+                ret_code |= consts.RET_CODE_ERR
 
         return ret_code
 
@@ -72,11 +73,11 @@ class TestAction(actions.BaseAction):
         # even if some connections are bad, we want to validate the remaining
         # ones later on. The 'None' filter keeps only trueish values.
         self.connected_locations = list(filter(None, self.connected_locations))
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             # at least one connection has failed
             if self.connected_locations:
                 # at least one location is apparently valid, so no error
-                return Globals.RET_CODE_WARN
+                return consts.RET_CODE_WARN
             else:
                 return ret_code
         else:
@@ -84,7 +85,7 @@ class TestAction(actions.BaseAction):
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code |= SetConnections.test_connections(self.connected_locations)

--- a/src/rdiffbackup/actions/verify.py
+++ b/src/rdiffbackup/actions/verify.py
@@ -24,9 +24,9 @@ This plug-in verifies that files in a repository at a given time
 have the correct hash.
 """
 
-from rdiff_backup import Globals
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
+from rdiffbackup.singletons import consts
 
 
 class VerifyAction(actions.BaseAction):
@@ -82,22 +82,22 @@ class VerifyAction(actions.BaseAction):
         # in setup we return as soon as we detect an issue to avoid changing
         # too much
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code = self.repo.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         self.action_time = self.repo.get_parsed_time(self.values["at"])
         if self.action_time is None:
-            return Globals.RET_CODE_ERR
+            return consts.RET_CODE_ERR
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def run(self):
         ret_code = super().run()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         ret_code |= self.repo.verify(self.action_time)

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -407,7 +407,7 @@ class _DirPatchITRB(rorpiter.ITRBranch):
     def __init__(self, basis_root_rp):
         """Set basis_root_rp, the base of the tree to be incremented"""
         assert (
-            basis_root_rp.conn is Globals.local_connection
+            basis_root_rp.conn is specifics.local_connection
         ), "Function shall be called only locally."
         self.basis_root_rp = basis_root_rp
         self.dir_replacement, self.dir_update = None, None

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -27,7 +27,6 @@ be instantiated.
 import os
 
 from rdiff_backup import (
-    Globals,
     hash,
     iterfile,
     log,
@@ -147,7 +146,7 @@ class ReadDirShadow(location.LocationShadow):
             elif src_rp.isreg():
                 reset_perms = False
                 if (
-                    Globals.process_uid != 0
+                    specifics.process_uid != 0
                     and not src_rp.readable()
                     and src_rp.isowner()
                 ):

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -39,7 +39,7 @@ from rdiff_backup import (
 )
 from rdiffbackup.locations import location
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 # ### COPIED FROM BACKUP ####
 

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -39,6 +39,7 @@ from rdiff_backup import (
 )
 from rdiffbackup.locations import location
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
+from rdiffbackup.singletons import consts
 
 # ### COPIED FROM BACKUP ####
 
@@ -87,7 +88,7 @@ class ReadDirShadow(location.LocationShadow):
         sel = selection.Select(base_rp)
         sel.parse_selection_args(select_opts)
         sel_iter = sel.get_select_iter()
-        cache_size = Globals.pipeline_max_length * 3  # to and from+leeway
+        cache_size = consts.PIPELINE_MAX_LENGTH * 3  # to and from+leeway
         cls._select = rorpiter.CacheIndexable(sel_iter, cache_size)
         # FIXME do we really need the cache? It can be removed if we remove
         # cls._select.get
@@ -322,14 +323,14 @@ class WriteDirShadow(location.LocationShadow):
                     "might be force overwritten by restore".format(tp=cls._base_dir),
                     log.WARNING,
                 )
-                ret_code |= Globals.RET_CODE_WARN
+                ret_code |= consts.RET_CODE_WARN
             else:
                 log.Log(
                     "Target path {tp} exists and isn't empty, "
                     "call with '--force' to overwrite".format(tp=cls._base_dir),
                     log.ERROR,
                 )
-                ret_code |= Globals.RET_CODE_ERR
+                ret_code |= consts.RET_CODE_ERR
 
         return ret_code
 
@@ -337,7 +338,7 @@ class WriteDirShadow(location.LocationShadow):
     @classmethod
     def setup(cls):
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
         ret_code |= cls._init_owners_mapping()
         return ret_code

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -579,7 +579,7 @@ class RepoShadow(location.LocationShadow):
                 and dest_rorp
                 and src_rorp == dest_rorp
                 and (
-                    not Globals.preserve_hardlinks
+                    not generics.preserve_hardlinks
                     or map_hardlinks.rorp_eq(src_rorp, dest_rorp)
                 )
             ):
@@ -593,7 +593,7 @@ class RepoShadow(location.LocationShadow):
     def _get_one_sig(cls, baserp, index, src_rorp, dest_rorp):
         """Return a signature given source and destination rorps"""
         if (
-            Globals.preserve_hardlinks
+            generics.preserve_hardlinks
             and src_rorp
             and map_hardlinks.is_linked(src_rorp)
         ):
@@ -950,21 +950,21 @@ class RepoShadow(location.LocationShadow):
     def _get_diffs_from_collated(cls, collated):
         """Get diff iterator from collated"""
         for mir_rorp, target_rorp in collated:
-            if Globals.preserve_hardlinks and mir_rorp:
+            if generics.preserve_hardlinks and mir_rorp:
                 map_hardlinks.add_rorp(mir_rorp, target_rorp)
             if (
                 not target_rorp
                 or not mir_rorp
                 or not mir_rorp == target_rorp
                 or (
-                    Globals.preserve_hardlinks
+                    generics.preserve_hardlinks
                     and not map_hardlinks.rorp_eq(mir_rorp, target_rorp)
                 )
             ):
                 diff = cls._get_diff(mir_rorp, target_rorp)
             else:
                 diff = None
-            if Globals.preserve_hardlinks and mir_rorp:
+            if generics.preserve_hardlinks and mir_rorp:
                 map_hardlinks.del_rorp(mir_rorp)
             if diff:
                 yield diff
@@ -974,7 +974,7 @@ class RepoShadow(location.LocationShadow):
         """Get a diff for mir_rorp at time"""
         if not mir_rorp:
             mir_rorp = rpath.RORPath(target_rorp.index)
-        elif Globals.preserve_hardlinks and map_hardlinks.is_linked(mir_rorp):
+        elif generics.preserve_hardlinks and map_hardlinks.is_linked(mir_rorp):
             mir_rorp.flaglinked(map_hardlinks.get_link_index(mir_rorp))
         elif mir_rorp.isreg():
             expanded_index = cls.mirror_base.index + mir_rorp.index
@@ -2109,7 +2109,7 @@ class _CacheCollatedPostProcess:
         errors at this point, so don't do anything which assumes they
         will be backed up correctly.
         """
-        if Globals.preserve_hardlinks:
+        if generics.preserve_hardlinks:
             if source_rorp:
                 map_hardlinks.add_rorp(source_rorp, dest_rorp)
             else:
@@ -2206,7 +2206,7 @@ class _CacheCollatedPostProcess:
         be true if the files have been successfully updated (this is
         always false for un-changed files).
         """
-        if Globals.preserve_hardlinks and source_rorp:
+        if generics.preserve_hardlinks and source_rorp:
             map_hardlinks.del_rorp(source_rorp)
 
         if not changed or success:

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -51,7 +51,7 @@ from rdiffbackup.locations import fs_abilities, increment, location
 from rdiffbackup.locations.map import filenames as map_filenames
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
 from rdiffbackup.locations.map import longnames as map_longnames
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, generics
 from rdiffbackup.utils import locking, simpleps
 
 # ### COPIED FROM BACKUP ####
@@ -2361,7 +2361,7 @@ class _RepoPatchITRB(rorpiter.ITRBranch):
                 return result
         if new.lstat():
             if diff_rorp.isflaglinked():
-                if Globals.eas_write:
+                if generics.eas_write:
                     # `isflaglinked() == True` implies that we are processing
                     # the 2nd (or later) file in a group of files linked to an
                     # inode.  As such, we don't need to perform the usual

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -51,7 +51,7 @@ from rdiffbackup.locations import fs_abilities, increment, location
 from rdiffbackup.locations.map import filenames as map_filenames
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
 from rdiffbackup.locations.map import longnames as map_longnames
-from rdiffbackup.singletons import consts, generics
+from rdiffbackup.singletons import consts, generics, specifics
 from rdiffbackup.utils import locking, simpleps
 
 # ### COPIED FROM BACKUP ####

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -2330,7 +2330,10 @@ class _RepoPatchITRB(rorpiter.ITRBranch):
             ), "Base directory '{rp}' isn't a directory.".format(rp=self.base_rp)
             rpath.copy_attribs(self.dir_update, self.base_rp)
 
-            if specifics.process_uid != 0 and self.dir_update.getperms() % 0o1000 < 0o700:
+            if (
+                specifics.process_uid != 0
+                and self.dir_update.getperms() % 0o1000 < 0o700
+            ):
                 # Directory was unreadable at start -- keep it readable
                 # until the end of the backup process.
                 self.base_rp.chmod(0o700 | self.dir_update.getperms())

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -996,7 +996,7 @@ class RepoShadow(location.LocationShadow):
         increments, and this is done automatically for rorp iterators.
         Encode the lines in the first element of the rorp's index.
         """
-        assert cls._base_dir.conn is Globals.local_connection, "Run locally only"
+        assert cls._base_dir.conn is specifics.local_connection, "Run locally only"
         cls.init_loop(restore_to_time)
 
         old_iter = cls._get_mirror_rorp_iter(cls._restore_time, True)
@@ -1024,7 +1024,7 @@ class RepoShadow(location.LocationShadow):
         Output is a RORP Iterator with info in index.
         See list_files_changed_since for details.
         """
-        assert cls._base_dir.conn is Globals.local_connection, "Run locally only"
+        assert cls._base_dir.conn is specifics.local_connection, "Run locally only"
         cls.init_loop(reftime)
         old_iter = cls._get_mirror_rorp_iter()
         for rorp in old_iter:
@@ -1144,7 +1144,7 @@ class RepoShadow(location.LocationShadow):
         Remove increments older than the given time
         """
         assert (
-            cls._data_dir.conn is Globals.local_connection
+            cls._data_dir.conn is specifics.local_connection
         ), "Function should be called only locally " "and not over '{co}'.".format(
             co=cls._data_dir.conn
         )
@@ -1305,7 +1305,7 @@ class RepoShadow(location.LocationShadow):
         Compute SHA1 sums of repository files and check against metadata
         """
         assert (
-            cls._ref_path.conn is Globals.local_connection
+            cls._ref_path.conn is specifics.local_connection
         ), "Only verify mirror locally, not remotely over '{conn}'.".format(
             conn=cls._ref_path.conn
         )
@@ -1477,7 +1477,7 @@ information in it.
             cls._base_dir.isdir() and cls._incs_dir.isdir()
         ), "Mirror and increments paths must be directories"
         assert (
-            cls._base_dir.conn is cls._incs_dir.conn is Globals.local_connection
+            cls._base_dir.conn is cls._incs_dir.conn is specifics.local_connection
         ), "Regress must happen locally."
         meta_manager, former_current_mirror_rp = cls._set_regress_time()
         cls._set_restore_times()
@@ -1583,7 +1583,7 @@ information in it.
 
         for curmir_rp in curmir_incs:
             assert (
-                curmir_rp.conn is Globals.local_connection
+                curmir_rp.conn is specifics.local_connection
             ), "Function must be called locally not over '{conn}'.".format(
                 conn=curmir_rp.conn
             )
@@ -2262,10 +2262,10 @@ class _RepoPatchITRB(rorpiter.ITRBranch):
     def __init__(self, basis_root_rp, CCPP):
         """Set basis_root_rp, the base of the tree to be incremented"""
         self.basis_root_rp = basis_root_rp
-        assert basis_root_rp.conn is Globals.local_connection, (
+        assert basis_root_rp.conn is specifics.local_connection, (
             "Basis root path connection {conn} isn't "
             "local connection {lconn}.".format(
-                conn=basis_root_rp.conn, lconn=Globals.local_connection
+                conn=basis_root_rp.conn, lconn=specifics.local_connection
             )
         )
         self.statfileobj = (

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -3175,5 +3175,5 @@ class _RepoRegressITRB(rorpiter.ITRBranch):
                 rf.mirror_rp.delete()
             rf.mirror_rp.write_from_fileobj(rf.get_restore_fp())
             rpath.copy_attribs(rf.metadata_rorp, rf.mirror_rp)
-        if Globals.fsync_directories:
+        if generics.fsync_directories:
             rf.mirror_rp.get_parent_rp().fsync()  # force move before inc delete

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -51,6 +51,7 @@ from rdiffbackup.locations import fs_abilities, increment, location
 from rdiffbackup.locations.map import filenames as map_filenames
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
 from rdiffbackup.locations.map import longnames as map_longnames
+from rdiffbackup.singletons import consts
 from rdiffbackup.utils import locking, simpleps
 
 # ### COPIED FROM BACKUP ####
@@ -154,13 +155,13 @@ class RepoShadow(location.LocationShadow):
     def setup(cls):
         if cls._must_be_writable:
             if not cls._create():
-                return Globals.RET_CODE_ERR
+                return consts.RET_CODE_ERR
         if cls._check_time and Globals.current_time <= cls.get_mirror_time():
             log.Log("The last backup is not in the past. Aborting.", log.ERROR)
-            return Globals.RET_CODE_ERR
+            return consts.RET_CODE_ERR
         Security.reset_restrict_path(cls._base_dir)
         lock_result = cls._lock()
-        ret_code = Globals.RET_CODE_OK
+        ret_code = consts.RET_CODE_OK
         if lock_result is False:
             if cls._values["force"]:
                 log.Log(
@@ -177,7 +178,7 @@ class RepoShadow(location.LocationShadow):
                     "or use the --force option".format(lf=cls._lockfile),
                     log.ERROR,
                 )
-                return Globals.RET_CODE_ERR
+                return consts.RET_CODE_ERR
         elif lock_result is None:
             log.Log(
                 "Repository couldn't be locked by file {lf}, probably "
@@ -186,13 +187,13 @@ class RepoShadow(location.LocationShadow):
                 log.NOTE,
             )
         ret_code |= cls._init_owners_mapping()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
         ret_code |= increment.init(
             cls._values.get("compression"),
             cls._values.get("not_compressed_regexp"),
         )
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
         return ret_code
 
@@ -551,7 +552,7 @@ class RepoShadow(location.LocationShadow):
         collated = rorpiter.Collate2Iters(source_iter, dest_iter)
         cls.CCPP = _CacheCollatedPostProcess(
             collated,
-            Globals.pipeline_max_length * 4,
+            consts.PIPELINE_MAX_LENGTH * 4,
             baserp,
             cls._data_dir,
             cls._values.get("file_statistics"),
@@ -563,7 +564,7 @@ class RepoShadow(location.LocationShadow):
         """
         Yield signatures of any changed destination files
         """
-        flush_threshold = Globals.pipeline_max_length - 2
+        flush_threshold = consts.PIPELINE_MAX_LENGTH - 2
         num_rorps_seen = 0
         for src_rorp, dest_rorp in cls.CCPP:
             # If we are backing up across a pipe, we must flush the pipeline
@@ -1166,7 +1167,7 @@ class RepoShadow(location.LocationShadow):
                 "No increment is older than '{ot}'".format(ot=time_string),
                 log.WARNING,
             )
-            return Globals.RET_CODE_WARN
+            return consts.RET_CODE_WARN
 
         for rp in yield_files(cls._data_dir):
             if (rp.isincfile() and rp.getinctime() < removal_time) or (
@@ -1174,7 +1175,7 @@ class RepoShadow(location.LocationShadow):
             ):
                 log.Log("Deleting increment file {fi}".format(fi=rp), log.INFO)
                 rp.delete()
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     @classmethod
     def _get_removal_time(cls, time_string, show_sizes):
@@ -1313,7 +1314,7 @@ class RepoShadow(location.LocationShadow):
 
         bad_files = 0
         no_hash = 0
-        ret_code = Globals.RET_CODE_OK
+        ret_code = consts.RET_CODE_OK
         for repo_rorp in repo_iter:
             if not repo_rorp.isreg():
                 continue
@@ -1325,7 +1326,7 @@ class RepoShadow(location.LocationShadow):
                     log.WARNING,
                 )
                 no_hash += 1
-                ret_code |= Globals.RET_CODE_FILE_WARN
+                ret_code |= consts.RET_CODE_FILE_WARN
                 continue
             fp = cls.rf_cache.get_fp(base_index + repo_rorp.index, repo_rorp)
             computed_hash = hash.compute_sha1_fp(fp)
@@ -1343,7 +1344,7 @@ class RepoShadow(location.LocationShadow):
                     ),
                     log.ERROR,
                 )
-                ret_code |= Globals.RET_CODE_FILE_ERR
+                ret_code |= consts.RET_CODE_FILE_ERR
         cls.finish_loop()
         if bad_files:
             log.Log(
@@ -1383,10 +1384,10 @@ class RepoShadow(location.LocationShadow):
                 ),
                 log.ERROR,
             )
-            return Globals.RET_CODE_ERR
+            return consts.RET_CODE_ERR
         else:
             cls._logging_to_file = True
-            return Globals.RET_CODE_OK
+            return consts.RET_CODE_OK
 
     @classmethod
     def _log_success(cls, src_rorp, mir_rorp=None):
@@ -1491,7 +1492,7 @@ information in it.
                 # Sync first, since we are marking dest dir as good now
                 C.sync()
             former_current_mirror_rp.delete()
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     # @API(RepoShadow.force_regress, 300)
     @classmethod

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -222,7 +222,7 @@ class RepoShadow(location.LocationShadow):
         # FIXME the problem is that the chars_to_quote can come from the command
         # line but can also be a value coming from the repository itself,
         # set globally by the fs_abilities.xxx_set_globals functions.
-        if not Globals.chars_to_quote:
+        if not generics.chars_to_quote:
             return False
 
         cls._base_dir = map_filenames.get_quotedrpath(cls._base_dir)

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -690,7 +690,7 @@ class RepoShadow(location.LocationShadow):
             older_inc = curmir_incs[0]
         else:
             older_inc = curmir_incs[1]
-        if Globals.do_fsync:
+        if generics.do_fsync:
             # Make sure everything is written before current_mirror is removed
             C.sync()
         older_inc.delete()
@@ -1488,7 +1488,7 @@ information in it.
             ITR(rf.index, rf)
         ITR.finish_processing()
         if former_current_mirror_rp:
-            if Globals.do_fsync:
+            if generics.do_fsync:
                 # Sync first, since we are marking dest dir as good now
                 C.sync()
             former_current_mirror_rp.delete()

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -32,7 +32,7 @@ from rdiffbackup.singletons import consts
 class ReadDir(location.Location):
     def __init__(self, orig_path, values):
         super().__init__(orig_path, values)
-        if orig_path.conn is Globals.local_connection:
+        if orig_path.conn is specifics.local_connection:
             # should be more efficient than going through the connection
             from rdiffbackup.locations import _dir_shadow
 
@@ -99,7 +99,7 @@ class ReadDir(location.Location):
 class WriteDir(location.Location):
     def __init__(self, orig_path, values):
         super().__init__(orig_path, values)
-        if orig_path.conn is Globals.local_connection:
+        if orig_path.conn is specifics.local_connection:
             # should be more efficient than going through the connection
             from rdiffbackup.locations import _dir_shadow
 

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -24,8 +24,9 @@ This plug-in tests that all remote locations are properly reachable and
 usable for a back-up.
 """
 
-from rdiffbackup.locations import fs_abilities, location
 from rdiff_backup import Globals, log
+from rdiffbackup.locations import fs_abilities, location
+from rdiffbackup.singletons import consts
 
 
 class ReadDir(location.Location):
@@ -43,12 +44,12 @@ class ReadDir(location.Location):
 
     def setup(self):
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         self.fs_abilities = self.get_fs_abilities()
         if not self.fs_abilities:
-            return ret_code | Globals.RET_CODE_ERR
+            return ret_code | consts.RET_CODE_ERR
         else:
             log.Log(
                 "--- Read directory file system capabilities ---\n"
@@ -110,12 +111,12 @@ class WriteDir(location.Location):
 
     def setup(self, src_repo):
         ret_code = super().setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         self.fs_abilities = self.get_fs_abilities()
         if not self.fs_abilities:
-            return ret_code | Globals.RET_CODE_ERR
+            return ret_code | consts.RET_CODE_ERR
         else:
             log.Log(
                 "--- Write directory file system capabilities ---\n"
@@ -123,10 +124,10 @@ class WriteDir(location.Location):
                 log.INFO,
             )
         ret_code |= fs_abilities.Repo2DirSetGlobals(src_repo, self)()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         return ret_code

--- a/src/rdiffbackup/locations/directory.py
+++ b/src/rdiffbackup/locations/directory.py
@@ -24,9 +24,9 @@ This plug-in tests that all remote locations are properly reachable and
 usable for a back-up.
 """
 
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup.locations import fs_abilities, location
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 
 class ReadDir(location.Location):

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -769,7 +769,7 @@ def detect_fs_abilities(root_rp, writable=True):
     Returns an FSAbilities object if detection goes well, else None if it fails
     """
     assert (
-        root_rp.conn is Globals.local_connection
+        root_rp.conn is specifics.local_connection
     ), "Action only foreseen locally and not over {conn}.".format(conn=root_rp.conn)
     try:
         return FSAbilities(root_rp, writable=writable)

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -855,7 +855,7 @@ class SetGlobals:
 
     def set_compatible_timestamps(self):
         if generics.chars_to_quote.find(b":") > -1:
-            generics.set("use_compatible_timestamps", 1)
+            generics.set("use_compatible_timestamps", True)
             # Update the current time string to new timestamp format
             Time.set_current_time(Time.getcurtime())
             log.Log("Enabled use_compatible_timestamps", log.INFO)

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -28,7 +28,7 @@ FSAbilities object describing it.
 
 import errno
 import os
-from rdiff_backup import Globals, log, robust, selection, Time
+from rdiff_backup import log, robust, selection, Time
 from rdiffbackup.meta import acl_win  # FIXME there should be no dependency
 from rdiffbackup.locations.map import filenames as map_filenames
 from rdiffbackup.singletons import consts, generics, specifics
@@ -783,7 +783,7 @@ def detect_fs_abilities(root_rp, writable=True):
 
 class SetGlobals:
     """
-    Various functions for setting Globals vars given FSAbilities object(s)
+    Various functions for setting generic vars given FSAbilities object(s)
 
     Factually it is an abstract class and shan't be instantiated but only
     derived.
@@ -809,7 +809,7 @@ class SetGlobals:
             self.dest_fsa.acls,
             ("acls_active", "acls_write", "acls_conn"),
         )
-        if Globals.never_drop_acls and not generics.acls_active:
+        if generics.never_drop_acls and not generics.acls_active:
             log.Log.FatalError(
                 "--never-drop-acls specified, but ACL support "
                 "missing from source filesystem"
@@ -1038,7 +1038,7 @@ class Dir2RepoSetGlobals(SetGlobals):
                         log.NOTE,
                     )
         else:
-            actual_ctq = generics.chars_to_quote  # Globals override
+            actual_ctq = generics.chars_to_quote  # globals override
             if actual_ctq != suggested_ctq:
                 log.Log(
                     "File system at '{fs}' suggested quoting '{sq}' "

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -838,24 +838,24 @@ class SetGlobals:
 
     def set_hardlinks(self):
         if Globals.preserve_hardlinks != 0:
-            Globals.set_all("preserve_hardlinks", self.dest_fsa.hardlinks)
+            generics.set("preserve_hardlinks", self.dest_fsa.hardlinks)
 
     def set_fsync_directories(self):
-        Globals.set_all("fsync_directories", self.dest_fsa.fsync_dirs)
+        generics.set("fsync_directories", self.dest_fsa.fsync_dirs)
 
     def set_change_ownership(self):
-        generics.set_all("change_ownership", self.dest_fsa.ownership)
+        generics.set("change_ownership", self.dest_fsa.ownership)
 
     def set_high_perms(self):
         if not self.dest_fsa.high_perms:
-            Globals.set_all("permission_mask", 0o777)
+            generics.set("permission_mask", 0o777)
 
     def set_symlink_perms(self):
-        Globals.set_all("symlink_perms", self.dest_fsa.symlink_perms)
+        generics.set("symlink_perms", self.dest_fsa.symlink_perms)
 
     def set_compatible_timestamps(self):
         if Globals.chars_to_quote.find(b":") > -1:
-            Globals.set_all("use_compatible_timestamps", 1)
+            generics.set("use_compatible_timestamps", 1)
             # Update the current time string to new timestamp format
             Time.set_current_time(Time.getcurtime())
             log.Log("Enabled use_compatible_timestamps", log.INFO)
@@ -938,10 +938,10 @@ class Dir2RepoSetGlobals(SetGlobals):
                     log.WARNING,
                 )
 
-        Globals.set_all("escape_dos_devices", actual_edd)
+        generics.set("escape_dos_devices", actual_edd)
         log.Log("Backup: escape_dos_devices = {dd}".format(dd=actual_edd), log.INFO)
 
-        Globals.set_all("escape_trailing_spaces", actual_ets)
+        generics.set("escape_trailing_spaces", actual_ets)
         log.Log("Backup: escape_trailing_spaces = {ts}".format(ts=actual_ets), log.INFO)
 
     def set_chars_to_quote(self, repo):
@@ -955,9 +955,9 @@ class Dir2RepoSetGlobals(SetGlobals):
         ctq = self._compare_ctq_file(repo, self._get_ctq_from_fsas())
         regexp, unregexp = map_filenames.get_quoting_regexps(ctq, Globals.quoting_char)
 
-        Globals.set_all("chars_to_quote", ctq)
-        Globals.set_all("chars_to_quote_regexp", regexp)
-        Globals.set_all("chars_to_quote_unregexp", unregexp)
+        generics.set("chars_to_quote", ctq)
+        generics.set("chars_to_quote_regexp", regexp)
+        generics.set("chars_to_quote_unregexp", unregexp)
 
     def _update_triple(self, src_support, dest_support, attr_triple):
         """
@@ -966,15 +966,15 @@ class Dir2RepoSetGlobals(SetGlobals):
         active_attr, write_attr, conn_attr = attr_triple
         if generics.get(active_attr) is not None:
             return  # don't override a value set by the user
-        generics.set_all(active_attr, None)
-        generics.set_all(write_attr, None)
+        generics.set(active_attr, None)
+        generics.set(write_attr, None)
         specifics.set(conn_attr, None)
         if not src_support:
             return  # if source doesn't support, nothing
-        generics.set_all(active_attr, 1)
+        generics.set(active_attr, 1)
         self.in_conn.specifics.set(conn_attr, 1)
         if dest_support:
-            generics.set_all(write_attr, 1)
+            generics.set(write_attr, 1)
             self.out_conn.specifics.set(conn_attr, 1)
 
     def _get_ctq_from_fsas(self):
@@ -1117,10 +1117,10 @@ class Repo2DirSetGlobals(SetGlobals):
                 actual_edd = self.dest_fsa.escape_dos_devices
                 actual_ets = self.dest_fsa.escape_trailing_spaces
 
-        Globals.set_all("escape_dos_devices", actual_edd)
+        generics.set("escape_dos_devices", actual_edd)
         log.Log("Backup: escape_dos_devices = {dd}".format(dd=actual_edd), log.INFO)
 
-        Globals.set_all("escape_trailing_spaces", actual_ets)
+        generics.set("escape_trailing_spaces", actual_ets)
         log.Log("Backup: escape_trailing_spaces = {ts}".format(ts=actual_ets), log.INFO)
 
     def set_chars_to_quote(self, repo):
@@ -1138,16 +1138,16 @@ class Repo2DirSetGlobals(SetGlobals):
             regexp, unregexp = map_filenames.get_quoting_regexps(
                 ctq, Globals.quoting_char
             )
-            Globals.set_all("chars_to_quote", ctq)
-            Globals.set_all("chars_to_quote_regexp", regexp)
-            Globals.set_all("chars_to_quote_unregexp", unregexp)
+            generics.set("chars_to_quote", ctq)
+            generics.set("chars_to_quote_regexp", regexp)
+            generics.set("chars_to_quote_unregexp", unregexp)
         else:
             log.Log(
                 "chars_to_quote config not found, assuming no quoting "
                 "required in backup repository".format(),
                 log.WARNING,
             )
-            Globals.set_all("chars_to_quote", b"")
+            generics.set("chars_to_quote", b"")
 
     def _update_triple(self, src_support, dest_support, attr_triple):
         """
@@ -1161,12 +1161,12 @@ class Repo2DirSetGlobals(SetGlobals):
         active_attr, write_attr, conn_attr = attr_triple
         if generics.get(active_attr) is not None:
             return  # don't override a value set by the user
-        generics.set_all(active_attr, None)
-        generics.set_all(write_attr, None)
+        generics.set(active_attr, None)
+        generics.set(write_attr, None)
         specifics.set(conn_attr, None)
         if not dest_support:
             return  # if dest doesn't support, do nothing
-        generics.set_all(active_attr, 1)
+        generics.set(active_attr, 1)
         self.out_conn.specifics.set(conn_attr, 1)
         self.out_conn.generics.set_local(write_attr, 1)  # FIXME: generics.set_all?
         if src_support:
@@ -1237,11 +1237,11 @@ class SingleRepoSetGlobals(Repo2DirSetGlobals):
         active_attr, write_attr, conn_attr = attr_triple
         if generics.get(active_attr) is not None:
             return  # don't override a value set by the user
-        generics.set_all(active_attr, None)
-        generics.set_all(write_attr, None)
+        generics.set(active_attr, None)
+        generics.set(write_attr, None)
         specifics.set(conn_attr, None)
         if not fsa_support:
             return
-        generics.set_all(active_attr, 1)
-        generics.set_all(write_attr, 1)
+        generics.set(active_attr, 1)
+        generics.set(write_attr, 1)
         self.conn.specifics.set(conn_attr, 1)

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -837,7 +837,7 @@ class SetGlobals:
         )
 
     def set_hardlinks(self):
-        if Globals.preserve_hardlinks != 0:
+        if generics.preserve_hardlinks:
             generics.set("preserve_hardlinks", self.dest_fsa.hardlinks)
 
     def set_fsync_directories(self):

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -854,7 +854,7 @@ class SetGlobals:
         generics.set("symlink_perms", self.dest_fsa.symlink_perms)
 
     def set_compatible_timestamps(self):
-        if Globals.chars_to_quote.find(b":") > -1:
+        if generics.chars_to_quote.find(b":") > -1:
             generics.set("use_compatible_timestamps", 1)
             # Update the current time string to new timestamp format
             Time.set_current_time(Time.getcurtime())
@@ -953,7 +953,7 @@ class Dir2RepoSetGlobals(SetGlobals):
         directory, not just the current fs features.
         """
         ctq = self._compare_ctq_file(repo, self._get_ctq_from_fsas())
-        regexp, unregexp = map_filenames.get_quoting_regexps(ctq, Globals.quoting_char)
+        regexp, unregexp = map_filenames.get_quoting_regexps(ctq, consts.QUOTING_CHAR)
 
         generics.set("chars_to_quote", ctq)
         generics.set("chars_to_quote_regexp", regexp)
@@ -997,7 +997,7 @@ class Dir2RepoSetGlobals(SetGlobals):
 
         # Quote quoting char if quoting anything
         if ctq:
-            ctq.append(Globals.quoting_char)
+            ctq.append(consts.QUOTING_CHAR)
         return b"".join(ctq)
 
     def _compare_ctq_file(self, repo, suggested_ctq):
@@ -1008,10 +1008,10 @@ class Dir2RepoSetGlobals(SetGlobals):
         """
         previous_ctq = repo.get_chars_to_quote()
         if previous_ctq is None:  # there was no previous chars_to_quote
-            if Globals.chars_to_quote is None:
+            if generics.chars_to_quote is None:
                 actual_ctq = suggested_ctq
             else:
-                actual_ctq = Globals.chars_to_quote
+                actual_ctq = generics.chars_to_quote
                 if actual_ctq != suggested_ctq:
                     log.Log(
                         "File system at '{fs}' suggested quoting '{sq}' "
@@ -1024,7 +1024,7 @@ class Dir2RepoSetGlobals(SetGlobals):
             repo.set_chars_to_quote(actual_ctq)
             return actual_ctq
 
-        if Globals.chars_to_quote is None:
+        if generics.chars_to_quote is None:
             if suggested_ctq and suggested_ctq != previous_ctq:
                 # the file system has new specific requirements
                 actual_ctq = suggested_ctq
@@ -1038,7 +1038,7 @@ class Dir2RepoSetGlobals(SetGlobals):
                         log.NOTE,
                     )
         else:
-            actual_ctq = Globals.chars_to_quote  # Globals override
+            actual_ctq = generics.chars_to_quote  # Globals override
             if actual_ctq != suggested_ctq:
                 log.Log(
                     "File system at '{fs}' suggested quoting '{sq}' "
@@ -1127,16 +1127,16 @@ class Repo2DirSetGlobals(SetGlobals):
         """
         Set chars_to_quote from rdiff-backup-data dir
         """
-        if Globals.chars_to_quote is None:
+        if generics.chars_to_quote is None:
             ctq = repo.get_chars_to_quote()
         else:
             # value has been overwritten from the command line but still needs
             # to be set across the connections and (un)regexp defined
-            ctq = Globals.chars_to_quote
+            ctq = generics.chars_to_quote
 
         if ctq is not None:
             regexp, unregexp = map_filenames.get_quoting_regexps(
-                ctq, Globals.quoting_char
+                ctq, consts.QUOTING_CHAR
             )
             generics.set("chars_to_quote", ctq)
             generics.set("chars_to_quote_regexp", regexp)

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -31,6 +31,7 @@ import os
 from rdiff_backup import Globals, log, robust, selection, Time
 from rdiffbackup.meta import acl_win  # FIXME there should be no dependency
 from rdiffbackup.locations.map import filenames as map_filenames
+from rdiffbackup.singletons import consts
 
 
 class FSAbilities:
@@ -888,7 +889,7 @@ class Dir2RepoSetGlobals(SetGlobals):
         self.set_special_escapes(self.repo)
         self.set_compatible_timestamps()
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def set_special_escapes(self, repo):
         """
@@ -1089,7 +1090,7 @@ class Repo2DirSetGlobals(SetGlobals):
         self.set_special_escapes(self.repo)
         self.set_compatible_timestamps()
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def set_special_escapes(self, repo):
         """
@@ -1199,7 +1200,7 @@ class SingleRepoSetGlobals(Repo2DirSetGlobals):
         self.set_special_escapes(self.repo)
         self.set_compatible_timestamps()
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     def set_eas(self):
         self._update_triple(self.dest_fsa.eas, ("eas_active", "eas_write", "eas_conn"))

--- a/src/rdiffbackup/locations/increment.py
+++ b/src/rdiffbackup/locations/increment.py
@@ -20,8 +20,8 @@
 
 import os
 import re
-from rdiff_backup import Globals, log, Rdiff, robust, rpath, statistics, Time
-from rdiffbackup.singletons import consts
+from rdiff_backup import log, Rdiff, robust, rpath, statistics, Time
+from rdiffbackup.singletons import consts, specifics
 
 compression = True
 not_compressed_regexp = None
@@ -154,7 +154,7 @@ def _make_diff_increment(new, mirror, incpref, inc_time):
 
     old_new_perms, old_mirror_perms = (None, None)
 
-    if Globals.process_uid != 0:
+    if specifics.process_uid != 0:
         # Check for unreadable files
         if not new.readable():
             old_new_perms = new.getperms()

--- a/src/rdiffbackup/locations/increment.py
+++ b/src/rdiffbackup/locations/increment.py
@@ -21,6 +21,7 @@
 import os
 import re
 from rdiff_backup import Globals, log, Rdiff, robust, rpath, statistics, Time
+from rdiffbackup.singletons import consts
 
 compression = True
 not_compressed_regexp = None
@@ -31,7 +32,7 @@ def init(compression_value=True, not_compressed_regexp_str=None):
     compression = compression_value
     if not_compressed_regexp_str is None:
         not_compressed_regexp = None
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
     # else we need to compile the regexp
     not_compressed_regexp_bytes = os.fsencode(not_compressed_regexp_str)
     try:
@@ -42,8 +43,8 @@ def init(compression_value=True, not_compressed_regexp_str=None):
             "compile".format(ex=not_compressed_regexp_str),
             log.ERROR,
         )
-        return Globals.RET_CODE_ERR
-    return Globals.RET_CODE_OK
+        return consts.RET_CODE_ERR
+    return consts.RET_CODE_OK
 
 
 def make_increment(new, mirror, incpref, inc_time=None):

--- a/src/rdiffbackup/locations/location.py
+++ b/src/rdiffbackup/locations/location.py
@@ -24,9 +24,10 @@ All those classes should be considered abstract and not instantiated directly.
 """
 
 import os
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup.locations import fs_abilities
 from rdiffbackup.locations.map import owners as map_owners
+from rdiffbackup.singletons import consts
 
 
 class Location:
@@ -87,15 +88,15 @@ class LocationShadow:
         """
         Check anything which can be checked about the location
 
-        Returns error codes as defined with Globals.RET_CODE_*
+        Returns error codes as defined with consts.RET_CODE_*
         """
-        ret_code = Globals.RET_CODE_OK
+        ret_code = consts.RET_CODE_OK
 
         if cls._must_exist and not cls._is_existing():
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
 
         if cls._must_be_writable and not cls._is_writable():
-            ret_code |= Globals.RET_CODE_ERR
+            ret_code |= consts.RET_CODE_ERR
 
         return ret_code
 
@@ -107,12 +108,12 @@ class LocationShadow:
         link two locations together (e.g. for backup resp. restore from
         one to the other).
 
-        Returns error codes as defined with Globals.RET_CODE_*
+        Returns error codes as defined with consts.RET_CODE_*
         """
         if cls._must_be_writable and not cls._create():
-            return Globals.RET_CODE_ERR
+            return consts.RET_CODE_ERR
 
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK
 
     @classmethod
     def get_fs_abilities(cls):
@@ -202,4 +203,4 @@ class LocationShadow:
             preserve_num_ids = cls._values.get("preserve_num_ids", False)
         map_owners.init_users_mapping(users_map, preserve_num_ids)
         map_owners.init_groups_mapping(groups_map, preserve_num_ids)
-        return Globals.RET_CODE_OK
+        return consts.RET_CODE_OK

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -31,7 +31,7 @@ handle that error.)
 import os
 import re
 from rdiff_backup import Globals, log, rpath
-from rdiffbackup.singletons import specifics
+from rdiffbackup.singletons import consts, generics, specifics
 from rdiffbackup.utils import safestr
 
 
@@ -123,7 +123,7 @@ def quote(path):
     would go to "10;05811;05812" if ":" were quoted and ";" were
     the quoting character.
     """
-    quoted_path = Globals.chars_to_quote_regexp.sub(_quote_single, path)
+    quoted_path = generics.chars_to_quote_regexp.sub(_quote_single, path)
     if not Globals.escape_dos_devices and not Globals.escape_trailing_spaces:
         return quoted_path
 
@@ -134,7 +134,7 @@ def quote(path):
             quoted_path[-1] == ord(" ") or quoted_path[-1] == ord(".")
         ):
             quoted_path = quoted_path[:-1] + b"%b%03d" % (
-                Globals.quoting_char,
+                consts.QUOTING_CHAR,
                 quoted_path[-1],
             )
 
@@ -147,14 +147,14 @@ def quote(path):
         rb"(aux|prn|con|nul|com[0-9]|lpt[1-9])(\.|$)", quoted_path, re.I
     ):
         return quoted_path
-    return b"%b%03d" % (Globals.quoting_char, quoted_path[0]) + quoted_path[1:]
+    return b"%b%03d" % (consts.QUOTING_CHAR, quoted_path[0]) + quoted_path[1:]
 
 
 def unquote(path):
     """
     Return original version of quoted filename
     """
-    return Globals.chars_to_quote_unregexp.sub(_unquote_single, path)
+    return generics.chars_to_quote_unregexp.sub(_unquote_single, path)
 
 
 def get_quotedrpath(rp, separate_basename=0):
@@ -196,7 +196,7 @@ def _quote_single(match):
     """
     Return replacement for a single character
     """
-    return b"%b%03d" % (Globals.quoting_char, ord(match.group()))
+    return b"%b%03d" % (consts.QUOTING_CHAR, ord(match.group()))
 
 
 def _unquote_single(match):

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -69,7 +69,7 @@ class QuotedRPath(rpath.RPath):
         Reproduce QuotedRPath from __getstate__ output
         """
         conn_number, self.base, self.index, self.data = rpath_state
-        self.conn = Globals.connection_dict[conn_number]
+        self.conn = specifics.connection_dict[conn_number]
         self.quoted_index = tuple(map(quote, self.index))
         self.path = self.path_join(self.base, *self.quoted_index)
 

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -30,7 +30,7 @@ handle that error.)
 
 import os
 import re
-from rdiff_backup import Globals, log, rpath
+from rdiff_backup import log, rpath
 from rdiffbackup.singletons import consts, generics, specifics
 from rdiffbackup.utils import safestr
 
@@ -124,12 +124,12 @@ def quote(path):
     the quoting character.
     """
     quoted_path = generics.chars_to_quote_regexp.sub(_quote_single, path)
-    if not Globals.escape_dos_devices and not Globals.escape_trailing_spaces:
+    if not generics.escape_dos_devices and not generics.escape_trailing_spaces:
         return quoted_path
 
     # Escape a trailing space or period (invalid in names on FAT32 under DOS,
     # Windows and modern Linux)
-    if Globals.escape_trailing_spaces:
+    if generics.escape_trailing_spaces:
         if len(quoted_path) and (
             quoted_path[-1] == ord(" ") or quoted_path[-1] == ord(".")
         ):
@@ -138,7 +138,7 @@ def quote(path):
                 quoted_path[-1],
             )
 
-        if not Globals.escape_dos_devices:
+        if not generics.escape_dos_devices:
             return quoted_path
 
     # Escape first char of any special DOS device files even if filename has an

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -31,6 +31,7 @@ handle that error.)
 import os
 import re
 from rdiff_backup import Globals, log, rpath
+from rdiffbackup.singletons import specifics
 from rdiffbackup.utils import safestr
 
 

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -21,9 +21,9 @@
 A location module to define repository classes as created by rdiff-backup
 """
 
-from rdiffbackup.locations import fs_abilities, location
-
 from rdiff_backup import Globals, log
+from rdiffbackup.locations import fs_abilities, location
+from rdiffbackup.singletons import consts
 
 
 class Repo(location.Location):
@@ -74,12 +74,12 @@ class Repo(location.Location):
         )
 
         ret_code = self._shadow.setup()
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         self.fs_abilities = self.get_fs_abilities()
         if not self.fs_abilities:
-            return Globals.RET_CODE_ERR
+            return consts.RET_CODE_ERR
         else:
             log.Log(
                 "--- Repository file system capabilities ---\n"
@@ -89,7 +89,7 @@ class Repo(location.Location):
 
         if src_dir is None:
             ret_code |= fs_abilities.SingleRepoSetGlobals(self)()
-            if ret_code & Globals.RET_CODE_ERR:
+            if ret_code & consts.RET_CODE_ERR:
                 return ret_code
         else:
             # FIXME this shouldn't be necessary, and the setting of variable
@@ -98,11 +98,11 @@ class Repo(location.Location):
             self.base_dir.conn.Globals.set_local("isbackup_writer", True)
             # this is the new way, more dedicated but not sufficient yet
             ret_code |= fs_abilities.Dir2RepoSetGlobals(src_dir, self)()
-            if ret_code & Globals.RET_CODE_ERR:
+            if ret_code & consts.RET_CODE_ERR:
                 return ret_code
         self.base_dir = self.setup_finish()
 
-        if ret_code & Globals.RET_CODE_ERR:
+        if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
         return ret_code

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -48,7 +48,7 @@ class Repo(location.Location):
         restore actions.
         """
         super().__init__(orig_path, values)
-        if orig_path.conn is Globals.local_connection:
+        if orig_path.conn is specifics.local_connection:
             # should be more efficient than going through the connection
             from rdiffbackup.locations import _repo_shadow
 

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -23,7 +23,7 @@ A location module to define repository classes as created by rdiff-backup
 
 from rdiff_backup import Globals, log
 from rdiffbackup.locations import fs_abilities, location
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, generics
 
 
 class Repo(location.Location):
@@ -94,8 +94,8 @@ class Repo(location.Location):
         else:
             # FIXME this shouldn't be necessary, and the setting of variable
             # across the connection should happen through the shadow
-            Globals.set_all("backup_writer", self.base_dir.conn)
-            self.base_dir.conn.Globals.set_local("isbackup_writer", True)
+            generics.set("backup_writer", self.base_dir.conn)
+            self.base_dir.conn.specifics.set("is_backup_writer", True)
             # this is the new way, more dedicated but not sufficient yet
             ret_code |= fs_abilities.Dir2RepoSetGlobals(src_dir, self)()
             if ret_code & consts.RET_CODE_ERR:
@@ -113,8 +113,8 @@ class Repo(location.Location):
         """
         # FIXME this shouldn't be necessary, and the setting of variable
         # across the connection should happen through the shadow
-        Globals.set_all("backup_writer", None)
-        self.base_dir.conn.Globals.set_local("isbackup_writer", False)
+        generics.set("backup_writer", None)
+        self.base_dir.conn.specifics.set("is_backup_writer", False)
         self._shadow.exit()
 
     def setup_finish(self):

--- a/src/rdiffbackup/locations/repository.py
+++ b/src/rdiffbackup/locations/repository.py
@@ -21,9 +21,9 @@
 A location module to define repository classes as created by rdiff-backup
 """
 
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup.locations import fs_abilities, location
-from rdiffbackup.singletons import consts, generics
+from rdiffbackup.singletons import consts, generics, specifics
 
 
 class Repo(location.Location):

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -37,7 +37,7 @@ from rdiff_backup import C, Globals, log, rorpiter
 from rdiffbackup import meta
 from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
-from rdiffbackup.singletons import generics
+from rdiffbackup.singletons import generics, specifics
 
 # When an ACL gets dropped, put name in dropped_acl_names.  This is
 # only used so that only the first dropped ACL for any given name

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     pass
 
-from rdiff_backup import C, Globals, log, rorpiter
+from rdiff_backup import C, log, rorpiter
 from rdiffbackup import meta
 from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
@@ -494,7 +494,7 @@ def _list_to_acl(entry_list, map_names=1):
     def warn_drop(name):
         """Warn about acl with name getting dropped"""
         global dropped_acl_names
-        if Globals.never_drop_acls:
+        if generics.never_drop_acls:
             log.Log.FatalError(
                 "--never-drop-acls specified but cannot map "
                 "ACL name {an}".format(an=name)

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -37,6 +37,7 @@ from rdiff_backup import C, Globals, log, rorpiter
 from rdiffbackup import meta
 from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
+from rdiffbackup.singletons import generics
 
 # When an ACL gets dropped, put name in dropped_acl_names.  This is
 # only used so that only the first dropped ACL for any given name
@@ -295,7 +296,7 @@ class AccessControlListFile(meta.FlatFile):
 
     @classmethod
     def is_active(cls):
-        return Globals.acls_active
+        return generics.acls_active
 
     @staticmethod
     def _object_to_record(acl):

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -123,7 +123,7 @@ class AccessControlLists:
     def write_to_rp(self, rp, map_names=1):
         """Write current access control list to RPath rp"""
         assert (
-            rp.conn is Globals.local_connection
+            rp.conn is specifics.local_connection
         ), "Function works locally not over '{co}'.".format(co=rp.conn)
         set_rp_acl(rp, self.entry_list, self.default_entry_list, map_names)
 
@@ -333,7 +333,7 @@ class AccessControlListFile(meta.FlatFile):
 def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
     """Set given rp with ACL that acl_text defines.  rp should be local"""
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "Set ACLs of path should only be done locally not over {conn}.".format(
         conn=rp.conn
     )
@@ -364,7 +364,7 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
 def get_acl_lists_from_rp(rp):
     """Returns (acl_list, def_acl_list) from an rpath.  Call locally"""
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "Get ACLs of path should only be done locally not over {conn}.".format(
         conn=rp.conn
     )
@@ -549,7 +549,7 @@ def get_meta(rp):
     Get acls of given rpath rp.
     """
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "Function works locally not over '{co}'.".format(co=rp.conn)
     acl = get_meta_object(rp.index)
     if not rp.issym():

--- a/src/rdiffbackup/meta/acl_win.py
+++ b/src/rdiffbackup/meta/acl_win.py
@@ -372,7 +372,7 @@ def init_acls():
 
 def get_meta(rp):
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "Function works locally not over '{co}'.".format(co=rp.conn)
     acl = get_meta_object(rp.index)
     acl.read_from_rp(rp)

--- a/src/rdiffbackup/meta/acl_win.py
+++ b/src/rdiffbackup/meta/acl_win.py
@@ -20,6 +20,7 @@
 import os
 from rdiff_backup import C, Globals, log, rorpiter
 from rdiffbackup import meta
+from rdiffbackup.singletons import generics
 from rdiffbackup.utils import safestr
 
 try:
@@ -298,7 +299,7 @@ class WinAccessControlListFile(meta.FlatFile):
 
     @classmethod
     def is_active(cls):
-        return Globals.win_acls_active
+        return generics.win_acls_active
 
     @staticmethod
     def join_iter(rorp_iter, wacl_iter):

--- a/src/rdiffbackup/meta/acl_win.py
+++ b/src/rdiffbackup/meta/acl_win.py
@@ -18,9 +18,9 @@
 # 02110-1301, USA
 
 import os
-from rdiff_backup import C, Globals, log, rorpiter
+from rdiff_backup import C, log, rorpiter
 from rdiffbackup import meta
-from rdiffbackup.singletons import generics
+from rdiffbackup.singletons import generics, specifics
 from rdiffbackup.utils import safestr
 
 try:

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -109,7 +109,11 @@ class ExtendedAttributes:
                     raise
 
     def write_to_rp(self, rp):
-        """Write extended attributes to rpath rp"""
+        """
+        Write extended attributes to rpath rp
+
+        Beware that the attributes don't get re-read and rp still bears the old EAs.
+        """
         assert (
             rp.conn is specifics.local_connection
         ), "Function works locally not over '{co}'.".format(co=rp.conn)

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -246,7 +246,7 @@ class ExtendedAttributesFile(meta.FlatFile):
 
     @classmethod
     def is_active(cls):
-        return Globals.eas_active
+        return generics.eas_active
 
     @staticmethod
     def _object_to_record(ea):

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -37,8 +37,9 @@ except ImportError:
     except ImportError:
         pass
 
-from rdiff_backup import C, Globals, log, rorpiter
+from rdiff_backup import C, log, rorpiter
 from rdiffbackup import meta
+from rdiffbackup.singletons import generics, specifics
 from rdiffbackup.utils import safestr
 
 

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -110,7 +110,7 @@ class ExtendedAttributes:
     def write_to_rp(self, rp):
         """Write extended attributes to rpath rp"""
         assert (
-            rp.conn is Globals.local_connection
+            rp.conn is specifics.local_connection
         ), "Function works locally not over '{co}'.".format(co=rp.conn)
 
         self._clear_rp(rp)
@@ -292,7 +292,7 @@ def get_meta(rp):
     Get extended attributes of given rpath
     """
     assert (
-        rp.conn is Globals.local_connection
+        rp.conn is specifics.local_connection
     ), "Function works locally not over '{co}'.".format(co=rp.conn)
     ea = get_meta_object(rp.index)
     if not rp.issock() and not rp.isfifo():

--- a/src/rdiffbackup/meta/stdattr.py
+++ b/src/rdiffbackup/meta/stdattr.py
@@ -55,8 +55,9 @@ field names and values.
 
 import re
 import binascii
-from rdiff_backup import log, Globals, rpath
+from rdiff_backup import log, rpath
 from rdiffbackup import meta
+from rdiffbackup.singletons import generics
 from rdiffbackup.utils import quoting
 
 
@@ -186,7 +187,7 @@ class AttrFile(meta.FlatFile):
                 str_list.append(b"  CarbonFile %b\n" % (cfile,))
 
             # If file is hardlinked, add that information
-            if Globals.preserve_hardlinks != 0:
+            if generics.preserve_hardlinks:
                 numlinks = rorpath.getnumlinks()
                 if numlinks > 1:
                     str_list.append(b"  NumHardLinks %i\n" % numlinks)

--- a/src/rdiffbackup/meta_mgr.py
+++ b/src/rdiffbackup/meta_mgr.py
@@ -22,7 +22,7 @@ store and retrieve different types of metadata.
 """
 
 import os
-from rdiff_backup import log, Globals, rpath, Time, rorpiter
+from rdiff_backup import log, rpath, Time, rorpiter
 from rdiffbackup.singletons import generics
 from rdiffbackup.utils import plugins
 import rdiffbackup.meta
@@ -144,7 +144,7 @@ class Manager:
             mrp=finalrp
         )
         rpath.rename(temprp[0], finalrp)
-        if Globals.fsync_directories:
+        if generics.fsync_directories:
             self.data_dir.fsync()
 
     def _get_meta_main_at_time(self, time, restrict_index):

--- a/src/rdiffbackup/meta_mgr.py
+++ b/src/rdiffbackup/meta_mgr.py
@@ -129,7 +129,7 @@ class Manager:
         writer = self._meta_main_class(
             temprp[0],
             "wb",
-            compress=Globals.compression,
+            compress=generics.compression,
             check_path=0,
             callback=callback,
         )
@@ -201,7 +201,7 @@ class Manager:
         if meta_class.is_active() or force:
             # Before API 201, metafiles couldn't be compressed
             return meta_class(
-                rp, "w", compress=Globals.compression, callback=self._add_incrp
+                rp, "w", compress=generics.compression, callback=self._add_incrp
             )
         else:
             return None

--- a/src/rdiffbackup/meta_mgr.py
+++ b/src/rdiffbackup/meta_mgr.py
@@ -23,6 +23,7 @@ store and retrieve different types of metadata.
 
 import os
 from rdiff_backup import log, Globals, rpath, Time, rorpiter
+from rdiffbackup.singletons import generics
 from rdiffbackup.utils import plugins
 import rdiffbackup.meta
 
@@ -242,7 +243,7 @@ class PatchDiffMan(Manager):
         unique_set = set()
         for time, rp in sortlist:
             if time in unique_set:
-                if Globals.allow_duplicate_timestamps:
+                if generics.allow_duplicate_timestamps:
                     log.Log(
                         "Metadata file '{mf}' has a duplicate "
                         "timestamp date, you might not be able to "

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -189,7 +189,7 @@ def _system_setup(arglist):
     Globals.set("use_compatible_timestamps", arglist.get("use_compatible_timestamps"))
     Globals.set("do_fsync", arglist.get("fsync"))
     if arglist.get("chars_to_quote") is not None:
-        Globals.set("chars_to_quote", os.fsencode(arglist.get("chars_to_quote")))
+        generics.set("chars_to_quote", os.fsencode(arglist.get("chars_to_quote")))
     return ret_val
 
 

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -20,7 +20,7 @@
 
 import os
 import sys
-from rdiff_backup import Globals, log
+from rdiff_backup import log
 from rdiffbackup import arguments, actions_mgr
 from rdiffbackup.singletons import consts, generics, specifics
 

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -183,7 +183,9 @@ def _system_setup(arglist):
     # if action in ("backup", "regress", "restore"):
     generics.set("compression", arglist.get("compression"))
     # if action in ("regress"):
-    generics.set("allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps"))
+    generics.set(
+        "allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps")
+    )
     # generic settings
     generics.set("null_separator", arglist.get("null_separator"))
     generics.set("use_compatible_timestamps", arglist.get("use_compatible_timestamps"))

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -185,7 +185,7 @@ def _system_setup(arglist):
     # if action in ("regress"):
     generics.set("allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps"))
     # generic settings
-    Globals.set("null_separator", arglist.get("null_separator"))
+    generics.set("null_separator", arglist.get("null_separator"))
     generics.set("use_compatible_timestamps", arglist.get("use_compatible_timestamps"))
     Globals.set("do_fsync", arglist.get("fsync"))
     if arglist.get("chars_to_quote") is not None:

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -22,7 +22,7 @@ import os
 import sys
 from rdiff_backup import Globals, log
 from rdiffbackup import arguments, actions_mgr
-from rdiffbackup.singletons import consts, specifics
+from rdiffbackup.singletons import consts, generics, specifics
 
 if os.name == "nt":
     import msvcrt
@@ -172,13 +172,13 @@ def _system_setup(arglist):
         specifics.set_api_version(arglist.get("api_version"))
 
     # if action in ("backup", "restore"):
-    Globals.set("acls_active", arglist.get("acls"))
-    Globals.set("win_acls_active", arglist.get("acls"))
-    Globals.set("carbonfile_active", arglist.get("carbonfile"))
+    generics.set("eas_active", arglist.get("eas"))
+    generics.set("acls_active", arglist.get("acls"))
+    generics.set("win_acls_active", arglist.get("acls"))
+    generics.set("resource_forks_active", arglist.get("resource_forks"))
+    generics.set("carbonfile_active", arglist.get("carbonfile"))
     Globals.set("compare_inode", arglist.get("compare_inode"))
-    Globals.set("eas_active", arglist.get("eas"))
     Globals.set("preserve_hardlinks", arglist.get("hard_links"))
-    Globals.set("resource_forks_active", arglist.get("resource_forks"))
     Globals.set("never_drop_acls", arglist.get("never_drop_acls"))
     # if action in ("backup", "regress", "restore"):
     Globals.set("compression", arglist.get("compression"))

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -183,10 +183,10 @@ def _system_setup(arglist):
     # if action in ("backup", "regress", "restore"):
     Globals.set("compression", arglist.get("compression"))
     # if action in ("regress"):
-    Globals.set("allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps"))
+    generics.set("allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps"))
     # generic settings
     Globals.set("null_separator", arglist.get("null_separator"))
-    Globals.set("use_compatible_timestamps", arglist.get("use_compatible_timestamps"))
+    generics.set("use_compatible_timestamps", arglist.get("use_compatible_timestamps"))
     Globals.set("do_fsync", arglist.get("fsync"))
     if arglist.get("chars_to_quote") is not None:
         generics.set("chars_to_quote", os.fsencode(arglist.get("chars_to_quote")))

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -187,7 +187,7 @@ def _system_setup(arglist):
     # generic settings
     generics.set("null_separator", arglist.get("null_separator"))
     generics.set("use_compatible_timestamps", arglist.get("use_compatible_timestamps"))
-    Globals.set("do_fsync", arglist.get("fsync"))
+    generics.set("do_fsync", arglist.get("fsync"))
     if arglist.get("chars_to_quote") is not None:
         generics.set("chars_to_quote", os.fsencode(arglist.get("chars_to_quote")))
     return ret_val

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -181,7 +181,7 @@ def _system_setup(arglist):
     generics.set("preserve_hardlinks", arglist.get("hard_links"))
     Globals.set("never_drop_acls", arglist.get("never_drop_acls"))
     # if action in ("backup", "regress", "restore"):
-    Globals.set("compression", arglist.get("compression"))
+    generics.set("compression", arglist.get("compression"))
     # if action in ("regress"):
     generics.set("allow_duplicate_timestamps", arglist.get("allow_duplicate_timestamps"))
     # generic settings

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -178,7 +178,7 @@ def _system_setup(arglist):
     generics.set("resource_forks_active", arglist.get("resource_forks"))
     generics.set("carbonfile_active", arglist.get("carbonfile"))
     Globals.set("compare_inode", arglist.get("compare_inode"))
-    Globals.set("preserve_hardlinks", arglist.get("hard_links"))
+    generics.set("preserve_hardlinks", arglist.get("hard_links"))
     Globals.set("never_drop_acls", arglist.get("never_drop_acls"))
     # if action in ("backup", "regress", "restore"):
     Globals.set("compression", arglist.get("compression"))

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -172,13 +172,7 @@ def _system_setup(arglist):
         specifics.set_api_version(arglist.get("api_version"))
 
     # if action in ("backup", "restore"):
-    generics.set("eas_active", arglist.get("eas"))
-    generics.set("acls_active", arglist.get("acls"))
-    generics.set("win_acls_active", arglist.get("acls"))
-    generics.set("resource_forks_active", arglist.get("resource_forks"))
-    generics.set("carbonfile_active", arglist.get("carbonfile"))
     generics.set("compare_inode", arglist.get("compare_inode"))
-    generics.set("preserve_hardlinks", arglist.get("hard_links"))
     generics.set("never_drop_acls", arglist.get("never_drop_acls"))
     # if action in ("backup", "regress", "restore"):
     generics.set("compression", arglist.get("compression"))

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -22,6 +22,7 @@ import os
 import sys
 from rdiff_backup import Globals, log
 from rdiffbackup import arguments, actions_mgr
+from rdiffbackup.singletons import consts
 
 if os.name == "nt":
     import msvcrt
@@ -60,7 +61,7 @@ def main_run(arglist, security_override=False):
 
     # setup the system settings globally
     ret_val = _system_setup(parsed_args)
-    if ret_val & Globals.RET_CODE_ERR:
+    if ret_val & consts.RET_CODE_ERR:
         return ret_val
 
     # instantiate the action object from the dictionary, handing over the
@@ -76,7 +77,7 @@ def main_run(arglist, security_override=False):
 
     # validate that everything looks good before really starting
     ret_val |= action.pre_check()
-    if ret_val & Globals.RET_CODE_ERR:
+    if ret_val & consts.RET_CODE_ERR:
         log.Log(
             "Action {ac} failed on step {st}".format(
                 ac=parsed_args["action"], st="pre_check"
@@ -104,7 +105,7 @@ def main_run(arglist, security_override=False):
             Security._security_level = "override"
 
         ret_val |= conn_act.check()
-        if ret_val & Globals.RET_CODE_ERR:
+        if ret_val & consts.RET_CODE_ERR:
             log.Log(
                 "Action {ac} failed on step {st}".format(
                     ac=parsed_args["action"], st="check"
@@ -114,7 +115,7 @@ def main_run(arglist, security_override=False):
             return ret_val
 
         ret_val |= conn_act.setup()
-        if ret_val & Globals.RET_CODE_ERR:
+        if ret_val & consts.RET_CODE_ERR:
             log.Log(
                 "Action {ac} failed on step {st}".format(
                     ac=parsed_args["action"], st="setup"
@@ -124,7 +125,7 @@ def main_run(arglist, security_override=False):
             return ret_val
 
         ret_val |= conn_act.run()
-        if ret_val & Globals.RET_CODE_ERR:
+        if ret_val & consts.RET_CODE_ERR:
             log.Log(
                 "Action {ac} failed on step {st}".format(
                     ac=parsed_args["action"], st="run"
@@ -134,19 +135,19 @@ def main_run(arglist, security_override=False):
             return ret_val
 
     # Give a final summary of what might have happened to the user
-    if ret_val & Globals.RET_CODE_WARN:
+    if ret_val & consts.RET_CODE_WARN:
         log.Log(
             "Action {ac} emitted warnings, "
             "see previous messages for details".format(ac=parsed_args["action"]),
             log.WARNING,
         )
-    if ret_val & Globals.RET_CODE_FILE_ERR:
+    if ret_val & consts.RET_CODE_FILE_ERR:
         log.Log(
             "Action {ac} failed on one or more files, "
             "see previous messages for details".format(ac=parsed_args["action"]),
             log.WARNING,
         )
-    if ret_val & Globals.RET_CODE_FILE_WARN:
+    if ret_val & consts.RET_CODE_FILE_WARN:
         log.Log(
             "Action {ac} emitted a warning on one or more files, "
             "see previous messages for details".format(ac=parsed_args["action"]),
@@ -165,7 +166,7 @@ def _system_setup(arglist):
     ret_val = log.Log.set_verbosity(
         arglist.get("verbosity"), arglist.get("terminal_verbosity")
     )
-    if ret_val & Globals.RET_CODE_ERR:
+    if ret_val & consts.RET_CODE_ERR:
         return ret_val
     if arglist.get("api_version") is not None:  # FIXME catch also env variable?
         Globals.set_api_version(arglist.get("api_version"))

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -179,7 +179,7 @@ def _system_setup(arglist):
     generics.set("carbonfile_active", arglist.get("carbonfile"))
     generics.set("compare_inode", arglist.get("compare_inode"))
     generics.set("preserve_hardlinks", arglist.get("hard_links"))
-    Globals.set("never_drop_acls", arglist.get("never_drop_acls"))
+    generics.set("never_drop_acls", arglist.get("never_drop_acls"))
     # if action in ("backup", "regress", "restore"):
     generics.set("compression", arglist.get("compression"))
     # if action in ("regress"):

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -177,7 +177,7 @@ def _system_setup(arglist):
     generics.set("win_acls_active", arglist.get("acls"))
     generics.set("resource_forks_active", arglist.get("resource_forks"))
     generics.set("carbonfile_active", arglist.get("carbonfile"))
-    Globals.set("compare_inode", arglist.get("compare_inode"))
+    generics.set("compare_inode", arglist.get("compare_inode"))
     generics.set("preserve_hardlinks", arglist.get("hard_links"))
     Globals.set("never_drop_acls", arglist.get("never_drop_acls"))
     # if action in ("backup", "regress", "restore"):

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -22,7 +22,7 @@ import os
 import sys
 from rdiff_backup import Globals, log
 from rdiffbackup import arguments, actions_mgr
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 if os.name == "nt":
     import msvcrt
@@ -54,7 +54,7 @@ def main_run(arglist, security_override=False):
     # parse accordingly the arguments
     parsed_args = arguments.parse(
         arglist,
-        "rdiff-backup {ver}".format(ver=Globals.version),
+        "rdiff-backup {ver}".format(ver=specifics.version),
         actions_mgr.get_generic_parsers(),
         discovered_actions,
     )
@@ -169,7 +169,7 @@ def _system_setup(arglist):
     if ret_val & consts.RET_CODE_ERR:
         return ret_val
     if arglist.get("api_version") is not None:  # FIXME catch also env variable?
-        Globals.set_api_version(arglist.get("api_version"))
+        specifics.set_api_version(arglist.get("api_version"))
 
     # if action in ("backup", "restore"):
     Globals.set("acls_active", arglist.get("acls"))

--- a/src/rdiffbackup/singletons/consts.py
+++ b/src/rdiffbackup/singletons/consts.py
@@ -1,0 +1,53 @@
+# Copyright 2002 Ben Escoto
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+"""
+Hold a variety of constants which should have the same value across client/server
+connection. If those values change, are removed or added, this probably mean the
+need for a new major version to show backward incompatible changes.
+"""
+
+# Pre-defined return codes, they must be potence of 2 so that they can be
+# combined.
+# FIXME consistent implementation of return codes isn't yet done
+RET_CODE_OK = 0  # everything is fine
+RET_CODE_ERR = 1  # some fatal error happened, the whole action failed
+RET_CODE_WARN = 2  # any kind of unexpected issue without complete failure
+RET_CODE_FILE_ERR = 4  # a single file (or more) failure
+RET_CODE_FILE_WARN = 8  # a single file (or more) warning or difference
+
+# This determines how many bytes to read at a time when copying
+BLOCKSIZE = 131072
+
+# This is used by the BufferedRead class to determine how many
+# bytes to request from the underlying file per read().  Larger
+# values may save on connection overhead and latency.
+CONN_BUFSIZE = 393216
+
+# This is used in the CacheCollatedPostProcess and MiscIterToFile
+# classes.  The number represents the number of rpaths which may be
+# stuck in buffers when moving over a remote connection.
+PIPELINE_MAX_LENGTH = 500
+
+# This represents the pickle protocol used by rdiff-backup over the connection
+# https://docs.python.org/3/library/pickle.html#pickle-protocols
+# Note that the receiving end will automatically recognize the protocol used so
+# that both ends don't need to use the same one to send, as long as they both
+# understand the maximum protocol version used.
+# Protocol 4 is understood since Python 3.4, protocol 5 since 3.8.
+PICKLE_PROTOCOL = 4

--- a/src/rdiffbackup/singletons/consts.py
+++ b/src/rdiffbackup/singletons/consts.py
@@ -51,3 +51,6 @@ PIPELINE_MAX_LENGTH = 500
 # understand the maximum protocol version used.
 # Protocol 4 is understood since Python 3.4, protocol 5 since 3.8.
 PICKLE_PROTOCOL = 4
+
+# the quoting character is used to mark quoted characters
+QUOTING_CHAR = b";"

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -111,7 +111,7 @@ compare_inode = True
 # performance reasons, so that the need for fsync can be checked on both sides,
 # without the need to open a connection.
 # That's OK because writing happens anyway only on one side.
-fsync_directories = False
+fsync_directories = None
 
 # If set, exit with error instead of dropping ACLs or ACL entries.
 never_drop_acls = False
@@ -125,10 +125,10 @@ permission_mask = 0o7777
 # the original permissions
 symlink_perms = None
 
-# Fsync everything by default. Use --no-fsync only if you really know what you are doing
-# Not having the data written to disk may render your backup unusable in case of FS failure.
-# Using --no-fsync disables only fsync of files during backup and sync() system call upon backup finish
-# and pre-regress
+# Fsync everything by default. Use --no-fsync only if you really know what you are
+# doing. Not having the data written to disk may render your backup unusable in case
+# of FS failure. Using --no-fsync disables only fsync of files during backup and
+# sync() system call upon backup finish and pre-regress.
 do_fsync = True
 
 # This is the current time, either as integer (epoch) or formatted string.

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -111,10 +111,10 @@ compare_inode = True
 # performance reasons, so that the need for fsync can be checked on both sides,
 # without the need to open a connection.
 # That's OK because writing happens anyway only on one side.
-fsync_directories = None
+fsync_directories = False
 
 # If set, exit with error instead of dropping ACLs or ACL entries.
-never_drop_acls = None
+never_drop_acls = False
 
 # Apply this mask to permissions before chmoding.  (Set to 0777 to
 # prevent highbit permissions on systems which don't support them.)

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -33,38 +33,34 @@ change_ownership = None
 preserve_atime = None
 
 # The following three attributes represent whether extended attributes
-# are supported.  If eas_active is true, then the current session
-# supports them.  If eas_write is true, then the extended attributes
-# should also be written to the destination side.  Finally, eas_conn
-# is relative to the current connection, and should be true iff that
-# particular connection supports extended attributes.
+# are supported.
+# If eas_active is true, then the current session supports them.
+# If eas_write is true, then the extended attributes should also be written to
+# the destination side.
+# Finally, eas_conn is relative to the current connection, and should be true iff
+# that particular connection supports extended attributes.
+# This last variable is in the specifics.
 eas_active = None
 eas_write = None
-eas_conn = None
 
 # The following settings are like the extended attribute settings, but
 # apply to access control lists instead.
 acls_active = None
 acls_write = None
-acls_conn = None
 
-# Like the above, but applies to support of Windows
-# access control lists.
+# Like the above, but applies to support of Windows access control lists.
 win_acls_active = None
 win_acls_write = None
-win_acls_conn = None
 
 # Like above two setting groups, but applies to support of Mac OS X
 # style resource forks.
 resource_forks_active = None
 resource_forks_write = None
-resource_forks_conn = None
 
 # Like the above, but applies to MacOS Carbon Finder creator/type info.
 # As of 1.0.2 this has defaulted to off because of bugs
 carbonfile_active = None
 carbonfile_write = None
-carbonfile_conn = None
 
 # This will be set as soon as the LocalConnection class loads
 local_connection = None

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -18,6 +18,7 @@
 # 02110-1301, USA
 """
 A variety of variables which need to have the same value across connections.
+They are generic to all instances of rdiff-backup involved.
 """
 
 import os
@@ -166,10 +167,6 @@ permission_mask = 0o7777
 # the original permissions
 symlink_perms = None
 
-# If set, the path that should be used instead of the default Python
-# tempfile.tempdir value on remote connections
-remote_tempdir = None
-
 # Fsync everything by default. Use --no-fsync only if you really know what you are doing
 # Not having the data written to disk may render your backup unusable in case of FS failure.
 # Using --no-fsync disables only fsync of files during backup and sync() system call upon backup finish
@@ -219,41 +216,3 @@ def set_all(setting_name, value):
 def set_local(name, val):
     """Like set above, but only set current connection"""
     globals()[name] = val
-
-
-def set_integer(name, val):
-    """Like set, but make sure val is an integer"""
-    try:
-        intval = int(val)
-    except ValueError:
-        log.Log.FatalError(
-            "Variable {vr} must be set to an integer, received "
-            "value '{vl}' instead".format(vr=name, vl=val)
-        )
-    set(name, intval)
-
-
-# @API(set_api_version, 201)
-def set_api_version(val):
-    """sets the actual API version after having verified that the new
-    value is an integer between mix and max values."""
-    try:
-        intval = int(val)
-    except ValueError:
-        log.Log.FatalError(
-            "API version must be set to an integer, "
-            "received value {va} instead.".format(va=val)
-        )
-    if intval < api_version["min"] or intval > api_version["max"]:
-        log.Log.FatalError(
-            "API version {av} must be between {mi} and {ma}.".format(
-                av=val, mi=api_version["min"], ma=api_version["max"]
-            )
-        )
-    api_version["actual"] = intval
-
-
-def get_api_version():
-    """Return the actual API version, either set explicitly or the default
-    one"""
-    return api_version["actual"] or api_version["default"]

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -107,6 +107,10 @@ compare_inode = True
 
 # If set, directories can be fsync'd just like normal files, to
 # guarantee that any changes have been comitted to disk.
+# It should be a variable specific to a file system, but it's made generic for
+# performance reasons, so that the need for fsync can be checked on both sides,
+# without the need to open a connection.
+# That's OK because writing happens anyway only on one side.
 fsync_directories = None
 
 # If set, exit with error instead of dropping ACLs or ACL entries.

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -69,8 +69,6 @@ backup_writer = None  # compat201
 chars_to_quote = None
 chars_to_quote_regexp = None
 chars_to_quote_unregexp = None
-# the quoting character is used to mark quoted characters
-quoting_char = b";"
 
 # evaluate if DOS device names (AUX, PRN, CON, NUL, COM, LPT) should be quoted
 # or spaces at the end of file and directory names.

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -99,7 +99,7 @@ compression = True
 
 # If true, filelists and directory statistics will be split on
 # nulls instead of newlines.
-null_separator = None
+null_separator = False
 
 # On the backup writer connection, holds the root incrementing branch
 # object.  Access is provided to increment error counts.

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -62,13 +62,6 @@ resource_forks_write = None
 carbonfile_active = None
 carbonfile_write = None
 
-# True if the script is the end that writes to the increment and
-# mirror directories.  True for purely local sessions.
-isbackup_writer = None  # compat201
-
-# Connection of the backup writer
-backup_writer = None  # compat201
-
 # This list is used by the set function below.  When a new
 # connection is created with init_connection, its Globals class
 # will match this one for all the variables mentioned in this

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -103,7 +103,7 @@ null_separator = False
 
 # If set, a file will be marked as changed if its inode changes.  See
 # the man page under --no-compare-inode for more information.
-compare_inode = 1
+compare_inode = True
 
 # If set, directories can be fsync'd just like normal files, to
 # guarantee that any changes have been comitted to disk.

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -22,9 +22,6 @@ They are generic to all instances of rdiff-backup involved.
 """
 
 import os
-import yaml
-from importlib import metadata
-from rdiff_backup import log
 from rdiffbackup.singletons import specifics
 
 # If true, when copying attributes, also change target's uid/gid

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -91,11 +91,11 @@ allow_duplicate_timestamps = False
 # between None and 0.  When restoring, None or 1 means to preserve
 # hardlinks iff can find a hardlink dictionary.  0 means ignore
 # hardlink information regardless.
-preserve_hardlinks = 1
+preserve_hardlinks = True
 
 # If this is false, then rdiff-backup will not compress any
 # increments.  Default is to compress based on regexp below.
-compression = 1
+compression = True
 
 # If true, filelists and directory statistics will be split on
 # nulls instead of newlines.

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -62,35 +62,12 @@ resource_forks_write = None
 carbonfile_active = None
 carbonfile_write = None
 
-# This will be set as soon as the LocalConnection class loads
-local_connection = None
-
-# All connections should be added to the following list, so
-# further global changes can be propagated to the remote systems.
-# The first element should be Globals.local_connection.  For a
-# server, the second is the connection to the client.
-connections = []
-
-# Each process should have a connection number unique to the
-# session.  The client has connection number 0.
-connection_number = 0
-
-# Dictionary pairing connection numbers with connections.  Set in
-# SetConnections for all connections.
-connection_dict = {}
-
 # True if the script is the end that writes to the increment and
 # mirror directories.  True for purely local sessions.
 isbackup_writer = None  # compat201
 
 # Connection of the backup writer
 backup_writer = None  # compat201
-
-# When backing up, issource should be true on the reader and isdest on
-# the writer.  When restoring, issource should be true on the mirror
-# and isdest should be true on the target.
-issource = None
-isdest = None
 
 # This list is used by the set function below.  When a new
 # connection is created with init_connection, its Globals class

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -101,10 +101,6 @@ compression = True
 # nulls instead of newlines.
 null_separator = False
 
-# On the backup writer connection, holds the root incrementing branch
-# object.  Access is provided to increment error counts.
-ITRB = None
-
 # If set, a file will be marked as changed if its inode changes.  See
 # the man page under --no-compare-inode for more information.
 compare_inode = 1

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -79,12 +79,11 @@ escape_trailing_spaces = os.name == "nt"
 # If true, the timestamps use the following format: "2008-09-01T04-49-04-07-00"
 # (instead of "2008-09-01T04:49:04-07:00"). This creates timestamps which
 # don't need to be escaped on Windows.
-use_compatible_timestamps = 0
+use_compatible_timestamps = False
 
 # Normally there shouldn't be any case of duplicate timestamp but it seems
 # we had the issue at some point in time, hence we need the flag to allow
 # users to clean up their repository. The default is to abort on such cases.
-
 allow_duplicate_timestamps = False
 
 # If true, then hardlinks will be preserved to mirror and recorded

--- a/src/rdiffbackup/singletons/globals.py
+++ b/src/rdiffbackup/singletons/globals.py
@@ -1,0 +1,259 @@
+# Copyright 2002 Ben Escoto
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+"""
+A variety of variables which need to have the same value across connections.
+"""
+
+import os
+import yaml
+from importlib import metadata
+from rdiff_backup import log
+
+# If true, when copying attributes, also change target's uid/gid
+change_ownership = None
+
+# If true, try to reset the atimes of the source partition.
+preserve_atime = None
+
+# The following three attributes represent whether extended attributes
+# are supported.  If eas_active is true, then the current session
+# supports them.  If eas_write is true, then the extended attributes
+# should also be written to the destination side.  Finally, eas_conn
+# is relative to the current connection, and should be true iff that
+# particular connection supports extended attributes.
+eas_active = None
+eas_write = None
+eas_conn = None
+
+# The following settings are like the extended attribute settings, but
+# apply to access control lists instead.
+acls_active = None
+acls_write = None
+acls_conn = None
+
+# Like the above, but applies to support of Windows
+# access control lists.
+win_acls_active = None
+win_acls_write = None
+win_acls_conn = None
+
+# Like above two setting groups, but applies to support of Mac OS X
+# style resource forks.
+resource_forks_active = None
+resource_forks_write = None
+resource_forks_conn = None
+
+# Like the above, but applies to MacOS Carbon Finder creator/type info.
+# As of 1.0.2 this has defaulted to off because of bugs
+carbonfile_active = None
+carbonfile_write = None
+carbonfile_conn = None
+
+# This will be set as soon as the LocalConnection class loads
+local_connection = None
+
+# All connections should be added to the following list, so
+# further global changes can be propagated to the remote systems.
+# The first element should be Globals.local_connection.  For a
+# server, the second is the connection to the client.
+connections = []
+
+# Each process should have a connection number unique to the
+# session.  The client has connection number 0.
+connection_number = 0
+
+# Dictionary pairing connection numbers with connections.  Set in
+# SetConnections for all connections.
+connection_dict = {}
+
+# True if the script is the end that writes to the increment and
+# mirror directories.  True for purely local sessions.
+isbackup_writer = None  # compat201
+
+# Connection of the backup writer
+backup_writer = None  # compat201
+
+# When backing up, issource should be true on the reader and isdest on
+# the writer.  When restoring, issource should be true on the mirror
+# and isdest should be true on the target.
+issource = None
+isdest = None
+
+# This list is used by the set function below.  When a new
+# connection is created with init_connection, its Globals class
+# will match this one for all the variables mentioned in this
+# list.
+changed_settings = []
+
+# chars_to_quote is a string whose characters should be quoted.  It
+# should be set if certain characters in filenames on the source side
+# should be escaped (see locations.map.filenames for more info).
+chars_to_quote = None
+chars_to_quote_regexp = None
+chars_to_quote_unregexp = None
+# the quoting character is used to mark quoted characters
+quoting_char = b";"
+
+# evaluate if DOS device names (AUX, PRN, CON, NUL, COM, LPT) should be quoted
+# or spaces at the end of file and directory names.
+# The default is based on the operating system type (nt or posix).
+escape_dos_devices = os.name == "nt"
+escape_trailing_spaces = os.name == "nt"
+
+# If true, the timestamps use the following format: "2008-09-01T04-49-04-07-00"
+# (instead of "2008-09-01T04:49:04-07:00"). This creates timestamps which
+# don't need to be escaped on Windows.
+use_compatible_timestamps = 0
+
+# Normally there shouldn't be any case of duplicate timestamp but it seems
+# we had the issue at some point in time, hence we need the flag to allow
+# users to clean up their repository. The default is to abort on such cases.
+
+allow_duplicate_timestamps = False
+
+# If true, then hardlinks will be preserved to mirror and recorded
+# in the increments directory.  There is also a difference here
+# between None and 0.  When restoring, None or 1 means to preserve
+# hardlinks iff can find a hardlink dictionary.  0 means ignore
+# hardlink information regardless.
+preserve_hardlinks = 1
+
+# If this is false, then rdiff-backup will not compress any
+# increments.  Default is to compress based on regexp below.
+compression = 1
+
+# If true, filelists and directory statistics will be split on
+# nulls instead of newlines.
+null_separator = None
+
+# On the backup writer connection, holds the root incrementing branch
+# object.  Access is provided to increment error counts.
+ITRB = None
+
+# If set, a file will be marked as changed if its inode changes.  See
+# the man page under --no-compare-inode for more information.
+compare_inode = 1
+
+# If set, directories can be fsync'd just like normal files, to
+# guarantee that any changes have been comitted to disk.
+fsync_directories = None
+
+# If set, exit with error instead of dropping ACLs or ACL entries.
+never_drop_acls = None
+
+# Apply this mask to permissions before chmoding.  (Set to 0777 to
+# prevent highbit permissions on systems which don't support them.)
+permission_mask = 0o7777
+
+# If true, symlinks permissions are affected by the process umask, and
+# we should change the umask when creating them in order to preserve
+# the original permissions
+symlink_perms = None
+
+# If set, the path that should be used instead of the default Python
+# tempfile.tempdir value on remote connections
+remote_tempdir = None
+
+# Fsync everything by default. Use --no-fsync only if you really know what you are doing
+# Not having the data written to disk may render your backup unusable in case of FS failure.
+# Using --no-fsync disables only fsync of files during backup and sync() system call upon backup finish
+# and pre-regress
+do_fsync = True
+
+# This is the current time, either as integer (epoch) or formatted string.
+# It is set once at the beginning of the program and defines the backup's
+# date and time
+current_time = None
+current_time_string = None
+
+
+# @API(get, 200)
+def get(name):
+    """Return the value of something in this module"""
+    return globals()[name]
+
+
+def set(name, val):
+    """
+    Set the value of something in this module on this connection and, delayed,
+    on all others
+
+    Use this instead of writing the values directly if the setting
+    matters to remote sides.  This function updates the
+    changed_settings list, so other connections know to copy the changes
+    during connection initiation. After the connection has been initiated,
+    use C<set_all> instead.
+    """
+    changed_settings.append(name)
+    globals()[name] = val
+
+
+def set_all(setting_name, value):
+    """
+    Sets the setting given to the value on all connections
+
+    Where set relies on each connection to grab the value at a later stage,
+    set_all forces the value on all connections at once.
+    """
+    for conn in connection_dict.values():
+        conn.Globals.set_local(setting_name, value)
+
+
+# @API(set_local, 200)
+def set_local(name, val):
+    """Like set above, but only set current connection"""
+    globals()[name] = val
+
+
+def set_integer(name, val):
+    """Like set, but make sure val is an integer"""
+    try:
+        intval = int(val)
+    except ValueError:
+        log.Log.FatalError(
+            "Variable {vr} must be set to an integer, received "
+            "value '{vl}' instead".format(vr=name, vl=val)
+        )
+    set(name, intval)
+
+
+# @API(set_api_version, 201)
+def set_api_version(val):
+    """sets the actual API version after having verified that the new
+    value is an integer between mix and max values."""
+    try:
+        intval = int(val)
+    except ValueError:
+        log.Log.FatalError(
+            "API version must be set to an integer, "
+            "received value {va} instead.".format(va=val)
+        )
+    if intval < api_version["min"] or intval > api_version["max"]:
+        log.Log.FatalError(
+            "API version {av} must be between {mi} and {ma}.".format(
+                av=val, mi=api_version["min"], ma=api_version["max"]
+            )
+        )
+    api_version["actual"] = intval
+
+
+def get_api_version():
+    """Return the actual API version, either set explicitly or the default
+    one"""
+    return api_version["actual"] or api_version["default"]

--- a/src/rdiffbackup/singletons/locals.py
+++ b/src/rdiffbackup/singletons/locals.py
@@ -16,7 +16,9 @@
 # along with rdiff-backup; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA
-"""Hold a variety of constants usually set at initialization."""
+"""
+A variety of variables which can have different values across connections.
+"""
 
 import os
 import yaml
@@ -39,28 +41,6 @@ api_version = {"default": 201, "min": 201, "max": 201, "actual": 0}
 # we don't do a lot of error handling because it's more of a dev option
 api_version.update(yaml.safe_load(os.environ.get("RDIFF_BACKUP_API_VERSION", "{}")))
 
-# Pre-defined return codes, they must be potence of 2 so that they can be
-# combined.
-# FIXME consistent implementation of return codes isn't yet done
-RET_CODE_OK = 0  # everything is fine
-RET_CODE_ERR = 1  # some fatal error happened, the whole action failed
-RET_CODE_WARN = 2  # any kind of unexpected issue without complete failure
-RET_CODE_FILE_ERR = 4  # a single file (or more) failure
-RET_CODE_FILE_WARN = 8  # a single file (or more) warning or difference
-
-# This determines how many bytes to read at a time when copying
-blocksize = 131072
-
-# This is used by the BufferedRead class to determine how many
-# bytes to request from the underlying file per read().  Larger
-# values may save on connection overhead and latency.
-conn_bufsize = 393216
-
-# This is used in the CacheCollatedPostProcess and MiscIterToFile
-# classes.  The number represents the number of rpaths which may be
-# stuck in buffers when moving over a remote connection.
-pipeline_max_length = 500
-
 # True if script is running as a server
 server = None
 
@@ -74,9 +54,6 @@ except AttributeError:
     process_uid = 0
     process_gid = 0
     process_groups = [0]
-
-# If true, when copying attributes, also change target's uid/gid
-change_ownership = None
 
 # If true, change the permissions of unwriteable mirror files
 # (such as directories) so that they can be written, and then
@@ -238,14 +215,6 @@ do_fsync = True
 # date and time
 current_time = None
 current_time_string = None
-
-# This represents the pickle protocol used by rdiff-backup over the connection
-# https://docs.python.org/3/library/pickle.html#pickle-protocols
-# Note that the receiving end will automatically recognize the protocol used so
-# that both ends don't need to use the same one to send, as long as they both
-# understand the maximum protocol version used.
-# Protocol 4 is understood since Python 3.4, protocol 5 since 3.8.
-PICKLE_PROTOCOL = 4
 
 
 # @API(get, 200)

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -90,7 +90,7 @@ connection_dict = {}
 
 # True if the script is the end that writes to the increment and
 # mirror directories.  True for purely local sessions.
-isbackup_writer = None  # compat201
+is_backup_writer = None  # compat201
 
 # Connection of the backup writer
 backup_writer = None  # compat201

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,10 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# On the backup writer connection, holds the root incrementing branch
-# object.  Access is provided to increment error counts.
-ITRB = None
-
 # If set, a file will be marked as changed if its inode changes.  See
 # the man page under --no-compare-inode for more information.
 compare_inode = 1

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -80,7 +80,7 @@ local_connection = None
 
 # All connections should be added to the following list, so
 # further global changes can be propagated to the remote systems.
-# The first element should be Globals.local_connection.  For a
+# The first element should be specifics.local_connection.  For a
 # server, the second is the connection to the client.
 connections = []
 
@@ -98,12 +98,6 @@ isbackup_writer = None  # compat201
 
 # Connection of the backup writer
 backup_writer = None  # compat201
-
-# When backing up, issource should be true on the reader and isdest on
-# the writer.  When restoring, issource should be true on the mirror
-# and isdest should be true on the target.
-issource = None
-isdest = None
 
 # This list is used by the set function below.  When a new
 # connection is created with init_connection, its Globals class

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -63,41 +63,16 @@ except AttributeError:
 # permissions).
 change_mirror_perms = process_uid != 0
 
-# If true, try to reset the atimes of the source partition.
-preserve_atime = None
-
 # The following three attributes represent whether extended attributes
 # are supported.  If eas_active is true, then the current session
 # supports them.  If eas_write is true, then the extended attributes
 # should also be written to the destination side.  Finally, eas_conn
 # is relative to the current connection, and should be true iff that
 # particular connection supports extended attributes.
-eas_active = None
-eas_write = None
 eas_conn = None
-
-# The following settings are like the extended attribute settings, but
-# apply to access control lists instead.
-acls_active = None
-acls_write = None
 acls_conn = None
-
-# Like the above, but applies to support of Windows
-# access control lists.
-win_acls_active = None
-win_acls_write = None
 win_acls_conn = None
-
-# Like above two setting groups, but applies to support of Mac OS X
-# style resource forks.
-resource_forks_active = None
-resource_forks_write = None
 resource_forks_conn = None
-
-# Like the above, but applies to MacOS Carbon Finder creator/type info.
-# As of 1.0.2 this has defaulted to off because of bugs
-carbonfile_active = None
-carbonfile_write = None
 carbonfile_conn = None
 
 # This will be set as soon as the LocalConnection class loads

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,10 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# Apply this mask to permissions before chmoding.  (Set to 0777 to
-# prevent highbit permissions on systems which don't support them.)
-permission_mask = 0o7777
-
 # If true, symlinks permissions are affected by the process umask, and
 # we should change the umask when creating them in order to preserve
 # the original permissions

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,10 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If set, directories can be fsync'd just like normal files, to
-# guarantee that any changes have been comitted to disk.
-fsync_directories = None
-
 # If set, exit with error instead of dropping ACLs or ACL entries.
 never_drop_acls = None
 

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -49,19 +49,10 @@ server = None
 # vary depending on the connection.
 try:
     process_uid = os.getuid()
-    process_gid = os.getgid()
-    process_groups = [process_gid] + os.getgroups()
+    process_groups = set(os.getgroups())
 except AttributeError:
     process_uid = 0
-    process_gid = 0
-    process_groups = [0]
-
-# If true, change the permissions of unwriteable mirror files
-# (such as directories) so that they can be written, and then
-# change them back.  This defaults to 1 just in case the process
-# is not running as root (root doesn't need to change
-# permissions).
-change_mirror_perms = process_uid != 0
+    process_groups = {0}
 
 # The following three attributes represent whether extended attributes
 # are supported.  If eas_active is true, then the current session
@@ -91,10 +82,6 @@ connection_dict = {}
 # True if the script is the end that writes to the increment and
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
-
-# If set, the path that should be used instead of the default Python
-# tempfile.tempdir value on remote connections
-remote_tempdir = None
 
 
 # @API(get, 300)

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,15 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# Connection of the backup writer
-backup_writer = None  # compat201
-
-# This list is used by the set function below.  When a new
-# connection is created with init_connection, its Globals class
-# will match this one for all the variables mentioned in this
-# list.
-changed_settings = []
-
 # chars_to_quote is a string whose characters should be quoted.  It
 # should be set if certain characters in filenames on the source side
 # should be escaped (see locations.map.filenames for more info).
@@ -171,13 +162,23 @@ symlink_perms = None
 remote_tempdir = None
 
 
-# @API(get, 200)
-def get(name):
-    """Return the value of something in this module"""
-    return globals()[name]
+# @API(get, 300)
+def get(setting_name):
+    """
+    Return the value of a specific setting
+    """
+    return globals()[setting_name]
 
 
-# @API(set_api_version, 201)
+# @API(set, 300)
+def set(setting_name, value):
+    """
+    Set the value of a specific setting
+    """
+    globals()[setting_name] = value
+
+
+# @API(set_api_version, 300)
 def set_api_version(val):
     """sets the actual API version after having verified that the new
     value is an integer between mix and max values."""

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,13 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If true, then hardlinks will be preserved to mirror and recorded
-# in the increments directory.  There is also a difference here
-# between None and 0.  When restoring, None or 1 means to preserve
-# hardlinks iff can find a hardlink dictionary.  0 means ignore
-# hardlink information regardless.
-preserve_hardlinks = 1
-
 # If this is false, then rdiff-backup will not compress any
 # increments.  Default is to compress based on regexp below.
 compression = 1

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,9 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If set, exit with error instead of dropping ACLs or ACL entries.
-never_drop_acls = None
-
 # Apply this mask to permissions before chmoding.  (Set to 0777 to
 # prevent highbit permissions on systems which don't support them.)
 permission_mask = 0o7777

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -43,7 +43,7 @@ api_version = {"default": 201, "min": 201, "max": 201, "actual": 0}
 api_version.update(yaml.safe_load(os.environ.get("RDIFF_BACKUP_API_VERSION", "{}")))
 
 # True if script is running as a server
-server = None
+server = False
 
 # uid and gid of the owner of the rdiff-backup process.  This can
 # vary depending on the connection.

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,11 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If true, symlinks permissions are affected by the process umask, and
-# we should change the umask when creating them in order to preserve
-# the original permissions
-symlink_perms = None
-
 # If set, the path that should be used instead of the default Python
 # tempfile.tempdir value on remote connections
 remote_tempdir = None

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,15 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# chars_to_quote is a string whose characters should be quoted.  It
-# should be set if certain characters in filenames on the source side
-# should be escaped (see locations.map.filenames for more info).
-chars_to_quote = None
-chars_to_quote_regexp = None
-chars_to_quote_unregexp = None
-# the quoting character is used to mark quoted characters
-quoting_char = b";"
-
 # evaluate if DOS device names (AUX, PRN, CON, NUL, COM, LPT) should be quoted
 # or spaces at the end of file and directory names.
 # The default is based on the operating system type (nt or posix).

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -18,6 +18,7 @@
 # 02110-1301, USA
 """
 A variety of variables which can have different values across connections.
+They are specific to each instance of rdiff-backup involved.
 """
 
 import os
@@ -204,67 +205,11 @@ symlink_perms = None
 # tempfile.tempdir value on remote connections
 remote_tempdir = None
 
-# Fsync everything by default. Use --no-fsync only if you really know what you are doing
-# Not having the data written to disk may render your backup unusable in case of FS failure.
-# Using --no-fsync disables only fsync of files during backup and sync() system call upon backup finish
-# and pre-regress
-do_fsync = True
-
-# This is the current time, either as integer (epoch) or formatted string.
-# It is set once at the beginning of the program and defines the backup's
-# date and time
-current_time = None
-current_time_string = None
-
 
 # @API(get, 200)
 def get(name):
     """Return the value of something in this module"""
     return globals()[name]
-
-
-def set(name, val):
-    """
-    Set the value of something in this module on this connection and, delayed,
-    on all others
-
-    Use this instead of writing the values directly if the setting
-    matters to remote sides.  This function updates the
-    changed_settings list, so other connections know to copy the changes
-    during connection initiation. After the connection has been initiated,
-    use C<set_all> instead.
-    """
-    changed_settings.append(name)
-    globals()[name] = val
-
-
-def set_all(setting_name, value):
-    """
-    Sets the setting given to the value on all connections
-
-    Where set relies on each connection to grab the value at a later stage,
-    set_all forces the value on all connections at once.
-    """
-    for conn in connection_dict.values():
-        conn.Globals.set_local(setting_name, value)
-
-
-# @API(set_local, 200)
-def set_local(name, val):
-    """Like set above, but only set current connection"""
-    globals()[name] = val
-
-
-def set_integer(name, val):
-    """Like set, but make sure val is an integer"""
-    try:
-        intval = int(val)
-    except ValueError:
-        log.Log.FatalError(
-            "Variable {vr} must be set to an integer, received "
-            "value '{vl}' instead".format(vr=name, vl=val)
-        )
-    set(name, intval)
 
 
 # @API(set_api_version, 201)

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,12 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# evaluate if DOS device names (AUX, PRN, CON, NUL, COM, LPT) should be quoted
-# or spaces at the end of file and directory names.
-# The default is based on the operating system type (nt or posix).
-escape_dos_devices = os.name == "nt"
-escape_trailing_spaces = os.name == "nt"
-
 # If true, the timestamps use the following format: "2008-09-01T04-49-04-07-00"
 # (instead of "2008-09-01T04:49:04-07:00"). This creates timestamps which
 # don't need to be escaped on Windows.

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,10 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If this is false, then rdiff-backup will not compress any
-# increments.  Default is to compress based on regexp below.
-compression = 1
-
 # If true, filelists and directory statistics will be split on
 # nulls instead of newlines.
 null_separator = None

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,10 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If set, a file will be marked as changed if its inode changes.  See
-# the man page under --no-compare-inode for more information.
-compare_inode = 1
-
 # If set, directories can be fsync'd just like normal files, to
 # guarantee that any changes have been comitted to disk.
 fsync_directories = None

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,17 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If true, the timestamps use the following format: "2008-09-01T04-49-04-07-00"
-# (instead of "2008-09-01T04:49:04-07:00"). This creates timestamps which
-# don't need to be escaped on Windows.
-use_compatible_timestamps = 0
-
-# Normally there shouldn't be any case of duplicate timestamp but it seems
-# we had the issue at some point in time, hence we need the flag to allow
-# users to clean up their repository. The default is to abort on such cases.
-
-allow_duplicate_timestamps = False
-
 # If true, then hardlinks will be preserved to mirror and recorded
 # in the increments directory.  There is also a difference here
 # between None and 0.  When restoring, None or 1 means to preserve

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -84,10 +84,6 @@ local_connection = None
 # server, the second is the connection to the client.
 connections = []
 
-# Each process should have a connection number unique to the
-# session.  The client has connection number 0.
-connection_number = 0
-
 # Dictionary pairing connection numbers with connections.  Set in
 # SetConnections for all connections.
 connection_dict = {}

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -92,10 +92,6 @@ connection_dict = {}
 # mirror directories.  True for purely local sessions.
 is_backup_writer = None  # compat201
 
-# If true, filelists and directory statistics will be split on
-# nulls instead of newlines.
-null_separator = None
-
 # On the backup writer connection, holds the root incrementing branch
 # object.  Access is provided to increment error counts.
 ITRB = None

--- a/src/rdiffbackup/utils/locking.py
+++ b/src/rdiffbackup/utils/locking.py
@@ -59,7 +59,7 @@ elif os.name == "posix":
         fcntl.flock(file, flags)
 
     def unlock(file):
-        fcntl.flock(file, fcntl.LOCK_UN)
+        fcntl.flock(file, fcntl.LOCK_UN | fcntl.LOCK_NB)
 
 else:  # pragma: no cover  # we will never test on other platforms
     raise RuntimeError("Portable locking only defined for nt and posix platforms")

--- a/testing/action_compare_test.py
+++ b/testing/action_compare_test.py
@@ -8,7 +8,7 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -89,7 +89,7 @@ class ActionCompareTest(unittest.TestCase):
                 b"compare",
                 ("--method", "meta"),
             ),
-            Globals.RET_CODE_FILE_WARN,
+            consts.RET_CODE_FILE_WARN,
         )
         self.assertEqual(
             comtst.rdiff_backup_action(
@@ -129,7 +129,7 @@ class ActionCompareTest(unittest.TestCase):
                 b"compare",
                 ("--at", "15000"),
             ),
-            Globals.RET_CODE_FILE_WARN,
+            consts.RET_CODE_FILE_WARN,
         )
 
         # then try to compare with hashes
@@ -143,7 +143,7 @@ class ActionCompareTest(unittest.TestCase):
                 b"compare",
                 ("--method", "hash"),
             ),
-            Globals.RET_CODE_FILE_WARN,
+            consts.RET_CODE_FILE_WARN,
         )
         self.assertEqual(
             comtst.rdiff_backup_action(
@@ -188,7 +188,7 @@ class ActionCompareTest(unittest.TestCase):
                 b"compare",
                 ("--method", "full"),
             ),
-            Globals.RET_CODE_FILE_WARN,
+            consts.RET_CODE_FILE_WARN,
         )
         self.assertEqual(
             comtst.rdiff_backup_action(

--- a/testing/action_complete_test.py
+++ b/testing/action_complete_test.py
@@ -7,7 +7,7 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -25,7 +25,7 @@ class ActionCompleteTest(unittest.TestCase):
             comtst.rdiff_backup_action(
                 True, True, None, None, ("--api-version", "201"), b"complete", ()
             ),
-            Globals.RET_CODE_ERR,
+            consts.RET_CODE_ERR,
         )
         self.assertEqual(
             comtst.rdiff_backup_action(
@@ -37,7 +37,7 @@ class ActionCompleteTest(unittest.TestCase):
                 b"complete",
                 ("--cword", "1", "--", "rdiff-backup"),
             ),
-            Globals.RET_CODE_ERR,
+            consts.RET_CODE_ERR,
         )
 
         # then try different combinations of verbosity

--- a/testing/action_regress_test.py
+++ b/testing/action_regress_test.py
@@ -10,6 +10,7 @@ import fileset
 
 from rdiff_backup import Globals, rpath
 from rdiffbackup.locations import _repo_shadow
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -124,7 +125,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"regress",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         # we again simulate a crash
         _repo_shadow.RepoShadow.init(
@@ -146,7 +147,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"regress",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         # but it runs with --force
         self.assertEqual(
@@ -159,7 +160,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"regress",
                 (),
             ),
-            Globals.RET_CODE_WARN,
+            consts.RET_CODE_WARN,
         )
         # we restore and compare
         self.assertEqual(
@@ -172,7 +173,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"restore",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertFalse(fileset.compare_paths(self.from2_path, self.to2_path))
         # we again simulate a crash
@@ -188,7 +189,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"backup",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         # now with --force, it can't be exactly the same time or it fails
         # on error_log already existing
@@ -202,7 +203,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"backup",
                 (),
             ),
-            Globals.RET_CODE_WARN,
+            consts.RET_CODE_WARN,
         )
         # we restore and compare
         self.assertEqual(
@@ -215,7 +216,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"restore",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertFalse(fileset.compare_paths(self.from4_path, self.to4_path))
 
@@ -235,7 +236,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"regress",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         # we do it twice
         self.assertEqual(
@@ -248,7 +249,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"regress",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         # we restore and compare
         self.assertEqual(
@@ -261,7 +262,7 @@ class ActionRegressTest(unittest.TestCase):
                 b"restore",
                 (),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertFalse(fileset.compare_paths(self.from1_path, self.to1_path))
         # the last tentative to regress forcefully ends with a warning

--- a/testing/action_regress_test.py
+++ b/testing/action_regress_test.py
@@ -8,9 +8,9 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
 from rdiffbackup.locations import _repo_shadow
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/action_regress_test.py
+++ b/testing/action_regress_test.py
@@ -129,7 +129,7 @@ class ActionRegressTest(unittest.TestCase):
         )
         # we again simulate a crash
         _repo_shadow.RepoShadow.init(
-            rpath.RPath(Globals.local_connection, self.bak_path),
+            rpath.RPath(specifics.local_connection, self.bak_path),
             {},
             True,
             True,

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -8,7 +8,7 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -118,7 +118,7 @@ class ActionRemoveTest(unittest.TestCase):
                 b"remove",
                 ("increments", "--older-than", "1B"),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertEqual(
             comtst.rdiff_backup_action(
@@ -130,7 +130,7 @@ class ActionRemoveTest(unittest.TestCase):
                 b"remove",
                 ("increments", "--older-than", "1B"),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         # then check that only one increment and mirror remain
         self.assertRegex(
@@ -167,7 +167,7 @@ class ActionRemoveTest(unittest.TestCase):
                 b"remove",
                 ("increments", "--older-than", "30000"),
             ),
-            Globals.RET_CODE_WARN,
+            consts.RET_CODE_WARN,
         )
         self.assertRegex(
             comtst.rdiff_backup_action(
@@ -205,7 +205,7 @@ class ActionRemoveTest(unittest.TestCase):
                 b"remove",
                 ("increments", "--older-than", "30001", "--size"),
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         # and check that only the mirror is left
         self.assertEqual(
@@ -241,7 +241,7 @@ class ActionRemoveTest(unittest.TestCase):
                 b"remove",
                 ("increments", "--older-than", "now"),
             ),
-            Globals.RET_CODE_WARN,
+            consts.RET_CODE_WARN,
         )
         # and check that it is still there
         self.assertEqual(

--- a/testing/api_test.py
+++ b/testing/api_test.py
@@ -9,8 +9,8 @@ import yaml
 
 import commontest as comtst
 
-from rdiff_backup import Globals
 from rdiffbackup import actions
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -20,14 +20,14 @@ class ApiVersionTest(unittest.TestCase):
 
     def test_runtime_info_calling(self):
         """make sure that the info output can be read back as YAML"""
-        latest_api = Globals.api_version["max"]
+        latest_api = specifics.api_version["max"]
         output = subprocess.check_output(
             [comtst.RBBin, b"--api-version", b"%i" % latest_api, b"info"]
         )
         out_info = yaml.safe_load(output)
         self.assertEqual(out_info["exec"]["parsed"]["action"], "info")
 
-        Globals.api_version["actual"] = latest_api
+        specifics.api_version["actual"] = latest_api
         # we make sure that the parsed info is the same
         info = actions.BaseAction.get_runtime_info(parsed=out_info["exec"]["parsed"])
 
@@ -50,7 +50,7 @@ class ApiVersionTest(unittest.TestCase):
         """validate that the default version is the actual one or the one explicitly set"""
         output = subprocess.check_output([comtst.RBBin, b"info"])
         api_version = yaml.safe_load(output)["exec"]["api_version"]
-        self.assertEqual(Globals.get_api_version(), api_version["default"])
+        self.assertEqual(specifics.get_api_version(), api_version["default"])
         api_param = os.fsencode(str(api_version["max"]))
         output = subprocess.check_output(
             [comtst.RBBin, b"--api-version", api_param, b"info"]
@@ -77,7 +77,7 @@ class ApiVersionTest(unittest.TestCase):
         self.assertEqual(api_version["min"], 111)
         self.assertEqual(api_version["max"], 999)
         # make sure the untouched variables are really untouched
-        self.assertEqual(Globals.get_api_version(), api_version["default"])
+        self.assertEqual(specifics.get_api_version(), api_version["default"])
 
 
 if __name__ == "__main__":

--- a/testing/arguments_test.py
+++ b/testing/arguments_test.py
@@ -7,8 +7,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals
 from rdiffbackup import arguments, actions_mgr
+from rdiffbackup.singletons import consts
 
 
 class ArgumentsTest(unittest.TestCase):
@@ -26,7 +26,7 @@ class ArgumentsTest(unittest.TestCase):
 
         output = subprocess.run([comtst.RBBin, b"info", b"--help"], capture_output=True)
         self.assertIn(b"Output information", output.stdout)
-        self.assertEqual(Globals.RET_CODE_OK, output.returncode)
+        self.assertEqual(consts.RET_CODE_OK, output.returncode)
 
     def test_error_return_code(self):
         """
@@ -36,7 +36,7 @@ class ArgumentsTest(unittest.TestCase):
             [comtst.RBBin, b"--thisdoesntexist"], capture_output=True
         )
         self.assertIn(b"the following arguments are required:", output.stderr)
-        self.assertEqual(Globals.RET_CODE_ERR, output.returncode)
+        self.assertEqual(consts.RET_CODE_ERR, output.returncode)
 
     def test_parse_function(self):
         """

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -12,8 +12,8 @@ import time
 
 import commontest as comtst
 
-from rdiff_backup import rpath, Globals
-from rdiffbackup.singletons import consts
+from rdiff_backup import rpath
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -52,7 +52,7 @@ def create_many(dirname, s, count):
     contain the string s.
 
     """
-    dir_rp = rpath.RPath(Globals.local_connection, dirname)
+    dir_rp = rpath.RPath(specifics.local_connection, dirname)
     if not dir_rp.isdir():
         dir_rp.mkdir()
     for i in range(count):
@@ -80,7 +80,7 @@ def create_nested(dirname, s, depth, branch_factor):
             list(map(lambda rp: helper(rp, depth - 1), sub_rps))
 
     comtst.re_init_subdir(TEST_BASE_DIR, b"nested_out")
-    helper(rpath.RPath(Globals.local_connection, dirname), depth)
+    helper(rpath.RPath(specifics.local_connection, dirname), depth)
 
 
 def benchmark(backup_cmd, restore_cmd, desc, update_func=None):

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -13,6 +13,7 @@ import time
 import commontest as comtst
 
 from rdiff_backup import rpath, Globals
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -39,7 +40,7 @@ def run_cmd(cmd):
     print("Running command '%s'" % (full_cmd,))
     t = time.time()
     rc = comtst.os_system(full_cmd)
-    if rc & Globals.RET_CODE_ERR:
+    if rc & consts.RET_CODE_ERR:
         raise RuntimeError("Return code of '{cmd}' is '{rc}'".format(cmd=cmd, rc=rc))
     return time.time() - t
 

--- a/testing/cmdline_test.py
+++ b/testing/cmdline_test.py
@@ -13,6 +13,7 @@ import fileset
 
 from rdiff_backup import Globals, log, robust, rpath, selection, Time
 from rdiffbackup.locations.map import filenames as map_filenames
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -618,7 +619,7 @@ class FinalMisc(PathSetter):
             Local.vftrp.path,
             Local.rpout.path,
             extra_options=(b"--tempdir", b"DoesSurelyNotExist", b"backup"),
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
 
 
@@ -783,7 +784,7 @@ class FinalSelection(PathSetter):
             Local.rpout.path,
             Local.rpout1.path,
             extra_options=(b"--force", b"restore", b"--at", b"now") + excludes,
-            expected_ret_code=Globals.RET_CODE_WARN,
+            expected_ret_code=consts.RET_CODE_WARN,
         )
         for rp in (file1_target, file2_target, existing_file):
             rp.setdata()
@@ -910,7 +911,7 @@ class FinalBugs(PathSetter):
             None,
             current_time=30000,
             extra_options=b"regress",
-            expected_ret_code=Globals.RET_CODE_WARN,
+            expected_ret_code=consts.RET_CODE_WARN,
         )
 
         # Check to see if file still there

--- a/testing/cmdline_test.py
+++ b/testing/cmdline_test.py
@@ -4,20 +4,17 @@ Regression tests
 
 import os
 import pathlib
-import re
 import time
 import unittest
 
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals, log, robust, rpath, selection, Time
+from rdiff_backup import log, robust, rpath, selection, Time
 from rdiffbackup.locations.map import filenames as map_filenames
 from rdiffbackup.singletons import consts, generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
-
-Globals.exclude_mirror_regexps = [re.compile(b".*/rdiff-backup-data")]
 
 lc = specifics.local_connection
 

--- a/testing/cmdline_test.py
+++ b/testing/cmdline_test.py
@@ -13,7 +13,7 @@ import fileset
 
 from rdiff_backup import Globals, log, robust, rpath, selection, Time
 from rdiffbackup.locations.map import filenames as map_filenames
-from rdiffbackup.singletons import consts, specifics
+from rdiffbackup.singletons import consts, generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -349,11 +349,11 @@ class Final(PathSetter):
                 self.AssertNotIn(":", walker)
 
         # Start restore of increment 2
-        Globals.chars_to_quote = b"^a-z0-9_ -."
+        generics.set("chars_to_quote", b"^a-z0-9_ -.")
         inc_paths = self.getinc_paths(
             b"increments.", b"testfiles/output/rdiff-backup-data", 1
         )
-        Globals.chars_to_quote = None
+        generics.set("chars_to_quote", None)
         self.assertEqual(len(inc_paths), 1)
         self.exec_rb(None, inc_paths[0], b"testfiles/restoretarget2")
         self.assertTrue(

--- a/testing/cmdline_test.py
+++ b/testing/cmdline_test.py
@@ -19,7 +19,7 @@ TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
 Globals.exclude_mirror_regexps = [re.compile(b".*/rdiff-backup-data")]
 
-lc = Globals.local_connection
+lc = specifics.local_connection
 
 
 class Local:
@@ -28,13 +28,13 @@ class Local:
 
     def get_src_local_rp(extension):
         return rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(comtst.old_test_dir, os.fsencode(extension)),
         )
 
     def get_tgt_local_rp(extension):
         return rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(TEST_BASE_DIR, os.fsencode(extension)),
         )
 
@@ -251,9 +251,9 @@ class PathSetter(unittest.TestCase):
         within a given directory."""
 
         if quoted:
-            dirrp = map_filenames.QuotedRPath(Globals.local_connection, directory)
+            dirrp = map_filenames.QuotedRPath(specifics.local_connection, directory)
         else:
-            dirrp = rpath.RPath(Globals.local_connection, directory)
+            dirrp = rpath.RPath(specifics.local_connection, directory)
         incbasenames = [
             filename
             for filename in robust.listrp(dirrp)
@@ -272,7 +272,7 @@ class Final(PathSetter):
         """Test initial backup of /proc locally"""
         procout_dir = os.path.join(TEST_BASE_DIR, b"procoutput")
         comtst.remove_dir(procout_dir)
-        procout = rpath.RPath(Globals.local_connection, procout_dir)
+        procout = rpath.RPath(specifics.local_connection, procout_dir)
         comtst.rdiff_backup(True, True, "/proc", procout.path, current_time=10000)
         time.sleep(1)
         comtst.rdiff_backup(True, True, "/proc", procout.path, current_time=20000)
@@ -289,7 +289,7 @@ class Final(PathSetter):
         """Test mirroring proc remote"""
         procout_dir = os.path.join(TEST_BASE_DIR, b"procoutput")
         comtst.remove_dir(procout_dir)
-        procout = rpath.RPath(Globals.local_connection, procout_dir)
+        procout = rpath.RPath(specifics.local_connection, procout_dir)
         comtst.rdiff_backup(True, False, "/proc", procout.path, current_time=10000)
         time.sleep(1)
         comtst.rdiff_backup(True, False, "/proc", procout.path, current_time=20000)
@@ -306,7 +306,7 @@ class Final(PathSetter):
         """Test mirroring proc, this time when proc is remote, dest local"""
         procout_dir = os.path.join(TEST_BASE_DIR, b"procoutput")
         comtst.remove_dir(procout_dir)
-        procout = rpath.RPath(Globals.local_connection, procout_dir)
+        procout = rpath.RPath(specifics.local_connection, procout_dir)
         comtst.rdiff_backup(False, True, "/proc", procout.path)
 
     @unittest.skipUnless(os.name == "nt", "Requires Windows support")
@@ -683,7 +683,7 @@ class FinalSelection(PathSetter):
         )
 
         # Test selective restoring
-        mirror_rp = rpath.RPath(Globals.local_connection, out_rel)
+        mirror_rp = rpath.RPath(specifics.local_connection, out_rel)
         restore_filename = comtst.get_increment_rp(mirror_rp, 10000).path
 
         comtst.rdiff_backup(
@@ -929,7 +929,7 @@ class FinalBugs(PathSetter):
 
         # create the bigdir on the fly
         bigdir_path = os.path.join(TEST_BASE_DIR, b"cmd_bigdir")
-        bigrp = rpath.RPath(Globals.local_connection, bigdir_path)
+        bigrp = rpath.RPath(specifics.local_connection, bigdir_path)
         bigdir_struct = {
             "subdir{}": {
                 "range": 4,

--- a/testing/cmdline_test.py
+++ b/testing/cmdline_test.py
@@ -13,7 +13,7 @@ import fileset
 
 from rdiff_backup import Globals, log, robust, rpath, selection, Time
 from rdiffbackup.locations.map import filenames as map_filenames
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -383,7 +383,7 @@ def reset_connections():
     Globals.chars_to_quote_regexp = None
     Globals.chars_to_quote_unregexp = None
     # EAs and ACLs support
-    Globals.eas_active = Globals.acls_active = None
+    generics.eas_active = generics.acls_active = None  # FIXME use set_all?
 
 
 def _hardlink_rorp_eq(src_rorp, dest_rorp):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -380,9 +380,9 @@ def reset_connections():
     specifics.connections = [specifics.local_connection]
     specifics.connection_dict = {0: specifics.local_connection}
     # reset the quoting status
-    Globals.chars_to_quote = None
-    Globals.chars_to_quote_regexp = None
-    Globals.chars_to_quote_unregexp = None
+    generics.set("chars_to_quote", None)
+    generics.set("chars_to_quote_regexp", None)
+    generics.set("chars_to_quote_unregexp", None)
     # EAs and ACLs support
     generics.eas_active = generics.acls_active = None  # FIXME use set_all?
 

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -372,7 +372,7 @@ def get_increment_rp(mirror_rp, time):
 def reset_connections():
     """Reset some global connection information"""
     Security._security_level = "override"
-    Globals.isbackup_reader = Globals.isbackup_writer = None
+    Globals.isbackup_reader = specifics.is_backup_writer = None
     Globals.rbdir = None
     # reset the connection status
     specifics.local_connection.conn_number = 0

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -639,7 +639,7 @@ def backup_restore_series(
     """
     backup_dir = os.path.join(test_base_dir, b"output")
     restore_dir = os.path.join(test_base_dir, b"restore")
-    Globals.set("preserve_hardlinks", compare_hardlinks)
+    generics.set("preserve_hardlinks", compare_hardlinks)
     Globals.set(
         "no_compression_regexp_string",
         os.fsencode(actions.DEFAULT_NOT_COMPRESSED_REGEXP),

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -11,7 +11,6 @@ import shutil
 import subprocess
 
 from rdiff_backup import (
-    Globals,
     hash,
     log,
     rorpiter,
@@ -19,7 +18,7 @@ from rdiff_backup import (
     Security,
     selection,
 )
-from rdiffbackup import actions, run
+from rdiffbackup import run
 from rdiffbackup.meta import ea, acl_posix
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
 from rdiffbackup.singletons import generics, specifics
@@ -373,8 +372,7 @@ def get_increment_rp(mirror_rp, time):
 def reset_connections():
     """Reset some global connection information"""
     Security._security_level = "override"
-    Globals.isbackup_reader = specifics.is_backup_writer = None
-    Globals.rbdir = None
+    specifics.is_backup_writer = None
     # reset the connection status
     specifics.local_connection.conn_number = 0
     specifics.connections = [specifics.local_connection]
@@ -640,10 +638,6 @@ def backup_restore_series(
     backup_dir = os.path.join(test_base_dir, b"output")
     restore_dir = os.path.join(test_base_dir, b"restore")
     generics.set("preserve_hardlinks", compare_hardlinks)
-    Globals.set(
-        "no_compression_regexp_string",
-        os.fsencode(actions.DEFAULT_NOT_COMPRESSED_REGEXP),
-    )
     time = 10000
     dest_rp = rpath.RPath(specifics.local_connection, backup_dir)
     restore_rp = rpath.RPath(specifics.local_connection, restore_dir)

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -382,7 +382,8 @@ def reset_connections():
     generics.set("chars_to_quote_regexp", None)
     generics.set("chars_to_quote_unregexp", None)
     # EAs and ACLs support
-    generics.eas_active = generics.acls_active = None  # FIXME use set_all?
+    generics.set("eas_active", None)
+    generics.set("acls_active", None)
 
 
 def _hardlink_rorp_eq(src_rorp, dest_rorp):

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -47,7 +47,7 @@ abs_testing_dir = os.path.dirname(os.path.abspath(os.fsencode(__file__)))
 __no_execute__ = 1  # Keeps the actual rdiff-backup program from running
 
 if os.name == "nt":
-    Globals.use_compatible_timestamps = 1
+    generics.set("use_compatible_timestamps", True)
     CMD_SEP = b" & "
 else:
     CMD_SEP = b" ; "

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -22,6 +22,7 @@ from rdiff_backup import (
 from rdiffbackup import actions, run
 from rdiffbackup.meta import ea, acl_posix
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
+from rdiffbackup.singletons import generics, specifics
 
 RBBin = os.fsencode(shutil.which("rdiff-backup") or "rdiff-backup")
 

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -375,9 +375,9 @@ def reset_connections():
     Globals.isbackup_reader = Globals.isbackup_writer = None
     Globals.rbdir = None
     # reset the connection status
-    Globals.connection_number = 0
-    Globals.connections = [specifics.local_connection]
-    Globals.connection_dict = {0: specifics.local_connection}
+    specifics.local_connection.conn_number = 0
+    specifics.connections = [specifics.local_connection]
+    specifics.connection_dict = {0: specifics.local_connection}
     # reset the quoting status
     Globals.chars_to_quote = None
     Globals.chars_to_quote_regexp = None

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -54,7 +54,7 @@ else:
 
 def remove_dir(dirstring):
     """Run myrm on given directory string"""
-    root_rp = rpath.RPath(Globals.local_connection, dirstring)
+    root_rp = rpath.RPath(specifics.local_connection, dirstring)
     for rp in selection.Select(root_rp).get_select_iter():
         if rp.isdir():
             rp.chmod(0o700)  # otherwise may not be able to remove
@@ -311,8 +311,8 @@ def InternalMirror(source_local, dest_local, src_dir, dest_dir, force=False):
     InternalBackup, but then delete rdiff-backup-data directory.
     """
     # Save attributes of root to restore later
-    src_root = rpath.RPath(Globals.local_connection, src_dir)
-    dest_root = rpath.RPath(Globals.local_connection, dest_dir)
+    src_root = rpath.RPath(specifics.local_connection, src_dir)
+    dest_root = rpath.RPath(specifics.local_connection, dest_dir)
     dest_rbdir = dest_root.append("rdiff-backup-data")
 
     InternalBackup(source_local, dest_local, src_dir, dest_dir, force=force)
@@ -376,8 +376,8 @@ def reset_connections():
     Globals.rbdir = None
     # reset the connection status
     Globals.connection_number = 0
-    Globals.connections = [Globals.local_connection]
-    Globals.connection_dict = {0: Globals.local_connection}
+    Globals.connections = [specifics.local_connection]
+    Globals.connection_dict = {0: specifics.local_connection}
     # reset the quoting status
     Globals.chars_to_quote = None
     Globals.chars_to_quote_regexp = None
@@ -644,12 +644,12 @@ def backup_restore_series(
         os.fsencode(actions.DEFAULT_NOT_COMPRESSED_REGEXP),
     )
     time = 10000
-    dest_rp = rpath.RPath(Globals.local_connection, backup_dir)
-    restore_rp = rpath.RPath(Globals.local_connection, restore_dir)
+    dest_rp = rpath.RPath(specifics.local_connection, backup_dir)
+    restore_rp = rpath.RPath(specifics.local_connection, restore_dir)
 
     remove_dir(backup_dir)
     for dirname in list_of_dirnames:
-        src_rp = rpath.RPath(Globals.local_connection, dirname)
+        src_rp = rpath.RPath(specifics.local_connection, dirname)
         reset_hardlink_dicts()
         reset_connections()
 
@@ -686,7 +686,7 @@ def backup_restore_series(
             eas=compare_eas,
             acls=compare_acls,
         )
-        src_rp = rpath.RPath(Globals.local_connection, dirname)
+        src_rp = rpath.RPath(specifics.local_connection, dirname)
         assert compare_recursive(
             src_rp,
             restore_rp,

--- a/testing/compare_test.py
+++ b/testing/compare_test.py
@@ -223,7 +223,7 @@ class CompareTest(unittest.TestCase):
                 "Something is wrong with the test setup.".format(diffs=templist),
             )
             diff_rp = rpath.RPath(
-                Globals.local_connection, os.path.join(incs_dir, templist[0])
+                specifics.local_connection, os.path.join(incs_dir, templist[0])
             )
             change_file(diff_rp)
 
@@ -248,7 +248,7 @@ class CompareTest(unittest.TestCase):
         )
         change_file(
             rpath.RPath(
-                Globals.local_connection, os.path.join(self.outdir, b"stph_icons.h")
+                specifics.local_connection, os.path.join(self.outdir, b"stph_icons.h")
             )
         )
         self.assertTrue(

--- a/testing/compare_test.py
+++ b/testing/compare_test.py
@@ -7,8 +7,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath
-from rdiffbackup.singletons import consts
+from rdiff_backup import rpath
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/compare_test.py
+++ b/testing/compare_test.py
@@ -8,6 +8,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -39,7 +40,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertNotEqual(
             comtst.rdiff_backup_action(
@@ -51,7 +52,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
 
         compare_options += ("--at", "10000")
@@ -66,7 +67,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertNotEqual(
             comtst.rdiff_backup_action(
@@ -78,7 +79,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
 
     def testBasicLocal(self):
@@ -123,7 +124,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertNotEqual(
             comtst.rdiff_backup_action(
@@ -135,7 +136,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
 
         compare_options += ("--at", "10000")
@@ -150,7 +151,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertNotEqual(
             comtst.rdiff_backup_action(
@@ -162,7 +163,7 @@ class CompareTest(unittest.TestCase):
                 b"compare",
                 compare_options,
             ),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
 
     def testSelLocal(self):

--- a/testing/connection_test.py
+++ b/testing/connection_test.py
@@ -210,21 +210,21 @@ class RedirectedConnectionTest(unittest.TestCase):
 
     def testBasic(self):
         """Test basic operations with redirection"""
-        self.conna.Globals.set("tmp_val", 1)
-        self.connb.Globals.set("tmp_val", 2)
-        self.assertEqual(self.conna.Globals.get("tmp_val"), 1)
-        self.assertEqual(self.connb.Globals.get("tmp_val"), 2)
+        self.conna.specifics.set("tmp_val", 1)
+        self.connb.specifics.set("tmp_val", 2)
+        self.assertEqual(self.conna.specifics.get("tmp_val"), 1)
+        self.assertEqual(self.connb.specifics.get("tmp_val"), 2)
 
-        self.conna.Globals.set("tmp_connb", self.connb)
-        self.connb.Globals.set("tmp_conna", self.conna)
-        self.assertIs(self.conna.Globals.get("tmp_connb"), self.connb)
-        self.assertIs(self.connb.Globals.get("tmp_conna"), self.conna)
+        self.conna.specifics.set("tmp_connb", self.connb)
+        self.connb.specifics.set("tmp_conna", self.conna)
+        self.assertIs(self.conna.specifics.get("tmp_connb"), self.connb)
+        self.assertIs(self.connb.specifics.get("tmp_conna"), self.conna)
 
     def testRpaths(self):
         """Test moving rpaths back and forth across connections"""
         rp = rpath.RPath(self.conna, "foo")
-        self.connb.Globals.set("tmp_rpath", rp)
-        rp_returned = self.connb.Globals.get("tmp_rpath")
+        self.connb.specifics.set("tmp_rpath", rp)
+        rp_returned = self.connb.specifics.get("tmp_rpath")
         self.assertIs(rp_returned.conn, rp.conn)
         self.assertEqual(rp_returned.path, rp.path)
 

--- a/testing/connection_test.py
+++ b/testing/connection_test.py
@@ -9,8 +9,9 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import connection, Globals, rpath, Security, SetConnections
+from rdiff_backup import connection, rpath, Security, SetConnections
 from rdiffbackup.locations.map import filenames as map_filenames
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/connection_test.py
+++ b/testing/connection_test.py
@@ -21,7 +21,7 @@ regfilename = os.path.join(comtst.old_test_dir, b"various_file_types", b"regular
 class LocalConnectionTest(unittest.TestCase):
     """Test the dummy connection"""
 
-    lc = Globals.local_connection
+    lc = specifics.local_connection
 
     def testGetAttrs(self):
         """Test getting of various attributes"""
@@ -172,7 +172,7 @@ class PipeConnectionTest(unittest.TestCase):
         rp = rpath.RPath(self.conn, regfilename)
         self.assertEqual(self.conn.reval("getattr", rp, "data"), rp.data)
         self.assertEqual(
-            self.conn.reval("getattr", rp, "conn"), Globals.local_connection
+            self.conn.reval("getattr", rp, "conn"), specifics.local_connection
         )
 
     def testQuotedRPaths(self):

--- a/testing/eas_acls_test.py
+++ b/testing/eas_acls_test.py
@@ -56,6 +56,12 @@ class EATest(unittest.TestCase):
     restore_dir = os.path.join(TEST_BASE_DIR, b"restore")
     restore_rp = rpath.RPath(specifics.local_connection, restore_dir)
 
+    def setUp(self):
+        # make sure EAs are active (assuming the test file system supports it)
+        generics.set("eas_active", True)
+        generics.set("eas_write", True)
+        specifics.set("eas_conn", True)
+
     def make_temp_out_dirs(self):
         """Make temp output and restore directories empty"""
         self.out_rp.setdata()  # in case the file changed in-between
@@ -156,6 +162,7 @@ user.empty
         rp1_4 = self.ea_test1_rpath.append("e4")
         list(map(rpath.RPath.touch, [rp1_1, rp1_2, rp1_3, rp1_4]))
         self.sample_ea.write_to_rp(self.ea_test1_rpath)
+        self.ea_test1_rpath.setdata()
         self.ea1.write_to_rp(rp1_1)
         self.ea2.write_to_rp(rp1_2)
         self.ea4.write_to_rp(rp1_4)
@@ -166,6 +173,7 @@ user.empty
         rp2_3 = self.ea_test2_rpath.append("e3")
         list(map(rpath.RPath.touch, [rp2_1, rp2_2, rp2_3]))
         self.ea3.write_to_rp(self.ea_test2_rpath)
+        self.ea_test2_rpath.setdata()
         self.sample_ea.write_to_rp(rp2_1)
         self.ea1.write_to_rp(rp2_2)
         self.ea2.write_to_rp(rp2_3)
@@ -178,6 +186,7 @@ user.empty
     def testIterate(self):
         """Test writing several records and then reading them back"""
         self.make_backup_dirs()
+        self.make_temp_out_dirs()
         rp1 = self.ea_test1_rpath.append("e1")
         rp2 = self.ea_test1_rpath.append("e2")
         rp3 = self.ea_test1_rpath.append("e3")

--- a/testing/eas_acls_test.py
+++ b/testing/eas_acls_test.py
@@ -45,15 +45,15 @@ class EATest(unittest.TestCase):
     ea3 = ea.ExtendedAttributes(("e3",))
     ea4 = ea.ExtendedAttributes(("e4",), {b"user.deleted": b"File to be deleted"})
     ea_test1_dir = os.path.join(TEST_BASE_DIR, b"ea_test1")
-    ea_test1_rpath = rpath.RPath(Globals.local_connection, ea_test1_dir)
+    ea_test1_rpath = rpath.RPath(specifics.local_connection, ea_test1_dir)
     ea_test2_dir = os.path.join(TEST_BASE_DIR, b"ea_test2")
-    ea_test2_rpath = rpath.RPath(Globals.local_connection, ea_test2_dir)
+    ea_test2_rpath = rpath.RPath(specifics.local_connection, ea_test2_dir)
     ea_empty_dir = os.path.join(TEST_BASE_DIR, b"ea_empty")
-    ea_empty_rpath = rpath.RPath(Globals.local_connection, ea_empty_dir)
+    ea_empty_rpath = rpath.RPath(specifics.local_connection, ea_empty_dir)
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
-    out_rp = rpath.RPath(Globals.local_connection, out_dir)
+    out_rp = rpath.RPath(specifics.local_connection, out_dir)
     restore_dir = os.path.join(TEST_BASE_DIR, b"restore")
-    restore_rp = rpath.RPath(Globals.local_connection, restore_dir)
+    restore_rp = rpath.RPath(specifics.local_connection, restore_dir)
 
     def make_temp_out_dirs(self):
         """Make temp output and restore directories empty"""
@@ -333,15 +333,15 @@ other::---""",
     )
     empty_acl = acl_posix.AccessControlLists((), "user::rwx\ngroup::---\nother::---")
     acl_test1_dir = os.path.join(TEST_BASE_DIR, b"acl_test1")
-    acl_test1_rpath = rpath.RPath(Globals.local_connection, acl_test1_dir)
+    acl_test1_rpath = rpath.RPath(specifics.local_connection, acl_test1_dir)
     acl_test2_dir = os.path.join(TEST_BASE_DIR, b"acl_test2")
-    acl_test2_rpath = rpath.RPath(Globals.local_connection, acl_test2_dir)
+    acl_test2_rpath = rpath.RPath(specifics.local_connection, acl_test2_dir)
     acl_empty_dir = os.path.join(TEST_BASE_DIR, b"acl_empty")
-    acl_empty_rpath = rpath.RPath(Globals.local_connection, acl_empty_dir)
+    acl_empty_rpath = rpath.RPath(specifics.local_connection, acl_empty_dir)
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
-    out_rp = rpath.RPath(Globals.local_connection, out_dir)
+    out_rp = rpath.RPath(specifics.local_connection, out_dir)
     restore_dir = os.path.join(TEST_BASE_DIR, b"restore")
-    restore_rp = rpath.RPath(Globals.local_connection, restore_dir)
+    restore_rp = rpath.RPath(specifics.local_connection, restore_dir)
 
     def make_temp_out_dirs(self):
         """Make temp output and restore directories empty"""
@@ -622,7 +622,7 @@ other::---""".format(
 
         self.make_temp_out_dirs()
         rootrp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"acl_map_test")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"acl_map_test")
         )
         make_dir(rootrp)
         (users_map_rp, groups_map_rp) = write_mapping_files(rootrp)
@@ -697,15 +697,15 @@ class CombinedTest(unittest.TestCase):
     """Test backing up and restoring directories with both EAs and ACLs"""
 
     combo_test1_dir = os.path.join(TEST_BASE_DIR, b"ea_acl_test1")
-    combo_test1_rpath = rpath.RPath(Globals.local_connection, combo_test1_dir)
+    combo_test1_rpath = rpath.RPath(specifics.local_connection, combo_test1_dir)
     combo_test2_dir = os.path.join(TEST_BASE_DIR, b"ea_acl_test2")
-    combo_test2_rpath = rpath.RPath(Globals.local_connection, combo_test2_dir)
+    combo_test2_rpath = rpath.RPath(specifics.local_connection, combo_test2_dir)
     combo_empty_dir = os.path.join(TEST_BASE_DIR, b"ea_acl_empty")
-    combo_empty_rpath = rpath.RPath(Globals.local_connection, combo_empty_dir)
+    combo_empty_rpath = rpath.RPath(specifics.local_connection, combo_empty_dir)
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
-    out_rp = rpath.RPath(Globals.local_connection, out_dir)
+    out_rp = rpath.RPath(specifics.local_connection, out_dir)
     restore_dir = os.path.join(TEST_BASE_DIR, b"restore")
-    restore_rp = rpath.RPath(Globals.local_connection, restore_dir)
+    restore_rp = rpath.RPath(specifics.local_connection, restore_dir)
 
     def make_backup_dirs(self):
         """Create testfiles/ea_acl_test[12] directories"""

--- a/testing/eas_acls_test.py
+++ b/testing/eas_acls_test.py
@@ -10,11 +10,11 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
 from rdiffbackup import meta_mgr
 from rdiffbackup.locations.map import owners as map_owners
 from rdiffbackup.meta import acl_posix, ea
-from rdiffbackup.singletons import specifics
+from rdiffbackup.singletons import generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/eas_acls_test.py
+++ b/testing/eas_acls_test.py
@@ -14,6 +14,7 @@ from rdiff_backup import Globals, rpath
 from rdiffbackup import meta_mgr
 from rdiffbackup.locations.map import owners as map_owners
 from rdiffbackup.meta import acl_posix, ea
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/eas_acls_test.py
+++ b/testing/eas_acls_test.py
@@ -674,10 +674,10 @@ other::---""",
         acl2 = acl_posix.AccessControlLists(("a1",))
         acl2.read_from_rp(rp2)
         self.assertTrue(acl2.is_basic())
-        Globals.never_drop_acls = 1
+        generics.never_drop_acls = True
         with self.assertRaises(SystemExit):
             rp.write_acl(acl)
-        Globals.never_drop_acls = None
+        generics.never_drop_acls = False
 
     def test_nochange(self):
         """Make sure files with ACLs not unnecessarily flagged changed"""

--- a/testing/errorsrecover_test.py
+++ b/testing/errorsrecover_test.py
@@ -8,8 +8,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import rpath, Globals
-from rdiffbackup.singletons import consts
+from rdiff_backup import rpath
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/errorsrecover_test.py
+++ b/testing/errorsrecover_test.py
@@ -18,7 +18,7 @@ class BrokenRepoTest(unittest.TestCase):
     """Handling of somehow broken repos"""
 
     def makerp(self, path):
-        return rpath.RPath(Globals.local_connection, path)
+        return rpath.RPath(specifics.local_connection, path)
 
     def makeext(self, path):
         return self.root.new_index(tuple(path.split("/")))

--- a/testing/errorsrecover_test.py
+++ b/testing/errorsrecover_test.py
@@ -9,6 +9,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import rpath, Globals
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -72,7 +73,7 @@ class BrokenRepoTest(unittest.TestCase):
             source_rp.__fspath__(),
             target_rp.__fspath__(),
             current_time=15 * 10000,
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
         # and this should also fail
         comtst.rdiff_backup(
@@ -80,7 +81,7 @@ class BrokenRepoTest(unittest.TestCase):
             1,
             target_rp.__fspath__(),
             None,
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
             extra_options=b"regress",
         )
         # but this should succeed (with a warning)
@@ -90,7 +91,7 @@ class BrokenRepoTest(unittest.TestCase):
             target_rp.__fspath__(),
             None,
             extra_options=(b"regress", b"--allow-duplicate-timestamps"),
-            expected_ret_code=Globals.RET_CODE_WARN,
+            expected_ret_code=consts.RET_CODE_WARN,
         )
         # now we can clean-up, getting rid of the duplicate metadata mirrors
         # NOTE: we could have cleaned-up even without checking/fixing the

--- a/testing/filename_mapping_test.py
+++ b/testing/filename_mapping_test.py
@@ -8,9 +8,9 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
 from rdiffbackup.locations.map import filenames as map_filenames
-from rdiffbackup.singletons import specifics
+from rdiffbackup.singletons import consts, generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -24,11 +24,11 @@ class FilenameMappingTest(unittest.TestCase):
         """Just initialize quoting"""
         ctq = b"A-Z"
         # FIXME possibly too much internas
-        regexp, unregexp = map_filenames.get_quoting_regexps(ctq, Globals.quoting_char)
+        regexp, unregexp = map_filenames.get_quoting_regexps(ctq, consts.QUOTING_CHAR)
 
-        Globals.chars_to_quote = ctq
-        Globals.chars_to_quote_regexp = regexp
-        Globals.chars_to_quote_unregexp = unregexp
+        generics.set("chars_to_quote", ctq)
+        generics.set("chars_to_quote_regexp", regexp)
+        generics.set("chars_to_quote_unregexp", unregexp)
 
     def tearDown(self):
         comtst.reset_connections()

--- a/testing/filename_mapping_test.py
+++ b/testing/filename_mapping_test.py
@@ -10,6 +10,7 @@ import commontest as comtst
 
 from rdiff_backup import Globals, rpath
 from rdiffbackup.locations.map import filenames as map_filenames
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/filename_mapping_test.py
+++ b/testing/filename_mapping_test.py
@@ -46,7 +46,7 @@ class FilenameMappingTest(unittest.TestCase):
             b".1969-12-31;08421;05833;05820-07;05800.data.gz"
         )
         qrp = map_filenames.get_quotedrpath(
-            rpath.RPath(Globals.local_connection, path), 1
+            rpath.RPath(specifics.local_connection, path), 1
         )
         self.assertEqual(qrp.base, b"/usr/local")
         self.assertEqual(len(qrp.index), 1)
@@ -56,10 +56,10 @@ class FilenameMappingTest(unittest.TestCase):
 
     def testLongFilenames(self):
         """See if long quoted filenames cause crash"""
-        outrp = rpath.RPath(Globals.local_connection, self.out_dir)
+        outrp = rpath.RPath(specifics.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(outrp)
         inrp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"quotetest")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"quotetest")
         )
         comtst.re_init_rpath_dir(inrp)
         long_filename = b"A" * 200  # when quoted should cause overflow
@@ -93,11 +93,11 @@ class FilenameMappingTest(unittest.TestCase):
 
     def testReQuote(self):
         inrp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"requote")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"requote")
         )
         comtst.re_init_rpath_dir(inrp)
         inrp.append("ABC_XYZ.1").touch()
-        outrp = rpath.RPath(Globals.local_connection, self.out_dir)
+        outrp = rpath.RPath(specifics.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(outrp)
         self.assertEqual(
             comtst.rdiff_backup_action(

--- a/testing/fs_abilities_test.py
+++ b/testing/fs_abilities_test.py
@@ -80,7 +80,7 @@ class FSAbilitiesTest(unittest.TestCase):
 
     def testReadOnly(self):
         """Test basic querying read only"""
-        base_dir = rpath.RPath(Globals.local_connection, TEST_BASE_DIR)
+        base_dir = rpath.RPath(specifics.local_connection, TEST_BASE_DIR)
         t = time.time()
         fsa = fs_abilities.detect_fs_abilities(base_dir, writable=False)
         print("Time elapsed = ", time.time() - t)
@@ -95,7 +95,7 @@ class FSAbilitiesTest(unittest.TestCase):
 
     def testReadWrite(self):
         """Test basic querying read/write"""
-        base_dir = rpath.RPath(Globals.local_connection, TEST_BASE_DIR)
+        base_dir = rpath.RPath(specifics.local_connection, TEST_BASE_DIR)
         new_dir = base_dir.append("fs_abilitiestest")
         if new_dir.lstat():
             comtst.remove_dir(new_dir.path)
@@ -127,7 +127,7 @@ class FSAbilitiesTest(unittest.TestCase):
     )
     def test_case_sensitive(self):
         """Test a read-only case-INsensitive directory"""
-        rp = rpath.RPath(Globals.local_connection, self.case_insensitive_path)
+        rp = rpath.RPath(specifics.local_connection, self.case_insensitive_path)
         fsa = fs_abilities.detect_fs_abilities(rp, writable=False)
         fsa._detect_case_sensitive_readonly(rp)
         self.assertEqual(fsa.case_sensitive, 0)

--- a/testing/fs_abilities_test.py
+++ b/testing/fs_abilities_test.py
@@ -8,8 +8,9 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
 from rdiffbackup.locations import fs_abilities
+from rdiffbackup.singletons import specifics
 
 # we don't need all these imports but we use them to decide which type will
 # have the corresponding attributes

--- a/testing/generic_roottest.py
+++ b/testing/generic_roottest.py
@@ -12,7 +12,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, generics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -463,7 +463,7 @@ class NonRoot(BaseRootTest):
     def test_non_root(self):
         """Main non-root -> root test"""
         input_rp1, input_rp2 = self.make_root_dirs()
-        Globals.change_ownership = 1
+        generics.change_ownership = 1
         output_rp = rpath.RPath(Globals.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(output_rp, userid)
         restore_rp = rpath.RPath(Globals.local_connection, self.restore_dir)

--- a/testing/generic_roottest.py
+++ b/testing/generic_roottest.py
@@ -12,7 +12,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath
-from rdiffbackup.singletons import consts, generics
+from rdiffbackup.singletons import consts, generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/generic_roottest.py
+++ b/testing/generic_roottest.py
@@ -80,7 +80,7 @@ class RootTest(BaseRootTest):
         (Earlier symlink ownership was not preserved.)
         """
         dirrp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"root_owner")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"root_owner")
         )
 
         def make_dir():
@@ -113,7 +113,7 @@ class RootTest(BaseRootTest):
         # this works only because we know that backup_restore_series creates
         # the backup in the 'output' sub-directory
         symrp = rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(TEST_BASE_DIR, b"output", b"symlink"),
         )
         self.assertTrue(symrp.issym())
@@ -125,7 +125,7 @@ class RootTest(BaseRootTest):
         def write_ownership_dir():
             """Write the directory testfiles/root_mapping"""
             rp = rpath.RPath(
-                Globals.local_connection, os.path.join(TEST_BASE_DIR, b"root_mapping")
+                specifics.local_connection, os.path.join(TEST_BASE_DIR, b"root_mapping")
             )
             comtst.re_init_rpath_dir(rp)
             rp1 = rp.append("1")
@@ -152,7 +152,7 @@ class RootTest(BaseRootTest):
 
         in_rp = write_ownership_dir()
         user_map, group_map = write_mapping_files(in_rp)
-        out_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        out_rp = rpath.RPath(specifics.local_connection, self.out_dir)
         if out_rp.lstat():
             comtst.remove_dir(out_rp.path)
 
@@ -184,7 +184,7 @@ class RootTest(BaseRootTest):
         def write_ownership_dir():
             """Write the directory testfiles/root_mapping"""
             rp = rpath.RPath(
-                Globals.local_connection, os.path.join(TEST_BASE_DIR, b"root_mapping")
+                specifics.local_connection, os.path.join(TEST_BASE_DIR, b"root_mapping")
             )
             comtst.re_init_rpath_dir(rp)
             rp1 = rp.append("1")
@@ -202,7 +202,7 @@ class RootTest(BaseRootTest):
             return (rp1.getuidgid(), rp2.getuidgid())
 
         in_rp = write_ownership_dir()
-        out_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        out_rp = rpath.RPath(specifics.local_connection, self.out_dir)
         if out_rp.lstat():
             comtst.remove_dir(out_rp.path)
 
@@ -229,7 +229,7 @@ class HalfRoot(BaseRootTest):
 
         """
         rp1 = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"root_half1")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"root_half1")
         )
         comtst.re_init_rpath_dir(rp1)
         rp1_1 = rp1.append("foo")
@@ -252,7 +252,7 @@ class HalfRoot(BaseRootTest):
         rp1_3.chmod(0)
 
         rp2 = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"root_half2")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"root_half2")
         )
         comtst.re_init_rpath_dir(rp2)
         rp2_1 = rp2.append("foo")
@@ -309,7 +309,7 @@ class HalfRoot(BaseRootTest):
     def test_backup(self):
         """Test back up, simple restores"""
         in_rp1, in_rp2 = self.make_dirs()
-        outrp = rpath.RPath(Globals.local_connection, self.out_dir)
+        outrp = rpath.RPath(specifics.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(outrp, userid)
         remote_schema = b'su -c "%s server" %s' % (comtst.RBBin, user.encode())
 
@@ -341,7 +341,7 @@ class HalfRoot(BaseRootTest):
         in_rp2.setdata()
         outrp.setdata()
 
-        rout_rp = rpath.RPath(Globals.local_connection, self.restore_dir)
+        rout_rp = rpath.RPath(specifics.local_connection, self.restore_dir)
         comtst.remove_dir(rout_rp.path)
         cmd3 = (
             comtst.RBBin,
@@ -400,7 +400,7 @@ class NonRoot(BaseRootTest):
     def make_root_dirs(self):
         """Make directory createable only by root"""
         rp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"root_out1")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"root_out1")
         )
         comtst.re_init_rpath_dir(rp)
         rp1 = rp.append("1")
@@ -415,7 +415,7 @@ class NonRoot(BaseRootTest):
         rp4.makedev("c", 4, 28)
 
         sp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"root_out2")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"root_out2")
         )
         if sp.lstat():
             comtst.remove_dir(sp.path)
@@ -464,11 +464,11 @@ class NonRoot(BaseRootTest):
         """Main non-root -> root test"""
         input_rp1, input_rp2 = self.make_root_dirs()
         generics.change_ownership = 1
-        output_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        output_rp = rpath.RPath(specifics.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(output_rp, userid)
-        restore_rp = rpath.RPath(Globals.local_connection, self.restore_dir)
+        restore_rp = rpath.RPath(specifics.local_connection, self.restore_dir)
         empty_rp = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"empty")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"empty")
         )
 
         self.backup(input_rp1, output_rp, 1000000)

--- a/testing/generic_roottest.py
+++ b/testing/generic_roottest.py
@@ -11,13 +11,10 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
 from rdiffbackup.singletons import consts, generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
-
-Globals.set("change_source_perms", None)
-Globals.counter = 0
 
 assert os.getuid() == 0, "Run this test as root!"
 

--- a/testing/generic_roottest.py
+++ b/testing/generic_roottest.py
@@ -12,6 +12,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -33,7 +34,7 @@ class BaseRootTest(unittest.TestCase):
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
     restore_dir = os.path.join(TEST_BASE_DIR, b"restore")
 
-    def _run_cmd(self, cmd, expect_rc=Globals.RET_CODE_OK):
+    def _run_cmd(self, cmd, expect_rc=consts.RET_CODE_OK):
         print("Running: ", cmd)
         rc = comtst.os_system(cmd)
         self.assertEqual(
@@ -384,7 +385,7 @@ class HalfRoot(BaseRootTest):
             b"%s regress %s" % (comtst.RBBin, outrp.path),
             user.encode(),
         )
-        self._run_cmd(cmd5, Globals.RET_CODE_WARN)
+        self._run_cmd(cmd5, consts.RET_CODE_WARN)
 
 
 class NonRoot(BaseRootTest):

--- a/testing/hardlink_test.py
+++ b/testing/hardlink_test.py
@@ -9,10 +9,10 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals, rpath, selection
+from rdiff_backup import rpath, selection
 from rdiffbackup.meta import stdattr
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
-from rdiffbackup.singletons import specifics
+from rdiffbackup.singletons import generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -50,7 +50,7 @@ class HardlinkTest(unittest.TestCase):
 
     def testBuildingDict(self):
         """See if the partial inode dictionary is correct"""
-        Globals.preserve_hardlinks = 1
+        generics.preserve_hardlinks = True
         comtst.reset_hardlink_dicts()
         for dsrp in selection.Select(self.hlinks_rp3).get_select_iter():
             map_hardlinks.add_rorp(dsrp)

--- a/testing/hardlink_test.py
+++ b/testing/hardlink_test.py
@@ -12,6 +12,7 @@ import fileset
 from rdiff_backup import Globals, rpath, selection
 from rdiffbackup.meta import stdattr
 from rdiffbackup.locations.map import hardlinks as map_hardlinks
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/hardlink_test.py
+++ b/testing/hardlink_test.py
@@ -26,10 +26,10 @@ class HardlinkTest(unittest.TestCase):
     hlinks_dir1copy = os.path.join(hlinks_dir, b"dir1copy")
     hlinks_dir2 = os.path.join(hlinks_dir, b"dir2")
     hlinks_dir3 = os.path.join(hlinks_dir, b"dir3")
-    hlinks_rp1 = rpath.RPath(Globals.local_connection, hlinks_dir1)
-    hlinks_rp1copy = rpath.RPath(Globals.local_connection, hlinks_dir1copy)
-    hlinks_rp2 = rpath.RPath(Globals.local_connection, hlinks_dir2)
-    hlinks_rp3 = rpath.RPath(Globals.local_connection, hlinks_dir3)
+    hlinks_rp1 = rpath.RPath(specifics.local_connection, hlinks_dir1)
+    hlinks_rp1copy = rpath.RPath(specifics.local_connection, hlinks_dir1copy)
+    hlinks_rp2 = rpath.RPath(specifics.local_connection, hlinks_dir2)
+    hlinks_rp3 = rpath.RPath(specifics.local_connection, hlinks_dir3)
     hello_str = "Hello, world!"
     hello_str_hash = "943a702d06f34599aee1f8da8ef9f7296031d699"
 
@@ -87,13 +87,13 @@ class HardlinkTest(unittest.TestCase):
 
     def testInnerRestore(self):
         """Restore part of a dir, see if hard links preserved"""
-        out_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        out_rp = rpath.RPath(specifics.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(out_rp)
         hlout1_dir = os.path.join(TEST_BASE_DIR, b"out_hardlink1")
         hlout2_dir = os.path.join(TEST_BASE_DIR, b"out_hardlink2")
 
         # Now set up directories out_hardlink1 and out_hardlink2
-        hlout1 = rpath.RPath(Globals.local_connection, hlout1_dir)
+        hlout1 = rpath.RPath(specifics.local_connection, hlout1_dir)
         if hlout1.lstat():
             hlout1.delete()
         hlout1.mkdir()
@@ -109,7 +109,7 @@ class HardlinkTest(unittest.TestCase):
         hl1_3.touch()
         hl1_4.hardlink(hl1_3.path)
 
-        hlout2 = rpath.RPath(Globals.local_connection, hlout2_dir)
+        hlout2 = rpath.RPath(specifics.local_connection, hlout2_dir)
         if hlout2.lstat():
             hlout2.delete()
         comtst.xcopytree(hlout1_dir, hlout2_dir)
@@ -162,7 +162,7 @@ class HardlinkTest(unittest.TestCase):
         # Now try restoring, still checking hard links.
         sub_dir = os.path.join(self.out_dir, b"subdir")
         out2_dir = os.path.join(TEST_BASE_DIR, b"out2")
-        out2 = rpath.RPath(Globals.local_connection, out2_dir)
+        out2 = rpath.RPath(specifics.local_connection, out2_dir)
         hlout1 = out2.append("hardlink1")
         hlout2 = out2.append("hardlink2")
         hlout3 = out2.append("hardlink3")
@@ -215,11 +215,11 @@ class HardlinkTest(unittest.TestCase):
         """
 
         # Setup initial backup
-        out_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        out_rp = rpath.RPath(specifics.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(out_rp)
         hlsrc_dir = os.path.join(TEST_BASE_DIR, b"src_hardlink")
 
-        hlsrc = rpath.RPath(Globals.local_connection, hlsrc_dir)
+        hlsrc = rpath.RPath(specifics.local_connection, hlsrc_dir)
         if hlsrc.lstat():
             hlsrc.delete()
         hlsrc.mkdir()
@@ -239,7 +239,7 @@ class HardlinkTest(unittest.TestCase):
 
         # validate that hashes and link counts are correctly saved in metadata
         meta_prefix = rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(self.out_dir, b"rdiff-backup-data", b"mirror_metadata"),
         )
         incs = meta_prefix.get_incfiles_list()
@@ -284,7 +284,7 @@ class HardlinkTest(unittest.TestCase):
         # Now try restoring, still checking hard links.
         sub_path = os.path.join(self.out_dir, b"subdir")
         restore_path = os.path.join(TEST_BASE_DIR, b"hl_restore")
-        restore_dir = rpath.RPath(Globals.local_connection, restore_path)
+        restore_dir = rpath.RPath(specifics.local_connection, restore_path)
         hlrestore_file1 = restore_dir.append("hardlink1")
         hlrestore_file2 = restore_dir.append("hardlink2")
         hlrestore_file3 = restore_dir.append("hardlink3")
@@ -320,11 +320,11 @@ class HardlinkTest(unittest.TestCase):
         """
 
         # Setup initial backup
-        out_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        out_rp = rpath.RPath(specifics.local_connection, self.out_dir)
         comtst.re_init_rpath_dir(out_rp)
         hlsrc_dir = os.path.join(TEST_BASE_DIR, b"src_hardlink")
 
-        hlsrc = rpath.RPath(Globals.local_connection, hlsrc_dir)
+        hlsrc = rpath.RPath(specifics.local_connection, hlsrc_dir)
         if hlsrc.lstat():
             hlsrc.delete()
         hlsrc.mkdir()
@@ -344,7 +344,7 @@ class HardlinkTest(unittest.TestCase):
 
         # validate that hashes and link counts are correctly saved in metadata
         meta_prefix = rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(self.out_dir, b"rdiff-backup-data", b"mirror_metadata"),
         )
         incs = meta_prefix.get_incfiles_list()
@@ -385,7 +385,7 @@ class HardlinkTest(unittest.TestCase):
         # Now try restoring, still checking hard links.
         sub_path = os.path.join(self.out_dir, b"subdir")
         restore_path = os.path.join(TEST_BASE_DIR, b"hl_restore")
-        restore_dir = rpath.RPath(Globals.local_connection, restore_path)
+        restore_dir = rpath.RPath(specifics.local_connection, restore_path)
         hlrestore_file1 = restore_dir.append("hardlink1")
         hlrestore_file2 = restore_dir.append("hardlink2")
         hlrestore_file3 = restore_dir.append("hardlink3")

--- a/testing/hash_test.py
+++ b/testing/hash_test.py
@@ -26,8 +26,8 @@ class HashTest(unittest.TestCase):
     s3_hash = "8843d7f92416211de9ebb963ff4ce28125932878"
 
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
-    out_rp = rpath.RPath(Globals.local_connection, out_dir)
-    root_rp = rpath.RPath(Globals.local_connection, TEST_BASE_DIR)
+    out_rp = rpath.RPath(specifics.local_connection, out_dir)
+    root_rp = rpath.RPath(specifics.local_connection, TEST_BASE_DIR)
 
     def test_basic(self):
         """Compare sha1sum of a few strings"""
@@ -102,7 +102,7 @@ class HashTest(unittest.TestCase):
 
         comtst.rdiff_backup(1, 1, in_rp1.path, self.out_dir, 10000)
         meta_prefix = rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(self.out_dir, b"rdiff-backup-data", b"mirror_metadata"),
         )
         incs = meta_prefix.get_incfiles_list()

--- a/testing/hash_test.py
+++ b/testing/hash_test.py
@@ -9,8 +9,9 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import hash, rpath, Globals, Security, SetConnections
+from rdiff_backup import hash, rpath, Security, SetConnections
 from rdiffbackup.meta import stdattr
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/hash_test.py
+++ b/testing/hash_test.py
@@ -132,8 +132,8 @@ class HashTest(unittest.TestCase):
         self.assertEqual(conn.reval("pow", 2, 5), 32)
 
         fp = hash.FileWrapper(io.BytesIO(self.s1.encode()))
-        conn.Globals.set_local("tmp_file", fp)
-        fp_remote = conn.Globals.get("tmp_file")
+        conn.specifics.set("tmp_file", fp)
+        fp_remote = conn.specifics.get("tmp_file")
         self.assertEqual(fp_remote.read(), self.s1.encode())
         self.assertEqual(fp_remote.close().sha1_digest, self.s1_hash)
 
@@ -147,8 +147,8 @@ class HashTest(unittest.TestCase):
         rp2.setfile(hash.FileWrapper(rp2.open("rb")))
         rpiter = iter([rp1, rp2])
 
-        conn.Globals.set_local("tmp_conn_iter", rpiter)
-        remote_iter = conn.Globals.get("tmp_conn_iter")
+        conn.specifics.set("tmp_conn_iter", rpiter)
+        remote_iter = conn.specifics.get("tmp_conn_iter")
 
         rorp1 = next(remote_iter)
         fp = hash.FileWrapper(rorp1.open("rb"))

--- a/testing/increment_test.py
+++ b/testing/increment_test.py
@@ -10,6 +10,7 @@ import commontest as comtst
 from rdiff_backup import Globals, rpath, Time, Rdiff
 from rdiffbackup import actions
 from rdiffbackup.locations import increment
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/increment_test.py
+++ b/testing/increment_test.py
@@ -13,7 +13,7 @@ from rdiffbackup.locations import increment
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
-lc = Globals.local_connection
+lc = specifics.local_connection
 Globals.change_source_perms = 1
 
 

--- a/testing/increment_test.py
+++ b/testing/increment_test.py
@@ -7,7 +7,7 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath, Time, Rdiff
+from rdiff_backup import rpath, Time, Rdiff
 from rdiffbackup import actions
 from rdiffbackup.locations import increment
 from rdiffbackup.singletons import specifics
@@ -15,7 +15,6 @@ from rdiffbackup.singletons import specifics
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
 lc = specifics.local_connection
-Globals.change_source_perms = 1
 
 
 def getrp(ending):
@@ -48,7 +47,7 @@ class inctest(unittest.TestCase):
     """Test the incrementRP function"""
 
     def setUp(self):
-        Globals.set("isbackup_writer", 1)
+        specifics.set("is_backup_writer", 1)
 
     def check_time(self, rp):
         """Make sure that rp is an inc file, and time is prevtime"""

--- a/testing/iterfile_test.py
+++ b/testing/iterfile_test.py
@@ -9,7 +9,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, iterfile, rpath
+from rdiff_backup import iterfile, rpath
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/iterfile_test.py
+++ b/testing/iterfile_test.py
@@ -82,7 +82,7 @@ class testMiscIters(unittest.TestCase):
     def setUp(self):
         """Make testfiles/output directory and a few files"""
         comtst.remove_dir(self.out_dir)
-        self.outputrp = rpath.RPath(Globals.local_connection, self.out_dir)
+        self.outputrp = rpath.RPath(specifics.local_connection, self.out_dir)
         self.regfile1 = self.outputrp.append("reg1")
         self.regfile2 = self.outputrp.append("reg2")
         self.regfile3 = self.outputrp.append("reg3")

--- a/testing/kill_test.py
+++ b/testing/kill_test.py
@@ -13,6 +13,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath, Time
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -250,7 +251,7 @@ class KillTest(ProcessFuncs):
             result = self.mark_incomplete(curtime, Local.rpout)
             self.assertEqual(
                 self.exec_rb(None, 1, "regress", Local.rpout.path),
-                Globals.RET_CODE_WARN,
+                consts.RET_CODE_WARN,
             )
             self.assertTrue(
                 comtst.compare_recursive(old_rp, Local.rpout, compare_hardlinks=0)

--- a/testing/kill_test.py
+++ b/testing/kill_test.py
@@ -12,8 +12,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath, Time
-from rdiffbackup.singletons import consts
+from rdiff_backup import rpath, Time
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/kill_test.py
+++ b/testing/kill_test.py
@@ -22,7 +22,7 @@ class Local:
     """Hold some local RPaths"""
 
     def get_local_rp(ext):
-        return rpath.RPath(Globals.local_connection, os.path.join(TEST_BASE_DIR, ext))
+        return rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, ext))
 
     ktrp = []
     for i in range(4):

--- a/testing/librsync_test.py
+++ b/testing/librsync_test.py
@@ -9,7 +9,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, librsync, rpath
+from rdiff_backup import librsync, rpath
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -25,7 +26,9 @@ def MakeRandomFile(path, length=None):
 class LibrsyncTest(unittest.TestCase):
     """Test various librsync wrapper functions"""
 
-    basis = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"basis"))
+    basis = rpath.RPath(
+        specifics.local_connection, os.path.join(TEST_BASE_DIR, b"basis")
+    )
     new = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"new"))
     new2 = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"new2"))
     sig = rpath.RPath(
@@ -34,7 +37,9 @@ class LibrsyncTest(unittest.TestCase):
     sig2 = rpath.RPath(
         specifics.local_connection, os.path.join(TEST_BASE_DIR, b"signature2")
     )
-    delta = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"delta"))
+    delta = rpath.RPath(
+        specifics.local_connection, os.path.join(TEST_BASE_DIR, b"delta")
+    )
 
     def sig_file_test_helper(self, blocksize, iterations, file_len=None):
         """Compare SigFile output to rdiff output at given blocksize"""

--- a/testing/librsync_test.py
+++ b/testing/librsync_test.py
@@ -25,16 +25,16 @@ def MakeRandomFile(path, length=None):
 class LibrsyncTest(unittest.TestCase):
     """Test various librsync wrapper functions"""
 
-    basis = rpath.RPath(Globals.local_connection, os.path.join(TEST_BASE_DIR, b"basis"))
-    new = rpath.RPath(Globals.local_connection, os.path.join(TEST_BASE_DIR, b"new"))
-    new2 = rpath.RPath(Globals.local_connection, os.path.join(TEST_BASE_DIR, b"new2"))
+    basis = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"basis"))
+    new = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"new"))
+    new2 = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"new2"))
     sig = rpath.RPath(
-        Globals.local_connection, os.path.join(TEST_BASE_DIR, b"signature")
+        specifics.local_connection, os.path.join(TEST_BASE_DIR, b"signature")
     )
     sig2 = rpath.RPath(
-        Globals.local_connection, os.path.join(TEST_BASE_DIR, b"signature2")
+        specifics.local_connection, os.path.join(TEST_BASE_DIR, b"signature2")
     )
-    delta = rpath.RPath(Globals.local_connection, os.path.join(TEST_BASE_DIR, b"delta"))
+    delta = rpath.RPath(specifics.local_connection, os.path.join(TEST_BASE_DIR, b"delta"))
 
     def sig_file_test_helper(self, blocksize, iterations, file_len=None):
         """Compare SigFile output to rdiff output at given blocksize"""

--- a/testing/location_lock_test.py
+++ b/testing/location_lock_test.py
@@ -21,7 +21,7 @@ class LocationLockTest(unittest.TestCase):
 
     def setUp(self):
         self.base_dir = os.path.join(TEST_BASE_DIR, b"location_lock")
-        self.base_rp = rpath.RPath(Globals.local_connection, self.base_dir)
+        self.base_rp = rpath.RPath(specifics.local_connection, self.base_dir)
         self.lockfile = self.base_rp.append("lock")
         comtst.re_init_rpath_dir(self.base_rp)
         self.success = False

--- a/testing/location_lock_test.py
+++ b/testing/location_lock_test.py
@@ -8,8 +8,9 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
 from rdiffbackup.locations import _repo_shadow
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/location_map_filenames_test.py
+++ b/testing/location_map_filenames_test.py
@@ -9,6 +9,7 @@ import commontest as comtst
 import fileset
 
 from rdiff_backup import Globals
+from rdiffbackup.singletons import consts, generics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -303,11 +304,11 @@ class LocationMapFilenamesUnitTest(unittest.TestCase):
 
         chars_to_quote = b"A-Z"
         regexp, unregexp = map_filenames.get_quoting_regexps(
-            chars_to_quote, Globals.quoting_char
+            chars_to_quote, consts.QUOTING_CHAR
         )
-        Globals.chars_to_quote = chars_to_quote
-        Globals.chars_to_quote_regexp = regexp
-        Globals.chars_to_quote_unregexp = unregexp
+        generics.set("chars_to_quote", chars_to_quote)
+        generics.set("chars_to_quote_regexp", regexp)
+        generics.set("chars_to_quote_unregexp", unregexp)
 
         self.assertEqual(map_filenames.quote(b"aux.123"), b";097ux.123")
         self.assertEqual(map_filenames.quote(b"ends in space "), b"ends in space;032")

--- a/testing/location_map_filenames_test.py
+++ b/testing/location_map_filenames_test.py
@@ -8,7 +8,6 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals
 from rdiffbackup.singletons import consts, generics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
@@ -298,8 +297,8 @@ class LocationMapFilenamesUnitTest(unittest.TestCase):
         """
         Check that DOS filenames are properly quoted
         """
-        Globals.escape_dos_devices = True
-        Globals.escape_trailing_spaces = True
+        generics.set("escape_dos_devices", True)
+        generics.set("escape_trailing_spaces", True)
         from rdiffbackup.locations.map import filenames as map_filenames
 
         chars_to_quote = b"A-Z"

--- a/testing/log_test.py
+++ b/testing/log_test.py
@@ -4,7 +4,8 @@ Test the logging functionality
 
 import unittest
 
-from rdiff_backup import Globals, log
+from rdiff_backup import log
+from rdiffbackup.singletons import consts
 
 
 class LogTest(unittest.TestCase):
@@ -30,23 +31,23 @@ class LogTest(unittest.TestCase):
         """test that verbosity is correctly set"""
         # happy path
         testlog = log.Logger()
-        self.assertEqual(testlog.set_verbosity(log.NONE), Globals.RET_CODE_OK)
+        self.assertEqual(testlog.set_verbosity(log.NONE), consts.RET_CODE_OK)
         self.assertEqual(testlog.file_verbosity, log.NONE)
         self.assertEqual(testlog.term_verbosity, log.NONE)
         self.assertEqual(
             testlog.set_verbosity(str(log.DEBUG), str(log.WARNING)),
-            Globals.RET_CODE_OK,
+            consts.RET_CODE_OK,
         )
         self.assertEqual(testlog.file_verbosity, log.DEBUG)
         self.assertEqual(testlog.term_verbosity, log.WARNING)
         # error cases
-        self.assertEqual(testlog.set_verbosity(str(log.NONE - 1)), Globals.RET_CODE_ERR)
+        self.assertEqual(testlog.set_verbosity(str(log.NONE - 1)), consts.RET_CODE_ERR)
         # nothing changes
         self.assertEqual(testlog.file_verbosity, log.DEBUG)
         self.assertEqual(testlog.term_verbosity, log.WARNING)
         self.assertEqual(
             testlog.set_verbosity(str(log.ERROR), log.TIMESTAMP + 1),
-            Globals.RET_CODE_ERR,
+            consts.RET_CODE_ERR,
         )
         # nothing changes even if only the 2nd value is wrong
         self.assertEqual(testlog.file_verbosity, log.DEBUG)

--- a/testing/longname_test.py
+++ b/testing/longname_test.py
@@ -8,7 +8,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath, Time
+from rdiff_backup import rpath, Time
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/longname_test.py
+++ b/testing/longname_test.py
@@ -21,7 +21,7 @@ else:
 class LongNameTest(unittest.TestCase):
     """Test the longname module"""
 
-    root_rp = rpath.RPath(Globals.local_connection, TEST_BASE_DIR)
+    root_rp = rpath.RPath(specifics.local_connection, TEST_BASE_DIR)
     out_rp = root_rp.append_path("output")
 
     def test_length_limit(self):
@@ -210,8 +210,8 @@ class LongNameTest(unittest.TestCase):
             extra_options=(b"restore", b"--at", b"0"),
         )
         comtst.compare_recursive(
-            rpath.RPath(Globals.local_connection, input_dir),
-            rpath.RPath(Globals.local_connection, restore_dir),
+            rpath.RPath(specifics.local_connection, input_dir),
+            rpath.RPath(specifics.local_connection, restore_dir),
         )
 
 

--- a/testing/metadata_test.py
+++ b/testing/metadata_test.py
@@ -20,7 +20,7 @@ TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
 class MetadataTest(unittest.TestCase):
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
-    out_rp = rpath.RPath(Globals.local_connection, out_dir)
+    out_rp = rpath.RPath(specifics.local_connection, out_dir)
 
     def testQuote(self):
         """Test quoting and unquoting"""
@@ -42,12 +42,12 @@ class MetadataTest(unittest.TestCase):
     def get_rpaths(self):
         """Return list of rorps"""
         vft = rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(comtst.old_test_dir, b"various_file_types"),
         )
         rpaths = [vft.append(x) for x in vft.listdir()]
         extra_rpaths = [
-            rpath.RPath(Globals.local_connection, x)
+            rpath.RPath(specifics.local_connection, x)
             for x in [b"/bin/ls", b"/dev/ttyS0", b"/dev/hda", b"aoeuaou"]
         ]
         return [vft] + rpaths + extra_rpaths
@@ -103,7 +103,7 @@ class MetadataTest(unittest.TestCase):
         fileset.create_fileset(bigdir_path, bigdir_struct)
 
         comtst.re_init_rpath_dir(self.out_rp)
-        rootrp = rpath.RPath(Globals.local_connection, bigdir_path)
+        rootrp = rpath.RPath(specifics.local_connection, bigdir_path)
         rpath_iter = selection.Select(rootrp).get_select_iter()
 
         start_time = time.time()
@@ -194,7 +194,7 @@ class MetadataTest(unittest.TestCase):
 
         comtst.re_init_rpath_dir(self.out_rp)
         rootrp = rpath.RPath(
-            Globals.local_connection,
+            specifics.local_connection,
             os.path.join(comtst.old_test_dir, b"various_file_types"),
         )
         # the following 3 lines make sure that we ignore incorrect files
@@ -285,16 +285,16 @@ class MetadataTest(unittest.TestCase):
         comtst.re_init_rpath_dir(self.out_rp)
         man = meta_mgr.PatchDiffMan(self.out_rp)
         inc1 = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment1")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment1")
         )
         inc2 = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment2")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment2")
         )
         inc3 = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment3")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment3")
         )
         inc4 = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment4")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment4")
         )
         write_dir_to_meta(man, inc1, 10000)
         compare(man, inc1, 10000)

--- a/testing/metadata_test.py
+++ b/testing/metadata_test.py
@@ -10,9 +10,10 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import rpath, Globals, selection
+from rdiff_backup import rpath, selection
 from rdiffbackup import meta_mgr
 from rdiffbackup.meta import stdattr
+from rdiffbackup.singletons import specifics
 from rdiffbackup.utils import quoting
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)

--- a/testing/rdiff_test.py
+++ b/testing/rdiff_test.py
@@ -26,7 +26,7 @@ def MakeRandomFile(path):
 class RdiffTest(unittest.TestCase):
     """Test rdiff"""
 
-    lc = Globals.local_connection
+    lc = specifics.local_connection
 
     basis = rpath.RPath(lc, os.path.join(TEST_BASE_DIR, b"basis"))
     new = rpath.RPath(lc, os.path.join(TEST_BASE_DIR, b"new"))

--- a/testing/rdiff_test.py
+++ b/testing/rdiff_test.py
@@ -8,7 +8,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, Rdiff, rpath
+from rdiff_backup import Rdiff, rpath
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/rdiffbackupdelete_test.py
+++ b/testing/rdiffbackupdelete_test.py
@@ -9,7 +9,7 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -87,13 +87,13 @@ class RdiffBackupDeleteTest(unittest.TestCase):
         # Call without arguments
         self._rdiff_backup_delete(
             extra_args=[],
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
             expected_output=b"fatal: missing arguments",
         )
         # Call with invalid arguments
         self._rdiff_backup_delete(
             extra_args=[b"--invalid"],
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
             expected_output=b"fatal: bad command line: option --invalid not recognized",
         )
 
@@ -101,7 +101,7 @@ class RdiffBackupDeleteTest(unittest.TestCase):
         # without rdiff-backup-dir
         self._rdiff_backup_delete(
             to_delete=b"somefile",
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
             expected_output=b"fatal: not a rdiff-backup repository (or any parent up to mount point /)",
         )
 
@@ -160,7 +160,7 @@ class RdiffBackupDeleteTest(unittest.TestCase):
             self.repo,
             None,
             extra_options=b"verify",
-            expected_ret_code=Globals.RET_CODE_FILE_WARN,
+            expected_ret_code=consts.RET_CODE_FILE_WARN,
         )
         self.assertNotFound(b"fifo")
 
@@ -178,7 +178,7 @@ class RdiffBackupDeleteTest(unittest.TestCase):
             self.repo,
             None,
             extra_options=b"verify",
-            expected_ret_code=Globals.RET_CODE_FILE_WARN,
+            expected_ret_code=consts.RET_CODE_FILE_WARN,
         )
 
     def test_delete_access_control_lists(self):
@@ -204,7 +204,7 @@ class RdiffBackupDeleteTest(unittest.TestCase):
             self.repo,
             None,
             extra_options=b"verify",
-            expected_ret_code=Globals.RET_CODE_FILE_WARN,
+            expected_ret_code=consts.RET_CODE_FILE_WARN,
         )
         self.assertFound(b"tmp")
 
@@ -219,7 +219,7 @@ class RdiffBackupDeleteTest(unittest.TestCase):
             f.write(b"PID 1234")
         self._rdiff_backup_delete(
             to_delete=os.path.join(self.repo, b"tmp"),
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
             expected_output=b"failed to acquire repository lock. "
             b"A backup may be running.",
         )

--- a/testing/readonly_actions_test.py
+++ b/testing/readonly_actions_test.py
@@ -116,7 +116,7 @@ class ActionReadOnlyTest(unittest.TestCase):
     def test_readonly_delete(self):
         """test the "delete" method of rpath on a read-only repository"""
 
-        from1_rp = rpath.RPath(Globals.local_connection, self.from1_path)
+        from1_rp = rpath.RPath(specifics.local_connection, self.from1_path)
         from1_rp.delete()
         self.assertIsNone(from1_rp.lstat())
 

--- a/testing/readonly_actions_test.py
+++ b/testing/readonly_actions_test.py
@@ -8,7 +8,8 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/regress_test.py
+++ b/testing/regress_test.py
@@ -9,7 +9,7 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath, Time
+from rdiff_backup import rpath, Time
 from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
@@ -54,8 +54,6 @@ class RegressTest(unittest.TestCase):
 
         comtst.rdiff_backup(1, 1, self.incrp[3].path, self.out_dir, current_time=40000)
         self.assertTrue(comtst.compare_recursive(self.incrp[3], self.out_rp))
-
-        Globals.rbdir = self.out_rbdir_rp
 
         regress_function(30000)
         self.assertTrue(

--- a/testing/regress_test.py
+++ b/testing/regress_test.py
@@ -10,7 +10,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath, Time
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/regress_test.py
+++ b/testing/regress_test.py
@@ -10,6 +10,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath, Time
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -95,7 +96,7 @@ class RegressTest(unittest.TestCase):
             self.out_dir,
             None,
             extra_options=b"regress",
-            expected_ret_code=Globals.RET_CODE_WARN,
+            expected_ret_code=consts.RET_CODE_WARN,
         )
 
     def test_local(self):
@@ -121,7 +122,7 @@ class RegressTest(unittest.TestCase):
 
         cmd = (b"rdiff-backup", b"regress", self.out_dir)
         print("Executing:", cmd)
-        self.assertEqual(comtst.os_system(cmd), Globals.RET_CODE_WARN)
+        self.assertEqual(comtst.os_system(cmd), consts.RET_CODE_WARN)
 
     def make_unreadable(self):
         """Make unreadable input directory

--- a/testing/regress_test.py
+++ b/testing/regress_test.py
@@ -17,13 +17,13 @@ TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
 class RegressTest(unittest.TestCase):
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
-    out_rp = rpath.RPath(Globals.local_connection, out_dir)
+    out_rp = rpath.RPath(specifics.local_connection, out_dir)
     out_rbdir_rp = out_rp.append_path("rdiff-backup-data")
     incrp = []
     for i in range(4):
         incrp.append(
             rpath.RPath(
-                Globals.local_connection,
+                specifics.local_connection,
                 os.path.join(comtst.old_test_dir, b"increment%d" % (i + 1)),
             )
         )
@@ -133,7 +133,7 @@ class RegressTest(unittest.TestCase):
 
         """
         rp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"regress")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"regress")
         )
         if rp.lstat():
             comtst.remove_dir(rp.path)

--- a/testing/resourcefork_macostest.py
+++ b/testing/resourcefork_macostest.py
@@ -10,6 +10,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import rpath, metadata, Globals
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -20,8 +21,12 @@ class ResourceForkTest(unittest.TestCase):
     """Test dealing with Mac OS X style resource forks"""
 
     tempdir = rpath.RPath(specifics.local_connection, "testfiles/output")
-    rf_testdir1 = rpath.RPath(specifics.local_connection, "testfiles/resource_fork_test1")
-    rf_testdir2 = rpath.RPath(specifics.local_connection, "testfiles/resource_fork_test2")
+    rf_testdir1 = rpath.RPath(
+        specifics.local_connection, "testfiles/resource_fork_test1"
+    )
+    rf_testdir2 = rpath.RPath(
+        specifics.local_connection, "testfiles/resource_fork_test2"
+    )
 
     def make_temp(self):
         """Make temp directory testfiles/resource_fork_test"""

--- a/testing/resourcefork_macostest.py
+++ b/testing/resourcefork_macostest.py
@@ -9,12 +9,10 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import rpath, metadata, Globals
+from rdiff_backup import rpath, metadata
 from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
-
-Globals.read_resource_forks = Globals.write_resource_forks = 1
 
 
 class ResourceForkTest(unittest.TestCase):
@@ -91,7 +89,6 @@ class ResourceForkTest(unittest.TestCase):
 
     def testSeriesLocal(self):
         """Test backing up and restoring directories with ACLs locally"""
-        Globals.read_resource_forks = Globals.write_resource_forks = 1
         self.make_backup_dirs()
         dirlist = [
             "testfiles/resource_fork_test1",
@@ -103,7 +100,6 @@ class ResourceForkTest(unittest.TestCase):
 
     def testSeriesRemote(self):
         """Test backing up and restoring directories with ACLs locally"""
-        Globals.read_resource_forks = Globals.write_resource_forks = 1
         self.make_backup_dirs()
         dirlist = [
             "testfiles/resource_fork_test1",

--- a/testing/resourcefork_macostest.py
+++ b/testing/resourcefork_macostest.py
@@ -19,9 +19,9 @@ Globals.read_resource_forks = Globals.write_resource_forks = 1
 class ResourceForkTest(unittest.TestCase):
     """Test dealing with Mac OS X style resource forks"""
 
-    tempdir = rpath.RPath(Globals.local_connection, "testfiles/output")
-    rf_testdir1 = rpath.RPath(Globals.local_connection, "testfiles/resource_fork_test1")
-    rf_testdir2 = rpath.RPath(Globals.local_connection, "testfiles/resource_fork_test2")
+    tempdir = rpath.RPath(specifics.local_connection, "testfiles/output")
+    rf_testdir1 = rpath.RPath(specifics.local_connection, "testfiles/resource_fork_test1")
+    rf_testdir2 = rpath.RPath(specifics.local_connection, "testfiles/resource_fork_test2")
 
     def make_temp(self):
         """Make temp directory testfiles/resource_fork_test"""

--- a/testing/restore_test.py
+++ b/testing/restore_test.py
@@ -7,8 +7,9 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, log, rpath, Time
+from rdiff_backup import log, rpath, Time
 from rdiffbackup.locations import _repo_shadow
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/restore_test.py
+++ b/testing/restore_test.py
@@ -12,9 +12,9 @@ from rdiffbackup.locations import _repo_shadow
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
-lc = Globals.local_connection
+lc = specifics.local_connection
 restore_base_rp = rpath.RPath(
-    Globals.local_connection, os.path.join(comtst.old_test_dir, b"restoretest")
+    specifics.local_connection, os.path.join(comtst.old_test_dir, b"restoretest")
 )
 restore_base_filenames = restore_base_rp.listdir()
 mirror_time = 1041109438  # just some late time
@@ -33,7 +33,7 @@ class RestoreFileComparer:
         self.rf = rf
         self.time_rp_dict = {}
         self.out_dir = os.path.join(TEST_BASE_DIR, b"output")
-        self.out_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        self.out_rp = rpath.RPath(specifics.local_connection, self.out_dir)
 
     def add_rpath(self, rp, t):
         """Add rp, which represents what rf should be at given time t"""
@@ -149,18 +149,18 @@ class RestoreTest(unittest.TestCase):
         """
         comtst.remove_dir(self.out_dir)
         restore3_dir = os.path.join(comtst.old_test_dir, b"restoretest3")
-        target_rp = rpath.RPath(Globals.local_connection, self.out_dir)
+        target_rp = rpath.RPath(specifics.local_connection, self.out_dir)
         inc1_rp = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment1")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment1")
         )
         inc2_rp = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment2")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment2")
         )
         inc3_rp = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment3")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment3")
         )
         inc4_rp = rpath.RPath(
-            Globals.local_connection, os.path.join(comtst.old_test_dir, b"increment4")
+            specifics.local_connection, os.path.join(comtst.old_test_dir, b"increment4")
         )
 
         comtst.InternalRestore(

--- a/testing/rorpiter_test.py
+++ b/testing/rorpiter_test.py
@@ -25,7 +25,7 @@ class RORPIterTest(unittest.TestCase):
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
 
     def setUp(self):
-        self.lc = Globals.local_connection
+        self.lc = specifics.local_connection
         self.inc0rp = rpath.RPath(
             self.lc, os.path.join(comtst.old_test_dir, b"empty"), ()
         )
@@ -124,7 +124,7 @@ class FillTest(unittest.TestCase):
 
     def test_fill_in(self):
         """Test fill_in_iter"""
-        rootrp = rpath.RPath(Globals.local_connection, self.out_dir)
+        rootrp = rpath.RPath(specifics.local_connection, self.out_dir)
 
         def get_rpiter():
             for index in [

--- a/testing/rorpiter_test.py
+++ b/testing/rorpiter_test.py
@@ -9,7 +9,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import rpath, rorpiter, Globals
+from rdiff_backup import rpath, rorpiter
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/rpath_test.py
+++ b/testing/rpath_test.py
@@ -18,7 +18,7 @@ TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
 class RPathTest(unittest.TestCase):
     out_dir = os.path.join(TEST_BASE_DIR, b"output")
-    lc = Globals.local_connection
+    lc = specifics.local_connection
     mainprefix = comtst.old_test_dir
     prefix = os.path.join(mainprefix, b"various_file_types")
     write_dir = comtst.re_init_subdir(TEST_BASE_DIR, b"rpathtests")
@@ -460,8 +460,8 @@ class FileCopying(RPathTest):
         fileset.create_fileset(
             base_path, struct, recurse={"atime": 12345, "mtime": 12345}
         )
-        short_dir = rpath.RPath(Globals.local_connection, os.path.join(base_path, b"1"))
-        long_dir = rpath.RPath(Globals.local_connection, os.path.join(base_path, b"2"))
+        short_dir = rpath.RPath(specifics.local_connection, os.path.join(base_path, b"1"))
+        long_dir = rpath.RPath(specifics.local_connection, os.path.join(base_path, b"2"))
         # Can guarantee below by adding files to long_dir
         self.assertGreater(long_dir.getsize(), short_dir.getsize())
         self.assertEqual(short_dir, long_dir)
@@ -577,11 +577,11 @@ class CheckPath(unittest.TestCase):
 
     def testpath(self):
         """Test root paths"""
-        root = rpath.RPath(Globals.local_connection, "/")
+        root = rpath.RPath(specifics.local_connection, "/")
         self.assertEqual(root.path, b"/")
         bin = root.append("bin")
         self.assertEqual(bin.path, b"/bin")
-        bin2 = rpath.RPath(Globals.local_connection, "/bin")
+        bin2 = rpath.RPath(specifics.local_connection, "/bin")
         self.assertEqual(bin2.path, b"/bin")
 
 

--- a/testing/rpath_test.py
+++ b/testing/rpath_test.py
@@ -11,7 +11,8 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals, rpath
+from rdiff_backup import rpath
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -460,8 +461,12 @@ class FileCopying(RPathTest):
         fileset.create_fileset(
             base_path, struct, recurse={"atime": 12345, "mtime": 12345}
         )
-        short_dir = rpath.RPath(specifics.local_connection, os.path.join(base_path, b"1"))
-        long_dir = rpath.RPath(specifics.local_connection, os.path.join(base_path, b"2"))
+        short_dir = rpath.RPath(
+            specifics.local_connection, os.path.join(base_path, b"1")
+        )
+        long_dir = rpath.RPath(
+            specifics.local_connection, os.path.join(base_path, b"2")
+        )
         # Can guarantee below by adding files to long_dir
         self.assertGreater(long_dir.getsize(), short_dir.getsize())
         self.assertEqual(short_dir, long_dir)

--- a/testing/security_test.py
+++ b/testing/security_test.py
@@ -49,7 +49,7 @@ class SecurityTest(unittest.TestCase):
         conn = SetConnections._init_connection(remote_cmd)
 
         for rp in [
-            rpath.RPath(Globals.local_connection, b"blahblah"),
+            rpath.RPath(specifics.local_connection, b"blahblah"),
             rpath.RPath(conn, b"foo/bar"),
         ]:
             conn.Globals.set_local("TEST_var", rp)
@@ -69,7 +69,7 @@ class SecurityTest(unittest.TestCase):
         )
         conn = SetConnections._init_connection(remote_cmd)
         for rp in [
-            rpath.RPath(Globals.local_connection, "blahblah"),
+            rpath.RPath(specifics.local_connection, "blahblah"),
             rpath.RPath(conn, "foo/bar"),
         ]:
             conn.Globals.set_local("TEST_var", rp)
@@ -277,7 +277,7 @@ class SecurityTest(unittest.TestCase):
             b"--restrict-path foobar",
             expected_ret_code=consts.RET_CODE_ERR,
         )
-        output = rpath.RPath(Globals.local_connection, self.out_dir)
+        output = rpath.RPath(specifics.local_connection, self.out_dir)
         self.assertFalse(output.lstat())
 
     def test_quoting_bug(self):

--- a/testing/security_test.py
+++ b/testing/security_test.py
@@ -8,8 +8,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, rpath, Security, SetConnections
-from rdiffbackup.singletons import consts
+from rdiff_backup import rpath, Security, SetConnections
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/security_test.py
+++ b/testing/security_test.py
@@ -9,6 +9,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, rpath, Security, SetConnections
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -152,7 +153,7 @@ class SecurityTest(unittest.TestCase):
             output2_dir,
             1,
             b"--restrict-path %b" % self.out_dir,
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
 
         # Restore to wrong directory
@@ -165,7 +166,7 @@ class SecurityTest(unittest.TestCase):
             1,
             b"--restrict-path %b" % output2_dir,
             extra_args=(b"restore", b"--at", b"now"),
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
 
         # Backup from wrong directory
@@ -176,7 +177,7 @@ class SecurityTest(unittest.TestCase):
             self.out_dir,
             0,
             b"--restrict-path %b" % wrong_files_dir,
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
 
     def test_restrict_readonly_positive(self):
@@ -199,7 +200,7 @@ class SecurityTest(unittest.TestCase):
             0,
             b"--restrict-path %b --restrict-mode read-only" % self.out_dir,
             extra_args=(b"restore", b"--at", b"now"),
-            expected_ret_code=Globals.RET_CODE_OK,
+            expected_ret_code=consts.RET_CODE_OK,
         )
 
     def test_restrict_readonly_negative(self):
@@ -211,7 +212,7 @@ class SecurityTest(unittest.TestCase):
             self.out_dir,
             1,
             b"--restrict-path %b --restrict-mode read-only" % self.out_dir,
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
 
         # Restore to restricted directory
@@ -224,7 +225,7 @@ class SecurityTest(unittest.TestCase):
             1,
             b"--restrict-path %b --restrict-mode read-only" % self.restore_dir,
             extra_args=(b"restore", b"--at", b"now"),
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
 
     def test_restrict_updateonly_positive(self):
@@ -248,10 +249,10 @@ class SecurityTest(unittest.TestCase):
             self.out_dir,
             1,
             b"--restrict-path %b --restrict-mode update-only" % self.out_dir,
-            expected_ret_code=Globals.RET_CODE_OK,
+            expected_ret_code=consts.RET_CODE_OK,
             # FIXME following was the correct value under old versions
             # but the new concept doesn't differentiate update from r/w
-            # expected_ret_code=Globals.RET_CODE_ERR,
+            # expected_ret_code=consts.RET_CODE_ERR,
         )
 
         comtst.remove_dir(self.out_dir)
@@ -263,7 +264,7 @@ class SecurityTest(unittest.TestCase):
             1,
             b"--restrict-path %b --restrict-mode update-only" % self.restore_dir,
             extra_args=(b"restore", b"--at", b"now"),
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
 
     def test_restrict_bug(self):
@@ -274,7 +275,7 @@ class SecurityTest(unittest.TestCase):
             self.out_dir,
             1,
             b"--restrict-path foobar",
-            expected_ret_code=Globals.RET_CODE_ERR,
+            expected_ret_code=consts.RET_CODE_ERR,
         )
         output = rpath.RPath(Globals.local_connection, self.out_dir)
         self.assertFalse(output.lstat())

--- a/testing/security_test.py
+++ b/testing/security_test.py
@@ -52,13 +52,13 @@ class SecurityTest(unittest.TestCase):
             rpath.RPath(specifics.local_connection, b"blahblah"),
             rpath.RPath(conn, b"foo/bar"),
         ]:
-            conn.Globals.set_local("TEST_var", rp)
-            self.assertEqual(conn.Globals.get("TEST_var").path, rp.path)
+            conn.specifics.set("TEST_var", rp)
+            self.assertEqual(conn.specifics.get("TEST_var").path, rp.path)
 
         for path in [b"foobar", b"/usr/local", b"foo/../bar"]:
             with self.assertRaises(Security.Violation):
                 rp = rpath.RPath(conn, path)
-                conn.Globals.set_local("TEST_var", rp)
+                conn.specifics.set("TEST_var", rp)
 
         SetConnections.CloseConnections()
 
@@ -72,8 +72,8 @@ class SecurityTest(unittest.TestCase):
             rpath.RPath(specifics.local_connection, "blahblah"),
             rpath.RPath(conn, "foo/bar"),
         ]:
-            conn.Globals.set_local("TEST_var", rp)
-            self.assertEqual(conn.Globals.get("TEST_var").path, rp.path)
+            conn.specifics.set("TEST_var", rp)
+            self.assertEqual(conn.specifics.get("TEST_var").path, rp.path)
         SetConnections.CloseConnections()
 
     def secure_rdiff_backup(

--- a/testing/selection_test.py
+++ b/testing/selection_test.py
@@ -11,7 +11,7 @@ import commontest as comtst
 import fileset
 
 from rdiff_backup import Globals, rpath, selection
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -787,7 +787,9 @@ class CommandTest(unittest.TestCase):
         os.chdir(TEST_BASE_DIR)
         currdir = os.path.basename(os.getcwdb())
         os.chdir(os.pardir)  # chdir one level up
-        selrp = rpath.RPath(specifics.local_connection, os.path.join(currdir, b"seltest"))
+        selrp = rpath.RPath(
+            specifics.local_connection, os.path.join(currdir, b"seltest")
+        )
         comtst.re_init_rpath_dir(selrp)
         emptydir = selrp.append("emptydir")
         emptydir.mkdir()

--- a/testing/selection_test.py
+++ b/testing/selection_test.py
@@ -20,7 +20,7 @@ class MatchingTest(unittest.TestCase):
     """Test matching of file names against various selection functions"""
 
     def makerp(self, path):
-        return rpath.RPath(Globals.local_connection, path)
+        return rpath.RPath(specifics.local_connection, path)
 
     def makeext(self, path):
         return self.root.new_index(tuple(path.split("/")))
@@ -30,7 +30,7 @@ class MatchingTest(unittest.TestCase):
         os.chdir(comtst.old_test_dir)
         os.chdir(os.pardir)  # chdir one level up
         self.root = rpath.RPath(
-            Globals.local_connection, "rdiff-backup_testfiles/select"
+            specifics.local_connection, "rdiff-backup_testfiles/select"
         )
         self.Select = selection.Select(self.root)
 
@@ -337,7 +337,7 @@ rdiff-backup_testfiles/select/1/1
 
     def testRoot(self):
         """testRoot - / may be a counterexample to several of these.."""
-        root = rpath.RPath(Globals.local_connection, "/")
+        root = rpath.RPath(specifics.local_connection, "/")
         select = selection.Select(root)
 
         self.assertEqual(select._glob_get_sf("/", 1)(root), 1)
@@ -361,23 +361,23 @@ rdiff-backup_testfiles/select/1/1
     @unittest.skipIf(sys.platform.startswith("win"), "can't work with Windows")
     def testOtherFilesystems(self):
         """Test to see if --exclude-other-filesystems works correctly"""
-        root = rpath.RPath(Globals.local_connection, "/")
+        root = rpath.RPath(specifics.local_connection, "/")
         select = selection.Select(root)
         sf = select._other_filesystems_get_sf(0)
         self.assertIsNone(sf(root))
         self.assertIsNone(
-            sf(rpath.RPath(Globals.local_connection, "/usr/bin")),
+            sf(rpath.RPath(specifics.local_connection, "/usr/bin")),
             "Assumption: /usr/bin is on the same filesystem as /",
         )
         self.assertEqual(
-            sf(rpath.RPath(Globals.local_connection, "/proc")),
+            sf(rpath.RPath(specifics.local_connection, "/proc")),
             0,
             "Assumption: /proc is on a different filesystem",
         )
         for check_dir in (b"/boot", b"/boot/efi", b"/tmp"):
             if (b" " + check_dir + b" ") in subprocess.check_output("mount"):
                 self.assertEqual(
-                    sf(rpath.RPath(Globals.local_connection, check_dir)),
+                    sf(rpath.RPath(specifics.local_connection, check_dir)),
                     0,
                     "Assumption: {dir} is on a different filesystem".format(
                         dir=check_dir
@@ -398,7 +398,7 @@ class ParseSelectionArgsTest(unittest.TestCase):
 
         if not self.root:
             self.root = rpath.RPath(
-                Globals.local_connection, "rdiff-backup_testfiles/select"
+                specifics.local_connection, "rdiff-backup_testfiles/select"
             )
         self.Select = selection.Select(self.root)
         self.Select.parse_selection_args(tuplelist)
@@ -638,7 +638,7 @@ rdiff-backup_testfiles/select**/2
     def testAlternateRoot(self):
         """Test select with different root"""
         self.root = rpath.RPath(
-            Globals.local_connection, "rdiff-backup_testfiles/select/1"
+            specifics.local_connection, "rdiff-backup_testfiles/select/1"
         )
         self.ParseTest(
             [("exclude", b"rdiff-backup_testfiles/select/1/[23]")],
@@ -646,7 +646,7 @@ rdiff-backup_testfiles/select**/2
         )
 
         if sys.platform.startswith("win"):
-            self.root = rpath.RPath(Globals.local_connection, "C:/")
+            self.root = rpath.RPath(specifics.local_connection, "C:/")
             self.ParseTest(
                 [
                     ("exclude", b"C:/Users/*"),
@@ -656,7 +656,7 @@ rdiff-backup_testfiles/select**/2
                 [(), ("Users",)],
             )
         else:
-            self.root = rpath.RPath(Globals.local_connection, "/")
+            self.root = rpath.RPath(specifics.local_connection, "/")
             self.ParseTest(
                 [("exclude", b"/home/*"), ("include", b"/home"), ("exclude", b"/")],
                 [(), ("home",)],
@@ -781,13 +781,13 @@ class CommandTest(unittest.TestCase):
         This checks for a bug present in 1.0.3/1.1.5 and similar.
         """
         out_dir = os.path.join(TEST_BASE_DIR, b"output")
-        out_rp = rpath.RPath(Globals.local_connection, out_dir)
+        out_rp = rpath.RPath(specifics.local_connection, out_dir)
         comtst.re_init_rpath_dir(out_rp)
         # we need to change directory to be able to work with relative paths
         os.chdir(TEST_BASE_DIR)
         currdir = os.path.basename(os.getcwdb())
         os.chdir(os.pardir)  # chdir one level up
-        selrp = rpath.RPath(Globals.local_connection, os.path.join(currdir, b"seltest"))
+        selrp = rpath.RPath(specifics.local_connection, os.path.join(currdir, b"seltest"))
         comtst.re_init_rpath_dir(selrp)
         emptydir = selrp.append("emptydir")
         emptydir.mkdir()
@@ -815,7 +815,7 @@ class CommandTest(unittest.TestCase):
         while ignoring this repo
         """
 
-        testrp = rpath.RPath(Globals.local_connection, TEST_BASE_DIR).append(
+        testrp = rpath.RPath(specifics.local_connection, TEST_BASE_DIR).append(
             "selection_overlap"
         )
         comtst.re_init_rpath_dir(testrp)

--- a/testing/selection_test.py
+++ b/testing/selection_test.py
@@ -10,8 +10,8 @@ import unittest
 import commontest as comtst
 import fileset
 
-from rdiff_backup import Globals, rpath, selection
-from rdiffbackup.singletons import consts, specifics
+from rdiff_backup import rpath, selection
+from rdiffbackup.singletons import consts, generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -159,7 +159,7 @@ rdiff-backup_testfiles/select/3\t"""  # noqa: W291 trailing whitespaces
     def testFilelistIncludeNullSep(self):
         """Test included filelist but with null_separator set"""
         filelist = b"""\0rdiff-backup_testfiles/select/1/2\0rdiff-backup_testfiles/select/1\0rdiff-backup_testfiles/select/1/2/3\0rdiff-backup_testfiles/select/3/3/2\0rdiff-backup_testfiles/select/hello\nthere\0"""
-        Globals.null_separator = 1
+        generics.null_separator = True
         sf = self.Select._filelist_get_sf(filelist, 1, "test")
         self.assertEqual(sf(self.root), 1)
         self.assertEqual(sf(self.makeext("1")), 1)
@@ -171,7 +171,7 @@ rdiff-backup_testfiles/select/3\t"""  # noqa: W291 trailing whitespaces
         self.assertIsNone(sf(self.makeext("3/3/3")))
         if not sys.platform.startswith("win"):  # can't succeed
             self.assertEqual(sf(self.makeext("hello\nthere")), 1)
-        Globals.null_separator = 0
+        generics.null_separator = False
 
     def testFilelistExclude(self):
         """Test included filelist"""

--- a/testing/selection_test.py
+++ b/testing/selection_test.py
@@ -11,6 +11,7 @@ import commontest as comtst
 import fileset
 
 from rdiff_backup import Globals, rpath, selection
+from rdiffbackup.singletons import consts
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -828,7 +829,7 @@ class CommandTest(unittest.TestCase):
             testrp.path,
             backuprp.path,
             extra_options=(b"backup", b"--exclude", backuprp.path),
-            expected_ret_code=Globals.RET_CODE_WARN,
+            expected_ret_code=consts.RET_CODE_WARN,
         )
 
         self.assertTrue(

--- a/testing/server.py
+++ b/testing/server.py
@@ -10,11 +10,6 @@ the directory the source files are in.
 """
 
 
-def Test_SetConnGlobals(conn, setting, value):
-    """This is used in connectiontest.py"""
-    conn.Globals.set_local(setting, value)
-
-
 def print_usage():
     print("Usage: server.py  [path to source files]", __doc__)
 

--- a/testing/statistics_test.py
+++ b/testing/statistics_test.py
@@ -8,8 +8,8 @@ import unittest
 
 import commontest as comtst
 
-from rdiff_backup import Globals, statistics, rpath
-from rdiffbackup.singletons import specifics
+from rdiff_backup import statistics, rpath
+from rdiffbackup.singletons import generics, specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -208,7 +208,7 @@ class IncStatTest(unittest.TestCase):
             templist.sort()
             return [inc for (t, inc) in templist]
 
-        Globals.compression = 1
+        generics.compression = True
         comtst.remove_dir(self.out_dir)
         comtst.InternalBackup(
             1, 1, os.path.join(comtst.old_test_dir, b"stattest1"), self.out_dir

--- a/testing/statistics_test.py
+++ b/testing/statistics_test.py
@@ -128,7 +128,7 @@ TotalDestinationSizeChange 7 (7 bytes)
     def test_write_rp(self):
         """Test reading and writing of statistics object"""
         rp = rpath.RPath(
-            Globals.local_connection, os.path.join(TEST_BASE_DIR, b"statstest")
+            specifics.local_connection, os.path.join(TEST_BASE_DIR, b"statstest")
         )
         if rp.lstat():
             rp.delete()
@@ -221,7 +221,7 @@ class IncStatTest(unittest.TestCase):
         )
 
         rbdir = rpath.RPath(
-            Globals.local_connection, os.path.join(self.out_dir, b"rdiff-backup-data")
+            specifics.local_connection, os.path.join(self.out_dir, b"rdiff-backup-data")
         )
 
         incs = sorti(rbdir.append("session_statistics").get_incfiles_list())

--- a/testing/statistics_test.py
+++ b/testing/statistics_test.py
@@ -9,6 +9,7 @@ import unittest
 import commontest as comtst
 
 from rdiff_backup import Globals, statistics, rpath
+from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 

--- a/testing/time_test.py
+++ b/testing/time_test.py
@@ -8,7 +8,8 @@ import unittest
 import commontest as comtst
 from commontest import *  # noqa: F403, F401 some side effect or test fails
 
-from rdiff_backup import Globals, Time
+from rdiff_backup import Time
+from rdiffbackup.singletons import generics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
@@ -49,9 +50,9 @@ class TimeTest(unittest.TestCase):
 
     def testConversion_separator(self):
         """Same as testConversion, but change time Separator"""
-        Globals.time_separator = "_"
+        generics.set("use_compatible_timestamps", True)
         self.testConversion()
-        Globals.time_separator = ":"
+        generics.set("use_compatible_timestamps", False)
 
     def testCmp(self):
         """Test time comparisons"""

--- a/testing/user_group_test.py
+++ b/testing/user_group_test.py
@@ -8,7 +8,6 @@ import os
 import pwd
 import unittest
 
-from rdiff_backup import Globals
 from rdiffbackup.utils import usrgrp
 from rdiffbackup.locations.map import owners as map_owners
 
@@ -41,7 +40,6 @@ class UserGroupTest(unittest.TestCase):
 
     def test_default_mapping(self):
         """Test the default user mapping"""
-        Globals.isdest = 1
         rootid = 0
         binid = pwd.getpwnam("bin")[2]
         mailid = pwd.getpwnam("mail")[2]
@@ -64,7 +62,6 @@ mail:0
         curr_user_uid = os.getuid()
         # testing UTF-8 user names
         mapping_string += "éłephänt:" + curr_user_name
-        Globals.isdest = 1
         rootid = 0
         binid = pwd.getpwnam("bin")[2]
         mailid = pwd.getpwnam("mail")[2]


### PR DESCRIPTION
## Changes done and why

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->
Split the Globals module into different singletons depending on the scope of the variables:

1. consts for constants (renamed to be all caps)
2. specifics for variables where the value can be different depending on client vs server
3. generics for variables which need to have the same value across all instances of rdiff-backup

This led to uncovering a few unused variables, which were removed.

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    5. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
