### PR TITLE
Use log instead of print and make log messages more parsable

### DIFF
--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -29,4 +29,3 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - get rid of the backup_writer variables (in singleton/specifics), replace with log/stats access to repository
 - get rid of compression as generics variable, replacing with usage of values.
 - replace null_separator with something like line_separator, directly having the character
-- replace all usage of print through log.Log

--- a/docs/rdiff-backup.1.adoc
+++ b/docs/rdiff-backup.1.adoc
@@ -94,6 +94,7 @@ This affects the expected format of the files specified by the *--{include|exclu
 --parsable-output::
 If set, rdiff-backup's output will be tailored for easy parsing by computers, instead of convenience for humans.
 Currently this only applies when listing increments using the *list increments* action, where the time will be given in seconds since the epoch.
+Also log lines are then kept in one single line instead of being formatted according to the width of the terminal.
 
 --remote-schema _remoteschema_::
 Specify an alternate method of connecting to a remote computer.

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -347,6 +347,7 @@ def _set_allowed_requests(sec_class, sec_level):
                 "specifics.set_api_version",
                 # API >= 300
                 "log.Log.set_verbosity",  # FIXME can we pipe this through?
+                "log.Log.set_parsable",
             ]
         )
     return requests

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -223,7 +223,6 @@ def _set_allowed_requests(sec_class, sec_level):
         # System
         # "gzip.GzipFile",  # ??? perhaps covered by VirtualFile
         # "open",  # ??? perhaps covered by VirtualFile
-        "sys.stdout.write",
         # API >=300
         "_repo_shadow.RepoShadow.init",
         "_repo_shadow.RepoShadow.check",

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -510,6 +510,7 @@ def _init_connection_routing(conn, conn_number, remote_cmd):
 def _init_connection_settings(conn):
     """Tell new conn about log settings and updated globals"""
     conn.log.Log.set_verbosity(log.Log.file_verbosity, log.Log.term_verbosity)
+    conn.log.Log.set_parsable(log.Log.parsable)
     generics.dispatch_settings(conn)
 
 

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -67,6 +67,8 @@ class Logger:
         # if something wrong happens during initialization, we want to know
         self.file_verbosity: Verbosity = NONE
         self.term_verbosity: Verbosity = WARNING
+        # output is human readable by default, not parsable
+        self.parsable: bool = False
 
     def __call__(self, message, verbosity):
         """
@@ -107,9 +109,11 @@ class Logger:
 
         tmpstr = self._format(message, self.term_verbosity, verbosity)
         # if the verbosity is below 9 and the string isn't deemed
-        # pre-formatted by newlines (we ignore the last character)
+        # pre-formatted by newlines (we ignore the last character),
+        # and neither verbosity is none, nor output is required to be parasable
         if (
             verbosity != NONE
+            and not self.parsable
             and self.term_verbosity < DEBUG
             and "\n" not in tmpstr[:-1]
         ):
@@ -213,6 +217,15 @@ class Logger:
         else:
             self.file_verbosity = tmp_verbosity
             return consts.RET_CODE_OK
+
+    # @API(Log.set_parsable, 300)
+    def set_parsable(self, parsable: bool) -> int:
+        """
+        Function to set if the output logged should be parsable or not.
+        Not parsable means more human readable.
+        """
+        self.parsable = parsable
+        return consts.RET_CODE_OK
 
     def open_logfile(self, log_rp):
         """Inform all connections of an open logfile.

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -108,7 +108,11 @@ class Logger:
         tmpstr = self._format(message, self.term_verbosity, verbosity)
         # if the verbosity is below 9 and the string isn't deemed
         # pre-formatted by newlines (we ignore the last character)
