### PR TITLE
Handle Cross-Platform OSError.errno Mismatch #1027

### DIFF
--- a/testing/connection_test.py
+++ b/testing/connection_test.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import unittest
+import errno
 
 import commontest as comtst
 
@@ -186,7 +187,10 @@ class PipeConnectionTest(unittest.TestCase):
 
     def testExceptions(self):
         """Test exceptional results"""
-        self.assertRaises(os.error, self.conn.os.lstat, "asoeut haosetnuhaoseu tn")
+        with self.assertRaises(os.error) as ctx:
+            self.conn.os.lstat("asoeut haosetnuhaoseu tn")
+        self.assertEqual(ctx.exception.errno, errno.ENOENT)
+        self.assertEqual(ctx.exception.errno_str, "ENOENT")
         self.assertRaises(NameError, self.conn.reval, "aoetnsu aoehtnsu")
         self.assertRaises(NameError, self.conn.reval, "aoetnsu.aoehtnsu")
         self.assertEqual(self.conn.pow(2, 3), 8)


### PR DESCRIPTION
FIX: issue with OSError.errno discrepancies when the source and destination are on different platforms.

## Changes done and why

Serialize and deserialize OSError differently to handle variations in error number values across platforms. Use the error code name to ensure cross-platform compatibility when transporting the error code.

@ericzolf Let me know what you think about this way to implement the fix.
I will need some time to reproduce the problem on a MacOS to ensure everything is working as expected.

## Self-Checklist

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
