### PR TITLE
Fixing failing complete on nargs=+

### DIFF
--- a/src/rdiffbackup/actions/complete.py
+++ b/src/rdiffbackup/actions/complete.py
@@ -229,7 +229,8 @@ class CompleteAction(actions.BaseAction):
             not is_matched
             and "locations" in args
             and (
-                args["locations"].nargs == "*"
+                args["locations"].nargs in {"*", "+"}
+                or (args["locations"].nargs == "?" and cword >= (len(words) - 1))
                 or cword >= (len(words) - args["locations"].nargs)
             )
         ):

--- a/testing/action_complete_test.py
+++ b/testing/action_complete_test.py
@@ -110,6 +110,19 @@ class ActionCompleteTest(unittest.TestCase):
         )
         self.assertTrue(full_output.startswith(b"--"))
         self.assertTrue(full_output.endswith(b"::file::\n"))
+        # try with a command accepting a variable number of files
+        full_output = comtst.rdiff_backup_action(
+            True,
+            True,
+            None,
+            None,
+            ("--api-version", "201"),
+            b"complete",
+            ("--cword", "2", "--", "rdiff-backup", "test", ""),
+            return_stdout=True,
+        )
+        self.assertTrue(full_output.startswith(b"-h"))
+        self.assertTrue(full_output.endswith(b"::file::\n"))
 
         full_output = comtst.rdiff_backup_action(
             True,


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

FIX: command line completion failed on TypeError unsupported operand type for nargs

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