-        if self.file_verbosity <= DEBUG and "\n" not in tmpstr[:-1]:
+        if (
+            verbosity != NONE
+            and self.term_verbosity < DEBUG
+            and "\n" not in tmpstr[:-1]
+        ):
             termfp.write(
                 textwrap.fill(
                     tmpstr,
@@ -178,8 +182,10 @@ class Logger:
         try:
             logging_func(exception_string, verbosity)
         except OSError:
-            print("OS error while trying to log exception!")
-            print(exception_string)
+            sys.stderr.write(
+                "OS error while trying to log exception!\n"
+                "{ex}\n".format(ex=exception_string)
+            )
 
     # @API(Log.set_verbosity, 300)
     def set_verbosity(
@@ -278,7 +284,9 @@ class Logger:
         """Format the message, possibly adding date information"""
         if verbosity <= DEBUG:
             # pre-formatted informative messages are returned as such
-            if msg_verbosity in {NONE, INFO} and "\n" in message[:-1]:
+            if msg_verbosity == NONE or (
+                msg_verbosity == INFO and "\n" in message[:-1]
+            ):
                 return "{msg}\n".format(msg=message)
             else:
                 return "{pre:<9}{msg}\n".format(

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -42,7 +42,7 @@ import shutil
 import stat
 import tempfile
 import time
-from rdiff_backup import Time, log, C
+from rdiff_backup import C, log, Time
 from rdiffbackup.locations.map import owners as map_owners
 from rdiffbackup.meta import acl_posix, acl_win, ea
 from rdiffbackup.singletons import consts, generics, specifics
@@ -1426,11 +1426,11 @@ class RPath(RORPath):
         return "rdiff-backup.tmp.{idx:d}".format(idx=cls._temp_file_index)
 
     def _debug_consistency(self):
-        """Raise an error if consistency of rp broken
+        """
+        Raise an error if consistency of rp broken
 
         This is useful for debugging when the cache and disk get out
         of sync and you need to find out where it happened.
-
         """
         temptype = self.data["type"]
         self.setdata()

--- a/src/rdiffbackup/actions/__init__.py
+++ b/src/rdiffbackup/actions/__init__.py
@@ -521,7 +521,7 @@ class BaseAction:
 
         return False
 
-    def print_values(self, explicit=True):
+    def debug_values(self, explicit=True):
         """
         Debug output method
         """

--- a/src/rdiffbackup/actions/calculate.py
+++ b/src/rdiffbackup/actions/calculate.py
@@ -22,7 +22,7 @@ A built-in rdiff-backup action plug-in to calculate average across multiple
 statistics files.
 """
 
-from rdiff_backup import statistics
+from rdiff_backup import log, statistics
 from rdiffbackup import actions
 from rdiffbackup.singletons import consts
 
@@ -67,10 +67,11 @@ class CalculateAction(actions.BaseAction):
         ]
         if self.values["method"] == "average":  # there is no other right now
             calc_stats = statistics.StatsObj().set_to_average(statobjs)
-        print(
+        log.Log(
             calc_stats.get_stats_logstring(
                 "Average of %d stat files" % len(self.connected_locations)
-            )
+            ),
+            log.NONE,
         )
 
         return ret_code

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -176,13 +176,14 @@ class CompareAction(actions.BaseAction):
             if parsable:
                 reason_verify_list.append({"reason": report.reason, "path": indexpath})
             else:
-                print("{rr}: {ip}".format(rr=report.reason, ip=indexpath))
+                log.Log("{rr}: {ip}".format(rr=report.reason, ip=indexpath), log.NONE)
 
         if parsable:
-            print(
+            log.Log(
                 yaml.safe_dump(
                     reason_verify_list, explicit_start=True, explicit_end=True
-                )
+                ),
+                log.NONE,
             )
         if not changed_files_found:
             log.Log("No changes found. Directory matches backup data", log.NOTE)

--- a/src/rdiffbackup/actions/info.py
+++ b/src/rdiffbackup/actions/info.py
@@ -24,6 +24,7 @@ for documenting an issue.
 
 import yaml
 
+from rdiff_backup import log
 from rdiffbackup import actions
 from rdiffbackup.singletons import consts
 
@@ -48,7 +49,10 @@ class InfoAction(actions.BaseAction):
             return ret_code
 
         runtime_info = self.get_runtime_info(parsed=self.values)
-        print(yaml.safe_dump(runtime_info, explicit_start=True, explicit_end=True))
+        log.Log(
+            yaml.safe_dump(runtime_info, explicit_start=True, explicit_end=True),
+            log.NONE,
+        )
         return ret_code
 
 

--- a/src/rdiffbackup/actions/list_.py
+++ b/src/rdiffbackup/actions/list_.py
@@ -26,7 +26,7 @@ builtin 'list' class.
 """
 
 import yaml
-from rdiff_backup import statistics, Time
+from rdiff_backup import log, statistics, Time
 from rdiffbackup import actions
 from rdiffbackup.locations import repository
 from rdiffbackup.singletons import consts
@@ -146,27 +146,35 @@ class ListAction(actions.BaseAction):
         triples = self.repo.get_increments_sizes()
 
         if self.values["parsable_output"]:
-            print(yaml.safe_dump(triples, explicit_start=True, explicit_end=True))
+            log.Log(
+                yaml.safe_dump(triples, explicit_start=True, explicit_end=True),
+                log.NONE,
+            )
         else:
             stat_obj = statistics.StatsObj()  # used for byte summary string
 
-            print("{: ^24} {: ^17} {: ^17}".format("Time", "Size", "Cumulative size"))
-            print("{:-^24} {:-^17} {:-^17}".format("", "", ""))
+            log.Log(
+                "{: ^24} {: ^17} {: ^17}".format("Time", "Size", "Cumulative size"),
+                log.NONE,
+            )
+            log.Log("{:-^24} {:-^17} {:-^17}".format("", "", ""), log.NONE)
             # print the normal increments then the mirror
             for triple in triples[:-1]:
-                print(
+                log.Log(
                     "{: <24} {: >17} {: >17}".format(
                         Time.timetopretty(triple["time"]),
                         stat_obj.get_byte_summary_string(triple["size"]),
                         stat_obj.get_byte_summary_string(triple["total_size"]),
-                    )
+                    ),
+                    log.NONE,
                 )
-            print(
+            log.Log(
                 "{: <24} {: >17} {: >17}  (current mirror)".format(
                     Time.timetopretty(triples[-1]["time"]),
                     stat_obj.get_byte_summary_string(triples[-1]["size"]),
                     stat_obj.get_byte_summary_string(triples[-1]["total_size"]),
-                )
+                ),
+                log.NONE,
             )
         return consts.RET_CODE_OK
 
@@ -176,17 +184,21 @@ class ListAction(actions.BaseAction):
         """
         incs = self.repo.get_increments()
         if self.values["parsable_output"]:
-            print(yaml.safe_dump(incs, explicit_start=True, explicit_end=True))
+            log.Log(
+                yaml.safe_dump(incs, explicit_start=True, explicit_end=True), log.NONE
+            )
         else:
-            print("Found {ni} increments:".format(ni=len(incs) - 1))
+            log.Log("Found {ni} increments:".format(ni=len(incs) - 1), log.NONE)
             for inc in incs[:-1]:
-                print(
+                log.Log(
                     "    {ib}   {ti}".format(
                         ib=inc["base"], ti=Time.timetopretty(inc["time"])
-                    )
+                    ),
+                    log.NONE,
                 )
-            print(
-                "Current mirror: {ti}".format(ti=Time.timetopretty(incs[-1]["time"]))
+            log.Log(
+                "Current mirror: {ti}".format(ti=Time.timetopretty(incs[-1]["time"])),
+                log.NONE,
             )  # time of the mirror
         return consts.RET_CODE_OK
 
@@ -194,14 +206,14 @@ class ListAction(actions.BaseAction):
         """List all the files under rp that have changed since restoretime"""
         rorp_iter = self.repo.list_files_changed_since(self.action_time)
         for rorp in rorp_iter:
-            print(str(rorp))  # this is a hack to transfer information
+            log.Log(str(rorp), log.NONE)  # this is a hack to transfer information
         return consts.RET_CODE_OK
 
     def _list_files_at_time(self):
         """List files in archive under rp that are present at restoretime"""
         rorp_iter = self.repo.list_files_at_time(self.action_time)
         for rorp in rorp_iter:
-            print(str(rorp))  # this is a hack to transfer information
+            log.Log(str(rorp), log.NONE)  # this is a hack to transfer information
         return consts.RET_CODE_OK
 
 

--- a/src/rdiffbackup/arguments.py
+++ b/src/rdiffbackup/arguments.py
@@ -137,6 +137,6 @@ if __name__ == "__main__":
         disc_actions,
     )
     action_object = disc_actions[values.action](values)
-    action_object.print_values()
+    action_object.debug_values()
     # in real life, the action_object would then do the action for which
     # it's been created

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -165,7 +165,7 @@ def _system_setup(arglist):
     # we need verbosity set properly asap
     ret_val = log.Log.set_verbosity(
         arglist.get("verbosity"), arglist.get("terminal_verbosity")
-    )
+    ) | log.Log.set_parsable(arglist.get("parsable_output"))
     if ret_val & consts.RET_CODE_ERR:
         return ret_val
     if arglist.get("api_version") is not None:  # FIXME catch also env variable?


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

As the subject says, I also have in mind for the future to make things even more parsable, e.g. by outputing everything in YAML format instead  of plain text, more or less formatted.

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
