### PR TITLE
Refactor statistics module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ skips = ["B301", "B101"]
 [tool.mypy]
 files = [
 	"src/rdiffbackup/singletons/",
+	"src/rdiffbackup/utils/buffer.py",
 	"src/rdiffbackup/utils/convert.py",
 	"src/rdiff_backup/statistics.py",
 ]
@@ -97,6 +98,7 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = [
 	"rdiffbackup.singletons.*",
+	"rdiffbackup.utils.buffer",
 	"rdiffbackup.utils.convert",
 	"rdiff_backup.statistics",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ skips = ["B301", "B101"]
 files = [
 	"src/rdiffbackup/singletons/",
 	"src/rdiffbackup/utils/convert.py",
+	"src/rdiff_backup/statistics.py",
 ]
 ignore_missing_imports = true
 ignore_errors = true
@@ -97,5 +98,6 @@ ignore_errors = true
 module = [
 	"rdiffbackup.singletons.*",
 	"rdiffbackup.utils.convert",
+	"rdiff_backup.statistics",
 ]
 ignore_errors = false

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -289,7 +289,6 @@ def _set_allowed_requests(sec_class, sec_level):
         requests.update(
             [
                 "VirtualFile.writetoid",  # connection.VirtualFile.writetoid
-                "statistics.record_error",
                 # API >= 201
                 "_repo_shadow.RepoShadow.close_statistics",
                 "_repo_shadow.RepoShadow.get_sigs",
@@ -297,6 +296,8 @@ def _set_allowed_requests(sec_class, sec_level):
                 "_repo_shadow.RepoShadow.remove_current_mirror",
                 "_repo_shadow.RepoShadow.set_config",
                 "_repo_shadow.RepoShadow.touch_current_mirror",
+                # API >= 300
+                "statistics.SessionsStats.add_error_local",
             ]
         )
     if sec_level == "read-write":

--- a/src/rdiff_backup/robust.py
+++ b/src/rdiff_backup/robust.py
@@ -21,8 +21,8 @@
 import errno
 import signal
 import zlib
-from rdiff_backup import librsync, C, rpath, connection
-from rdiffbackup.singletons import generics, log
+from rdiff_backup import C, connection, librsync, rpath, statistics
+from rdiffbackup.singletons import log
 
 
 # Those are the signals we want to catch because they relate to conditions
@@ -112,8 +112,7 @@ def check_common_error(error_handler, function, args=[]):
     except (Exception, KeyboardInterrupt, SystemExit) as exc:
         if catch_error(exc):
             log.Log.exception()
-            if generics.backup_writer is not None:
-                generics.backup_writer.statistics.record_error()
+            statistics.SessionStats.add_error()
             if error_handler:
                 return error_handler(exc, *args)
             else:

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -50,7 +50,7 @@ class SessionStatsWriter(typing.Protocol):  # pragma: no cover
 class SessionStatsReader(typing.Protocol):  # pragma: no cover
     """Protocol representing a subset of io.BufferedReader methods"""
 
-    def read(self) -> str:
+    def read(self, size: int = -1) -> str:
         """Read a string from the file and return it"""
         ...
 
@@ -79,8 +79,8 @@ class FileStatsWriter(typing.Protocol):  # pragma: no cover
 class FileStatsReader(typing.Protocol):  # pragma: no cover
     """Protocol representing a subset of io.BufferedReader methods"""
 
-    def readline(self) -> bytes:
-        """Read a line of bytes from the file and return it"""
+    def __iter__(self) -> bytes:
+        """Iterate over the input"""
         ...
 
     def close(self) -> None:

--- a/src/rdiff_backup/statistics.py
+++ b/src/rdiff_backup/statistics.py
@@ -381,6 +381,7 @@ class FileStatsTracker:
     _fileobj: typing.Optional[FileStatsWriter] = None
     _line_sep: bytes = b"\n"
     _line_buffer: list[bytes] = []
+    _header: bytes = b""
 
     def open_stats_file(self, stats_writer: FileStatsWriter, separator: bytes) -> None:
         """Open file stats object and prepare to write"""
@@ -424,12 +425,15 @@ class FileStatsTracker:
     def _write_header(self) -> None:
         """Write the first line (a documentation string) into file"""
         assert self._fileobj, "FileStats hasn't been properly initialized."
-        self._fileobj.write(b"# Format of each line in file statistics file:")
-        self._fileobj.write(self._line_sep)
-        self._fileobj.write(
-            b"# Filename Changed SourceSize MirrorSize "
-            b"IncrementSize" + self._line_sep
+        # we keep a copy of the header to simplify testing
+        self._header = self._line_sep.join(
+            (
+                b"# Format of each line in file statistics file:",
+                b"# Filename Changed SourceSize MirrorSize IncrementSize",
+                b"",  # for a final line separator
+            )
         )
+        self._fileobj.write(self._header)
 
     def _get_size(self, rorp: typing.Optional["rpath.RORPath"]) -> bytes:
         """Return the size of rorp as bytes, or "NA" if not a regular file"""

--- a/src/rdiffbackup/actions/calculate.py
+++ b/src/rdiffbackup/actions/calculate.py
@@ -61,14 +61,14 @@ class CalculateAction(actions.BaseAction):
         if ret_code & consts.RET_CODE_ERR:
             return ret_code
 
-        statobjs = [
-            statistics.StatsObj().read_stats_from_rp(loc)
+        sess_stats = [
+            statistics.SessionStatsCalc().read_stats(loc.open("r"))
             for loc in self.connected_locations
         ]
         if self.values["method"] == "average":  # there is no other right now
-            calc_stats = statistics.StatsObj().set_to_average(statobjs)
+            calc_stats = statistics.SessionStatsCalc().calc_average(sess_stats)
         log.Log(
-            calc_stats.get_stats_logstring(
+            calc_stats.get_stats_as_string(
                 "Average of %d stat files" % len(self.connected_locations)
             ),
             log.NONE,

--- a/src/rdiffbackup/locations/increment.py
+++ b/src/rdiffbackup/locations/increment.py
@@ -70,7 +70,7 @@ def make_increment(new, mirror, incpref, inc_time=None):
         incrp = _make_diff_increment(new, mirror, incpref, inc_time)
     else:
         incrp = _make_snapshot_increment(mirror, incpref, inc_time)
-    statistics.process_increment(incrp)
+    statistics.SessionStats.add_increment(incrp)
     return incrp
 
 

--- a/src/rdiffbackup/utils/buffer.py
+++ b/src/rdiffbackup/utils/buffer.py
@@ -1,0 +1,86 @@
+# Copyright 2024 Eric Lavarde
+#
+# This file is part of rdiff-backup.
+#
+# rdiff-backup is free software; you can redistribute it and/or modify
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# rdiff-backup is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with rdiff-backup; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+"""
+Classes to improve performance of an opened file by buffering lines
+"""
+
+import typing
+
+
+class LinesBuffer:
+    """
+    Iterate lines like a normal filelike descriptor
+
+    This can be used to improve performance of a normal file, e.g. compressed.
+    """
+
+    blocksize: int = 65536
+    max_lines: int = 100
+    buffer: list[typing.AnyStr]
+    at_end: bool = False
+    separator: typing.AnyStr
+    _rest: typing.Optional[typing.AnyStr] = None
+
+    def __init__(self, filedesc, separator: typing.AnyStr):
+        """Initialize with file descriptor and line separator"""
+        self.filedesc = filedesc
+        self.separator = separator
+        # we need to initialize anew with each instance or the buffer is shared
+        self.buffer = []
+
+    def __iter__(self):
+        """Yield the lines in self.filedesc"""
+        while self.buffer or not self.at_end:
+            if self.buffer:
+                yield self.buffer.pop(0)
+            else:
+                self._replenish_buffer()
+
+    def close(self) -> None:
+        if self.filedesc.writable() and self.buffer:
+            self.flush()
+        self.filedesc.close()
+
+    def flush(self) -> None:
+        if self.buffer:
+            self.filedesc.write(self.separator.join(self.buffer) + self.separator)
+            self.buffer = []
+        self.filedesc.flush()
+
+    def write(self, line: typing.AnyStr) -> None:
+        self.buffer.append(line)
+        if len(self.buffer) >= self.max_lines:
+            self.flush()
+
+    def _replenish_buffer(self) -> None:
+        """Read next block from filedesc, split and add to buffer list"""
+        block = self.filedesc.read(self.blocksize)
+        # most of the complexity is due to the fact that a line might be split
+        # between two blocks
+        if block:
+            split = block.split(self.separator)
+            if self._rest:
+                split[0] = self._rest + split[0]
+            self._rest = split.pop()
+            self.buffer.extend(split)
+        else:
+            if self._rest:
+                self.buffer.append(self._rest)
+                self._rest = None
+            self.at_end = True

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -16,6 +16,7 @@ from rdiff_backup import (
     rpath,
     Security,
     selection,
+    statistics,
 )
 from rdiffbackup import run
 from rdiffbackup.meta import ea, acl_posix
@@ -385,6 +386,7 @@ def reset_connections():
     # EAs and ACLs support
     generics.set("eas_active", None)
     generics.set("acls_active", None)
+    statistics.reset_statistics()
 
 
 def _hardlink_rorp_eq(src_rorp, dest_rorp):

--- a/testing/statistics_test.py
+++ b/testing/statistics_test.py
@@ -251,7 +251,8 @@ class FileStatsTrackerTest(unittest.TestCase):
         tracker = statistics.FileStatsTracker()
         writer = io.BytesIO()
         tracker.open_stats_file(writer, b"|")
-        compare_str = tracker._header
+        compare_str = b"|".join(tracker._HEADER) + b"|"
+        tracker.flush()  # we need to flush before we can compare
         self.assertEqual(writer.getvalue(), compare_str)
         src = rpath.RORPath(["s", "r", "c"], {"size": 1234, "type": "reg"})
         dst = rpath.RORPath(["d", "s", "t"], {"size": 2468, "type": "reg"})
@@ -261,7 +262,7 @@ class FileStatsTrackerTest(unittest.TestCase):
         compare_str += b"s/r/c True 1234 2468 999|"
         tracker.add_stats(None, dst, False, inc2)
         compare_str += b"d/s/t False NA 2468 0|"
-        tracker._write_buffer()  # kind of flush
+        tracker.flush()  # we need to flush before we can compare
         self.assertEqual(writer.getvalue(), compare_str)
         tracker.close()
 

--- a/testing/utils_buffer_test.py
+++ b/testing/utils_buffer_test.py
@@ -22,7 +22,7 @@ class UtilsBufferTest(unittest.TestCase):
         write_lines.flush()
         read_io = io.StringIO(write_io.getvalue().decode())
         read_lines = buffer.LinesBuffer(read_io, "|")
-        for x, y in zip(read_lines, range(0, 65535), strict=True):
+        for x, y in zip(read_lines, range(0, 65535)):  # add , strict=True once >=3.10
             self.assertEqual(int(x), y)
 
 

--- a/testing/utils_buffer_test.py
+++ b/testing/utils_buffer_test.py
@@ -1,0 +1,30 @@
+"""
+Test the line buffering to improve speed of files
+"""
+
+import io
+import unittest
+
+from rdiffbackup.utils import buffer
+
+
+class UtilsBufferTest(unittest.TestCase):
+    """
+    Test the buffer module
+    """
+
+    def test_buffer_read_write(self):
+        """Test writing and reading back lines using buffer"""
+        write_io = io.BytesIO()
+        write_lines = buffer.LinesBuffer(write_io, b"|")
+        for line in range(0, 65535):
+            write_lines.write(str(line).encode())
+        write_lines.flush()
+        read_io = io.StringIO(write_io.getvalue().decode())
+        read_lines = buffer.LinesBuffer(read_io, "|")
+        for x, y in zip(read_lines, range(0, 65535), strict=True):
+            self.assertEqual(int(x), y)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/utils_convert_test.py
+++ b/testing/utils_convert_test.py
@@ -1,5 +1,5 @@
 """
-Test the simpleps alternative implementation
+Test the convert utils module
 """
 
 import unittest

--- a/tools/misc/benchmark_compress.py
+++ b/tools/misc/benchmark_compress.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python3
+# a script to benchmark different ways to compress files
+# A typical result with default values looks like this:
+# $ ./tools/misc/benchmark_compress.py 
+# DIRECT UNBUFFERED N/A 0.17925615100011782
+# DIRECT BUFFERED N/A 0.1017055429992979
+# GZIP UNBUFFERED 9 0.652450399999907
+# GZIP BUFFERED 9 0.35367933100042137
+# BZ2 UNBUFFERED 9 15.648743923000438
+# BZ2 BUFFERED 9 14.793156550000276
+# LZMA UNBUFFERED 6 3.715828219999821
+# LZMA BUFFERED 6 2.684497156999896
+# $ ll /tmp/*buffered*
+# 99900 Dec 15 09:23 /tmp/buffered
+#   480 Dec 15 09:23 /tmp/buffered.gz
+#   282 Dec 15 09:24 /tmp/buffered.bz2
+#   248 Dec 15 09:24 /tmp/buffered.xz
+# 99900 Dec 15 09:23 /tmp/unbuffered
+#   482 Dec 15 09:23 /tmp/unbuffered.gz
+#   282 Dec 15 09:24 /tmp/unbuffered.bz2
+#   248 Dec 15 09:24 /tmp/unbuffered.xz
+
+import bz2
+import gzip
+import lzma
+import timeit
+
+LINE = b"""alfjaw44534u8od /q389-t346b 5aop[fz89p34/ 0))({"l;346 af gtwioqwtiqtobi asgu godfi dnfiot45 89sg g.
+"""
+LINES = 1000
+NUMBER = 1000
+GZIP_COMPRESS = 9  # 0-9, default is 9
+BZ2_COMPRESS = 9  # 1-9, default is 9
+LZMA_PRESET = 6  # 0-9, default is 6
+
+
+def write_direct_unbuffered():
+    file = open("/tmp/unbuffered", mode="wb")
+    for i in range(0, LINES):
+        file.write(LINE)
+    file.close()
+
+
+def write_direct_buffered():
+    file = open("/tmp/buffered", mode="wb")
+    buffer = []
+    for i in range(0, LINES):
+        buffer.append(LINE)
+    file.write(b"".join(buffer))
+    file.close()
+
+
+def write_gzip_unbuffered():
+    file = gzip.GzipFile("/tmp/unbuffered.gz", compresslevel=GZIP_COMPRESS, mode="wb")
+    for i in range(0, LINES):
+        file.write(LINE)
+    file.close()
+
+
+def write_gzip_buffered():
+    file = gzip.GzipFile("/tmp/buffered.gz", compresslevel=GZIP_COMPRESS, mode="wb")
+    buffer = []
+    for i in range(0, LINES):
+        buffer.append(LINE)
+    file.write(b"".join(buffer))
+    file.close()
+
+
+def write_bz2_unbuffered():
+    file = bz2.BZ2File("/tmp/unbuffered.bz2", mode="wb", compresslevel=BZ2_COMPRESS)
+    for i in range(0, LINES):
+        file.write(LINE)
+    file.close()
+
+
+def write_bz2_buffered():
+    file = bz2.BZ2File("/tmp/buffered.bz2", mode="wb", compresslevel=BZ2_COMPRESS)
+    buffer = []
+    for i in range(0, LINES):
+        buffer.append(LINE)
+    file.write(b"".join(buffer))
+    file.close()
+
+
+def write_lzma_unbuffered():
+    file = lzma.LZMAFile("/tmp/unbuffered.xz", mode="wb", preset=LZMA_PRESET)
+    for i in range(0, LINES):
+        file.write(LINE)
+    file.close()
+
+
+def write_lzma_buffered():
+    file = lzma.LZMAFile("/tmp/buffered.xz", mode="wb", preset=LZMA_PRESET)
+    buffer = []
+    for i in range(0, LINES):
+        buffer.append(LINE)
+    file.write(b"".join(buffer))
+    file.close()
+
+
+print(
+    "DIRECT UNBUFFERED",
+    "N/A",
+    timeit.timeit(stmt="write_direct_unbuffered()", number=NUMBER, globals=globals()),
+)
+print(
+    "DIRECT BUFFERED",
+    "N/A",
+    timeit.timeit(stmt="write_direct_buffered()", number=NUMBER, globals=globals()),
+)
+
+print(
+    "GZIP UNBUFFERED",
+    GZIP_COMPRESS,
+    timeit.timeit(stmt="write_gzip_unbuffered()", number=NUMBER, globals=globals()),
+)
+print(
+    "GZIP BUFFERED",
+    GZIP_COMPRESS,
+    timeit.timeit(stmt="write_gzip_buffered()", number=NUMBER, globals=globals()),
+)
+
+print(
+    "BZ2 UNBUFFERED",
+    BZ2_COMPRESS,
+    timeit.timeit(stmt="write_bz2_unbuffered()", number=NUMBER, globals=globals()),
+)
+print(
+    "BZ2 BUFFERED",
+    BZ2_COMPRESS,
+    timeit.timeit(stmt="write_bz2_buffered()", number=NUMBER, globals=globals()),
+)
+
+print(
+    "LZMA UNBUFFERED",
+    LZMA_PRESET,
+    timeit.timeit(stmt="write_lzma_unbuffered()", number=NUMBER, globals=globals()),
+)
+print(
+    "LZMA BUFFERED",
+    LZMA_PRESET,
+    timeit.timeit(stmt="write_lzma_buffered()", number=NUMBER, globals=globals()),
+)

--- a/tools/misc/benchmark_compress.py
+++ b/tools/misc/benchmark_compress.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # a script to benchmark different ways to compress files
 # A typical result with default values looks like this:
-# $ ./tools/misc/benchmark_compress.py 
+# $ ./tools/misc/benchmark_compress.py
 # DIRECT UNBUFFERED N/A 0.17925615100011782
 # DIRECT BUFFERED N/A 0.1017055429992979
 # GZIP UNBUFFERED 9 0.652450399999907
@@ -10,15 +10,16 @@
 # BZ2 BUFFERED 9 14.793156550000276
 # LZMA UNBUFFERED 6 3.715828219999821
 # LZMA BUFFERED 6 2.684497156999896
-# $ ll /tmp/*buffered*
-# 99900 Dec 15 09:23 /tmp/buffered
-#   480 Dec 15 09:23 /tmp/buffered.gz
-#   282 Dec 15 09:24 /tmp/buffered.bz2
-#   248 Dec 15 09:24 /tmp/buffered.xz
-# 99900 Dec 15 09:23 /tmp/unbuffered
-#   482 Dec 15 09:23 /tmp/unbuffered.gz
-#   282 Dec 15 09:24 /tmp/unbuffered.bz2
-#   248 Dec 15 09:24 /tmp/unbuffered.xz
+# $ ll tmp-*buffered*
+# 99900 Dec 15 09:23 tmp-buffered
+#   480 Dec 15 09:23 tmp-buffered.gz
+#   282 Dec 15 09:24 tmp-buffered.bz2
+#   248 Dec 15 09:24 tmp-buffered.xz
+# 99900 Dec 15 09:23 tmp-unbuffered
+#   482 Dec 15 09:23 tmp-unbuffered.gz
+#   282 Dec 15 09:24 tmp-unbuffered.bz2
+#   248 Dec 15 09:24 tmp-unbuffered.xz
+# $ rm tmp-*buffered*
 
 import bz2
 import gzip
@@ -35,14 +36,14 @@ LZMA_PRESET = 6  # 0-9, default is 6
 
 
 def write_direct_unbuffered():
-    file = open("/tmp/unbuffered", mode="wb")
+    file = open("tmp-unbuffered", mode="wb")
     for i in range(0, LINES):
         file.write(LINE)
     file.close()
 
 
 def write_direct_buffered():
-    file = open("/tmp/buffered", mode="wb")
+    file = open("tmp-buffered", mode="wb")
     buffer = []
     for i in range(0, LINES):
         buffer.append(LINE)
@@ -51,14 +52,14 @@ def write_direct_buffered():
 
 
 def write_gzip_unbuffered():
-    file = gzip.GzipFile("/tmp/unbuffered.gz", compresslevel=GZIP_COMPRESS, mode="wb")
+    file = gzip.GzipFile("tmp-unbuffered.gz", compresslevel=GZIP_COMPRESS, mode="wb")
     for i in range(0, LINES):
         file.write(LINE)
     file.close()
 
 
 def write_gzip_buffered():
-    file = gzip.GzipFile("/tmp/buffered.gz", compresslevel=GZIP_COMPRESS, mode="wb")
+    file = gzip.GzipFile("tmp-buffered.gz", compresslevel=GZIP_COMPRESS, mode="wb")
     buffer = []
     for i in range(0, LINES):
         buffer.append(LINE)
@@ -67,14 +68,14 @@ def write_gzip_buffered():
 
 
 def write_bz2_unbuffered():
-    file = bz2.BZ2File("/tmp/unbuffered.bz2", mode="wb", compresslevel=BZ2_COMPRESS)
+    file = bz2.BZ2File("tmp-unbuffered.bz2", mode="wb", compresslevel=BZ2_COMPRESS)
     for i in range(0, LINES):
         file.write(LINE)
     file.close()
 
 
 def write_bz2_buffered():
-    file = bz2.BZ2File("/tmp/buffered.bz2", mode="wb", compresslevel=BZ2_COMPRESS)
+    file = bz2.BZ2File("tmp-buffered.bz2", mode="wb", compresslevel=BZ2_COMPRESS)
     buffer = []
     for i in range(0, LINES):
         buffer.append(LINE)
@@ -83,14 +84,14 @@ def write_bz2_buffered():
 
 
 def write_lzma_unbuffered():
-    file = lzma.LZMAFile("/tmp/unbuffered.xz", mode="wb", preset=LZMA_PRESET)
+    file = lzma.LZMAFile("tmp-unbuffered.xz", mode="wb", preset=LZMA_PRESET)
     for i in range(0, LINES):
         file.write(LINE)
     file.close()
 
 
 def write_lzma_buffered():
-    file = lzma.LZMAFile("/tmp/buffered.xz", mode="wb", preset=LZMA_PRESET)
+    file = lzma.LZMAFile("tmp-buffered.xz", mode="wb", preset=LZMA_PRESET)
     buffer = []
     for i in range(0, LINES):
         buffer.append(LINE)

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ commands =
 	coverage run testing/statistics_test.py --verbose
 	coverage run testing/time_test.py --verbose
 	coverage run testing/user_group_test.py --verbose
+	coverage run testing/utils_buffer_test.py --verbose
 	coverage run testing/utils_convert_test.py --verbose
 	coverage run testing/utils_simpleps_test.py --verbose
 # can only work on OS/X TODO later

--- a/tox_smoke.ini
+++ b/tox_smoke.ini
@@ -47,5 +47,6 @@ commands =
 	python testing/setconnections_test.py --verbose
 	python testing/time_test.py --verbose
 	python testing/user_group_test.py --verbose
+	python testing/utils_buffer_test.py --verbose
 	python testing/utils_convert_test.py --verbose
 	python testing/utils_simpleps_test.py --verbose

--- a/tox_win.ini
+++ b/tox_win.ini
@@ -67,6 +67,7 @@ commands =
     python testing/statistics_test.py
     python testing/time_test.py
 #    python testing/user_group_test.py   # no module named pwd under Windows
+    python testing/utils_buffer_test.py --verbose
     python testing/utils_convert_test.py --verbose
     python testing/utils_simpleps_test.py --verbose
 # can only work on OS/X TODO later


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

- Align the statistics module more with the log approach, as singleton
- Rewrite the session statistics classes
- adapt accordingly the testing
- Move buffering to rdiffbackup.utils.buffer
- add test case for utils.buffer
- Add typing to buffer module
- Add misc script to benchmark compression
- Adding FileStats tests to statistics tests
- Rename FileStats to FileStatsTracker and instantiate it as object FileStats
- introduce StatsWriter and Reader
- simplify and modernize some code
- Adapt tests to changes
- Add typing to statistics module

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
