### PR TITLE
Make log singleton use repo to log to file (and other improvements)

### DIFF
--- a/docs/THOUGHTS.adoc
+++ b/docs/THOUGHTS.adoc
@@ -7,7 +7,6 @@ As I go through a major rewrite and see things I don't like, or would like to im
 - renumber verbosities to avoid "holes" between 0 and 9
 - replace log verbosity with IntEnum
 - replace return codes with IntFlag
-- split logging mechanism between front-end and back-end (writing to file, which is specific to the repository format)
 - replace own Logger implementation with standard one (in the background)
 - extend runtime info to also check locations and output file system information
 - set api version to 300 (or 290-299 to start with)

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -290,7 +290,6 @@ def _set_allowed_requests(sec_class, sec_level):
                 "log.ErrorLog.open",
                 "log.ErrorLog.write_if_open",
                 "log.Log.close_logfile_local",
-                "log.Log.open_logfile_local",
                 "statistics.record_error",
                 # API >= 201
                 "_repo_shadow.RepoShadow.close_statistics",

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -289,7 +289,6 @@ def _set_allowed_requests(sec_class, sec_level):
                 "log.ErrorLog.isopen",
                 "log.ErrorLog.open",
                 "log.ErrorLog.write_if_open",
-                "log.Log.close_logfile_local",
                 "statistics.record_error",
                 # API >= 201
                 "_repo_shadow.RepoShadow.close_statistics",

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -229,6 +229,9 @@ def _set_allowed_requests(sec_class, sec_level):
         "_repo_shadow.RepoShadow.setup",
         "_repo_shadow.RepoShadow.setup_finish",
         "_repo_shadow.RepoShadow.exit",
