### PR TITLE
Allow wildcard drive letter on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ mprofile_*.dat
 
 # Ignore virtualenv
 .venv
+
+# Ignore compiled modules
+src/rdiff_backup/*.so

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ mprofile_*.dat
 
 # Ignore Windows artefacts
 *.dll
+
+# Ignore virtualenv
+.venv

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -506,7 +506,6 @@ class FileStat:
 
 def sum_fst(rp_pairs):
     """Add the file statistics given as list of (session_rp, file_rp) pairs"""
-    global quiet
     n = len(rp_pairs)
     if not quiet:
         log.Log("Processing statistics from session 1 of %d" % (n,), log.NONE)

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -191,6 +191,7 @@ class Select:
             "exclude-device-files": (self._devfiles_get_sf, Select.EXCLUDE),
             "exclude-sockets": (self._sockets_get_sf, Select.EXCLUDE),
             "exclude-fifos": (self._fifos_get_sf, Select.EXCLUDE),
+            "exclude-unreadable": (self._unreadable_get_sf, Select.EXCLUDE),
             "exclude-other-filesystems": (
                 self._other_filesystems_get_sf,
                 Select.EXCLUDE,
@@ -569,6 +570,19 @@ probably isn't what you meant""".format(
         """Return a selection function matching all fifos"""
         return self._gen_get_sf(rpath.RORPath.isfifo, include, "fifo files")
 
+    def _unreadable_get_sf(self, include):
+        """Return a selection function matching unreadable files."""
+
+        def sel_func(rp):
+            if not rp.readable():
+                return include
+            else:
+                return None
+
+        sel_func.exclude = not include
+        sel_func.name = (include and "include" or "exclude") + " unreadable files"
+        return sel_func
+
     def _special_get_sf(self, include):
         """Return sel function matching sockets, symlinks, sockets, devs"""
 
@@ -737,7 +751,7 @@ probably isn't what you meant""".format(
         prefixes = [b"/".join(glob_parts[: i + 1]) for i in range(len(glob_parts))]
         # we must make exception for root "/", or "X:/" under Windows,
         # only dirs to end in slash
-        if prefixes[0] == b"" or re.fullmatch(b"[a-zA-Z]:", prefixes[0]):
+        if prefixes[0] == b"" or re.fullmatch(b"[a-zA-Z*]:", prefixes[0]):
             prefixes[0] += b"/"
         return list(map(self._glob_to_re, prefixes))
 

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -493,7 +493,6 @@ def _list_to_acl(entry_list, map_names=1):
 
     def warn_drop(name):
         """Warn about acl with name getting dropped"""
-        global dropped_acl_names
         if generics.never_drop_acls:
             log.Log.FatalError(
                 "--never-drop-acls specified but cannot map "

--- a/testing/generic_roottest.py
+++ b/testing/generic_roottest.py
@@ -426,7 +426,6 @@ class NonRoot(BaseRootTest):
         return rp, sp
 
     def backup(self, input_rp, output_rp, time):
-        global user
         backup_cmd = b"%s --current-time %i backup --no-compare-inode %b %b" % (
             comtst.RBBin,
             time,

--- a/testing/selection_test.py
+++ b/testing/selection_test.py
@@ -655,6 +655,15 @@ rdiff-backup_testfiles/select**/2
                 ],
                 [(), ("Users",)],
             )
+            self.root = rpath.RPath(specifics.local_connection, "C:/")
+            self.ParseTest(
+                [
+                    ("exclude", b"*:/Users/*"),
+                    ("include", b"C:/Users"),
+                    ("exclude", b"C:/"),
+                ],
+                [(), ("Users",)],
+            )
         else:
             self.root = rpath.RPath(specifics.local_connection, "/")
             self.ParseTest(


### PR DESCRIPTION
## Changes done and why

--include and --exclude may now be defined as `--exclude "*:/filename"`

## Self-Checklist

- [ ] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