+        "log.ErrorLog.open_logfile_allconn",
+        "log.ErrorLog.close_logfile_allconn",
+        "log.ErrorLog.log_to_file",
     }
     if (
         sec_level == "read-only"
@@ -286,9 +289,6 @@ def _set_allowed_requests(sec_class, sec_level):
         requests.update(
             [
                 "VirtualFile.writetoid",  # connection.VirtualFile.writetoid
-                "log.ErrorLog.isopen",
-                "log.ErrorLog.open",
-                "log.ErrorLog.write_if_open",
                 "statistics.record_error",
                 # API >= 201
                 "_repo_shadow.RepoShadow.close_statistics",

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -215,8 +215,6 @@ def _set_allowed_requests(sec_class, sec_level):
         "VirtualFile.readfromid",  # connection.VirtualFile.readfromid
         "VirtualFile.closebyid",  # connection.VirtualFile.closebyid
         "specifics.get",
-        "log.Log.open_logfile_allconn",
-        "log.Log.close_logfile_allconn",
         "log.Log.log_to_file",
         "robust.install_signal_handlers",
         "SetConnections.add_redirected_conn",
@@ -229,8 +227,10 @@ def _set_allowed_requests(sec_class, sec_level):
         "_repo_shadow.RepoShadow.setup",
         "_repo_shadow.RepoShadow.setup_finish",
         "_repo_shadow.RepoShadow.exit",
-        "log.ErrorLog.open_logfile_allconn",
-        "log.ErrorLog.close_logfile_allconn",
+        "log.Log.open_logfile_local",
+        "log.Log.close_logfile_local",
+        "log.ErrorLog.open_logfile_local",
+        "log.ErrorLog.close_logfile_local",
         "log.ErrorLog.log_to_file",
     }
     if (

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -78,6 +78,9 @@ class Connection:
     def __bool__(self):
         return True
 
+    def __getattr__(self, name: str) -> typing.Any:
+        pass  # abstract method
+
     @classmethod
     def import_modules(cls):
         """

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -18,13 +18,14 @@
 # 02110-1301, USA
 """Support code for remote execution and data transfer"""
 
+import errno
 import importlib
 import pickle
 import subprocess
 import sys
 import time
 import traceback
-import errno
+import typing
 
 from rdiff_backup import (
     iterfile,
@@ -165,7 +166,7 @@ class LocalConnection(Connection):
         super().__init__()
         self.conn_number = 0  # changed by SetConnections for server
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> typing.Any:
         if name in self.globals:
             return self.globals[name]
         elif isinstance(__builtins__, dict):
@@ -462,7 +463,7 @@ class PipeConnection(LowLevelPipeConnection):
         else:
             return str(self)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> typing.Any:
         """Intercept attributes to allow for . invocation"""
         return EmulateCallable(self, name)
 
@@ -641,7 +642,7 @@ class RedirectedConnection(Connection):
     def __str__(self):
         return "RedirectedConnection %d,%d" % (self.conn_number, self.routing_number)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> typing.Any:
         return EmulateCallableRedirected(self.conn_number, self.routing_conn, name)
 
 
@@ -655,7 +656,7 @@ class EmulateCallable:
     def __call__(self, *args):
         return self.connection.reval(*(self.call_name,) + args)
 
-    def __getattr__(self, attr_name):
+    def __getattr__(self, attr_name: str) -> typing.Any:
         return EmulateCallable(self.connection, "%s.%s" % (self.call_name, attr_name))
 
 
@@ -671,7 +672,7 @@ class EmulateCallableRedirected:
             *("RedirectedRun", self.conn_number, self.call_name) + args
         )
 
-    def __getattr__(self, attr_name):
+    def __getattr__(self, attr_name: str) -> typing.Any:
         return EmulateCallableRedirected(
             self.conn_number, self.routing_conn, "%s.%s" % (self.call_name, attr_name)
         )

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -26,12 +26,12 @@ import sys
 import textwrap
 import typing
 import traceback
+
 from rdiffbackup.singletons import consts, generics, specifics
+from rdiffbackup.utils import safestr
 
 if typing.TYPE_CHECKING:  # for type checking only
     from rdiff_backup import connection
-
-LOGFILE_ENCODING: typing.Final[str] = "utf-8"
 
 # type definitions
 Verbosity = typing.Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]  # : typing.TypeAlias
@@ -119,7 +119,7 @@ class Logger:
     def log_to_file(self, message: str, verbosity: Verbosity) -> None:
         """Write the message to the log file, if possible"""
         tmpstr = self._format(message, self.file_verbosity, verbosity)
-        self.log_writer.write(_to_bytes(tmpstr))
+        self.log_writer.write(safestr.to_bytes(tmpstr))
         self.log_writer.flush()
 
     def log_to_term(self, message: str, verbosity: Verbosity) -> None:
@@ -421,7 +421,7 @@ class ErrorLogger:
         else:
             logstr = re.sub("\n", " ", logstr)
             logstr += "\n"
-        self.log_writer.write(_to_bytes(logstr))
+        self.log_writer.write(safestr.to_bytes(logstr))
 
     def _get_log_string(
         self, error_type: ErrorType, rp: typing.Any, exc: BaseException
@@ -431,10 +431,3 @@ class ErrorLogger:
 
 
 ErrorLog = ErrorLogger()
-
-
-def _to_bytes(logline: str, encoding: str = LOGFILE_ENCODING) -> bytes:
-    """
-    Convert string into bytes for logging into file.
-    """
-    return logline.encode(encoding, "backslashreplace")

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -156,6 +156,8 @@ class Logger:
             result_repr = repr(result)
         else:
             result_repr = str(result)
+        if self.parsable:  # keep everything on one line
+            result_repr = result_repr.replace("\n", " | ")
         # TODO shorten the result to a max size of 720 chars with ellipsis if needed
         # result_repr = result_repr[:720] + (result_repr[720:] and '[...]')  # noqa: E265
         if specifics.server:
@@ -171,6 +173,8 @@ class Logger:
 
     def FatalError(self, message: str, return_code: int = 1) -> None:
         """Log a fatal error and exit"""
+        if self.parsable:  # keep everything on one line
+            message = message.replace("\n", " | ")
         self.log_to_term("Fatal Error: {em}".format(em=message), ERROR)
         sys.exit(return_code)
 
@@ -192,6 +196,8 @@ class Logger:
                 return
 
         exception_string = self._exception_to_string()
+        if self.parsable:  # keep everything on one line
+            exception_string = exception_string.replace("\n", " | ")
         try:
             logging_func(exception_string, verbosity)
         except OSError:
@@ -245,8 +251,7 @@ class Logger:
         """
         assert not self.log_file_open, "Can't open an already opened logfile"
         self.log_writer = log_writer
-        self.log_file_open = True
-        for conn in specifics.connections[1:]:
+        for conn in specifics.connections:
             conn.log.Log.open_logfile_local()
 
     # @API(Log.open_logfile_local, 300)
@@ -368,8 +373,7 @@ class ErrorLogger:
         """
         assert not self.log_file_open, "Can't open an already opened logfile"
         self.log_writer = log_writer
-        self.log_file_open = True
-        for conn in specifics.connections[1:]:
+        for conn in specifics.connections:
             conn.log.ErrorLog.open_logfile_local()
 
     # @API(ErrorLog.open_logfile_local, 300)

--- a/src/rdiff_backup/log.py
+++ b/src/rdiff_backup/log.py
@@ -251,7 +251,8 @@ class Logger:
         """
         assert not self.log_file_open, "Can't open an already opened logfile"
         self.log_writer = log_writer
-        for conn in specifics.connections:
+        self.log_file_open = True  # this simplifies unit tests
+        for conn in specifics.connections[1:]:
             conn.log.Log.open_logfile_local()
 
     # @API(Log.open_logfile_local, 300)
@@ -262,9 +263,10 @@ class Logger:
     def close_logfile(self) -> None:
         """Close logfile locally if necessary and inform all connections"""
         if self.log_file_open:
-            for conn in specifics.connections:
+            for conn in specifics.connections[1:]:
                 conn.log.Log.close_logfile_local()
             self.log_writer.close()
+            self.log_file_open = False  # this simplifies unit tests
 
     # @API(Log.close_logfile_local, 300)
     def close_logfile_local(self) -> None:
@@ -373,7 +375,8 @@ class ErrorLogger:
         """
         assert not self.log_file_open, "Can't open an already opened logfile"
         self.log_writer = log_writer
-        for conn in specifics.connections:
+        self.log_file_open = True  # this simplifies unit tests
+        for conn in specifics.connections[1:]:
             conn.log.ErrorLog.open_logfile_local()
 
     # @API(ErrorLog.open_logfile_local, 300)
@@ -384,9 +387,10 @@ class ErrorLogger:
     def close_logfile(self) -> None:
         """Close logfile locally if necessary and inform all connections"""
         if self.log_file_open:
-            for conn in specifics.connections:
+            for conn in specifics.connections[1:]:
                 conn.log.ErrorLog.close_logfile_local()
             self.log_writer.close()
+            self.log_file_open = False  # this simplifies unit tests
 
     # @API(ErrorLog.close_logfile_local, 300)
     def close_logfile_local(self) -> None:

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -119,9 +119,9 @@ def check_common_error(error_handler, function, args=[]):
             else:
                 return None
         if is_routine_fatal(exc):
-            log.Log.exception(1, log.INFO)
+            log.Log.exception(log.LOCAL, log.INFO)
         else:
-            log.Log.exception(1, log.WARNING)
+            log.Log.exception(log.LOCAL, log.WARNING)
         raise
 
 

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -82,7 +82,7 @@ def get_error_handler(error_type):
     """
 
     def error_handler(exc, rp, *args):
-        log.ErrorLog.write_if_open(error_type, rp, exc)
+        log.ErrorLog(error_type, rp, exc)
         return 0
 
     return error_handler

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1972,7 +1972,7 @@ def setdata_local(rp):
             # symlinks, so we would anyway try to chmod the file pointed at,
             # not the symlink itself
             rp.data["type"] = None
-            log.ErrorLog.write_if_open(
+            log.ErrorLog(
                 "ListError",
                 rp,
                 OSError("[Errno n/a] Ignoring strange unreadable symlink"),

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -225,7 +225,7 @@ class Select:
         """
 
         def error_handler(exc, filename):
-            log.ErrorLog.write_if_open("ListError", rpath.index + (filename,), exc)
+            log.ErrorLog("ListError", rpath.index + (filename,), exc)
             return None
 
         def diryield(rpath):
@@ -288,7 +288,7 @@ class Select:
         """List directory rpath with error logging and sorting entries"""
 
         def error_handler(exc):
-            log.ErrorLog.write_if_open("ListError", dir_rp, exc)
+            log.ErrorLog("ListError", dir_rp, exc)
             return []
 
         dir_listing = robust.check_common_error(error_handler, dir_rp.listdir)

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -1375,8 +1375,8 @@ class RepoShadow(location.LocationShadow):
         """
         try:  # the target repository must be writable
             logfile = cls._data_dir.append(cls._values["action"] + ".log")
-            log.Log.open_logfile(logfile)
-        except (log.LoggerError, Security.Violation) as exc:
+            log.Log.open_logfile(logfile.open("ab"))
+        except (OSError, Security.Violation) as exc:
             log.Log(
                 "Unable to open logfile '{lf}' due to '{ex}'".format(
                     lf=logfile, ex=exc

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -143,7 +143,6 @@ class RepoShadow(location.LocationShadow):
         cls._restore_time = None
         cls._regress_time = None
         cls._unsuccessful_backup_time = None
-        cls._logging_to_file = None
 
         return (cls._base_dir, cls._ref_index, cls._ref_type)
 
@@ -240,21 +239,26 @@ class RepoShadow(location.LocationShadow):
         if cls._must_be_writable:
             if log.Log.file_verbosity > 0:
                 cls._open_logfile()
-            # FIXME the logic shouldn't be dependent on the action's name
-            if cls._values["action"] == "backup":
-                log.ErrorLog.open(
-                    data_dir=cls._data_dir,
-                    time_string=Time.getcurtimestr(),
-                    compress=cls._values["compression"],
+            # The logic shouldn't be dependent on the action's name but if someone
+            # wants to create an action using the ErrorLog they'll have to give it a
+            # name containing 'backup'
+            if "backup" in cls._values["action"]:
+                base_rp = cls._data_dir.append(
+                    "error_log.%s.data" % Time.getcurtimestr()
                 )
+                if cls._values["compression"]:
+                    # FIXME extract MaybeGzip from rpath and make it utils?
+                    log_writer = rpath.MaybeGzip(base_rp)
+                else:
+                    log_writer = base_rp.open("wb", compress=0)
+                log.ErrorLog.open_logfile(log_writer)
 
     # @API(RepoShadow.exit, 300)
     @classmethod
     def exit(cls):
         cls._unlock()
-        log.ErrorLog.close()
-        if cls._logging_to_file:
-            log.Log.close_logfile()
+        log.ErrorLog.close_logfile()
+        log.Log.close_logfile()
 
     # @API(RepoShadow.get_sigs, 201)
     @classmethod
@@ -1385,7 +1389,6 @@ class RepoShadow(location.LocationShadow):
             )
             return consts.RET_CODE_ERR
         else:
-            cls._logging_to_file = True
             return consts.RET_CODE_OK
 
     @classmethod

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -26,7 +26,7 @@ import typing
 
 from rdiffbackup.singletons import specifics
 
-if typing.TYPE_CHECKING:  # for type checking only
+if typing.TYPE_CHECKING:  # pragma: no cover
     import re
     from rdiff_backup import connection
 
@@ -162,7 +162,7 @@ def set(setting_name: str, value: typing.Any) -> None:
     # if there are no connections yet, only set locally
     if specifics.connection_dict:
         for conn in specifics.connection_dict.values():
-            conn.generics.set_local(setting_name, value)  # type: ignore
+            conn.generics.set_local(setting_name, value)
     else:
         globals()[setting_name] = value
 
@@ -173,7 +173,7 @@ def dispatch_settings(conn: "connection.Connection") -> None:
     to the (assumed new) given connection.
     """
     for setting_name in changed_settings:
-        conn.generics.set_local(setting_name, get(setting_name))  # type: ignore
+        conn.generics.set_local(setting_name, get(setting_name))
 
 
 # @API(set_local, 200)

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -29,7 +29,7 @@ from importlib import metadata
 
 from rdiff_backup import log
 
-if typing.TYPE_CHECKING:  # for type checking only
+if typing.TYPE_CHECKING:  # pragma: no cover
     from rdiff_backup import connection
 
 # The current version of rdiff-backup

--- a/src/rdiffbackup/utils/safestr.py
+++ b/src/rdiffbackup/utils/safestr.py
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA
 """
-Simple function to safely transform bytes and other objects to string
+Simple functions to safely transform bytes and other objects to string and vice-versa
 """
 
 
@@ -27,3 +27,10 @@ def to_str(something):
         return str(something, errors="replace")
     else:
         return str(something)
+
+
+def to_bytes(something: str, encoding: str = "utf-8") -> bytes:
+    """
+    Convert string into bytes in a safe way
+    """
+    return something.encode(encoding=encoding, errors="backslashreplace")

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -270,13 +270,13 @@ def InternalBackup(
     acls=None,
     force=False,
 ):
-    """Backup src to dest internally
+    """
+    Backup src to dest internally
 
     This is like rdiff_backup but instead of running a separate
     rdiff-backup script, use the separate *.py files.  This way the
     script doesn't have to be rebuild constantly, and stacktraces have
     correct line/file references.
-
     """
     args = []
     if current_time is not None:
@@ -373,6 +373,8 @@ def reset_connections():
     """Reset some global connection information"""
     Security._security_level = "override"
     specifics.is_backup_writer = None
+    log.Log.close_logfile()
+    log.ErrorLog.close_logfile()
     # reset the connection status
     specifics.local_connection.conn_number = 0
     specifics.connections = [specifics.local_connection]

--- a/testing/log_test.py
+++ b/testing/log_test.py
@@ -2,10 +2,11 @@
 Test the logging functionality
 """
 
+import io
 import unittest
 
 from rdiff_backup import log
-from rdiffbackup.singletons import consts
+from rdiffbackup.singletons import consts, generics
 
 
 class LogTest(unittest.TestCase):
@@ -52,6 +53,34 @@ class LogTest(unittest.TestCase):
         # nothing changes even if only the 2nd value is wrong
         self.assertEqual(testlog.file_verbosity, log.DEBUG)
         self.assertEqual(testlog.term_verbosity, log.WARNING)
+
+    def test_log_open_logfile(self):
+        """test that log strings are properly written to log writer"""
+        testlog = log.Logger()
+        logbuffer = io.BytesIO()
+        testlog.open_logfile(logbuffer)
+        testlog.set_verbosity(log.WARNING, log.NONE)
+        testlog("Something fishy", log.WARNING)
+        self.assertEqual(logbuffer.getvalue(), b"WARNING: Something fishy\n")
+        testlog("All is good", log.NONE)
+        self.assertEqual(
+            logbuffer.getvalue(), b"WARNING: Something fishy\nAll is good\n"
+        )
+
+    def test_errorlog_open_logfile(self):
+        """test that error log strings are properly written to log writer"""
+        testlog = log.ErrorLogger()
+        logbuffer = io.BytesIO()
+        testlog.open_logfile(logbuffer)
+        testlog("ListError", "Something\nfishy", Exception("xyz"))
+        self.assertEqual(logbuffer.getvalue(), b"ListError: 'Something fishy' xyz\n")
+        generics.set("null_separator", True)
+        testlog("UpdateError", "Swimming\nagain", Exception("abc"))
+        self.assertEqual(
+            logbuffer.getvalue(),
+            b"ListError: 'Something fishy' xyz\n"
+            b"UpdateError: 'Swimming\nagain' abc\0",
+        )
 
 
 if __name__ == "__main__":

--- a/testing/log_test.py
+++ b/testing/log_test.py
@@ -6,7 +6,7 @@ import io
 import unittest
 
 from rdiff_backup import log
-from rdiffbackup.singletons import consts, generics
+from rdiffbackup.singletons import consts, generics, specifics
 
 
 class LogTest(unittest.TestCase):
@@ -56,6 +56,7 @@ class LogTest(unittest.TestCase):
 
     def test_log_open_logfile(self):
         """test that log strings are properly written to log writer"""
+        specifics.set("is_backup_writer", True)
         testlog = log.Logger()
         logbuffer = io.BytesIO()
         testlog.open_logfile(logbuffer)
@@ -69,6 +70,7 @@ class LogTest(unittest.TestCase):
 
     def test_errorlog_open_logfile(self):
         """test that error log strings are properly written to log writer"""
+        specifics.set("is_backup_writer", True)
         testlog = log.ErrorLogger()
         logbuffer = io.BytesIO()
         testlog.open_logfile(logbuffer)


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

* Make log usage independent of repo implementation, meaning the log "file" doesn't need to be a file but could be a database, as long as it's represented by a LogWriter object
* Align ErrorLog with Log, both implementations were completely different even though they do similar things
* Rename _allconn to _local for consistency with other similar constructs
* Add typing hints to log module
* Add LogWriter type and simplify code
* Move log._to_bytes to utils.safestr.to_bytes
* Improve test coverage for log


<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
