### PR TITLE
Use surrogateescape for list files & compare output

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -197,7 +197,7 @@ class RORPath:
 
         For instance, if the index is ("a", "b"), return "'a/b'".
         """
-        return self.get_indexpath().decode(errors="replace")
+        return self.get_indexpath().decode(errors="surrogateescape")
 
     def __getstate__(self):
         """Return picklable state

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -171,7 +171,7 @@ class CompareAction(actions.BaseAction):
         for report in report_iter:
             changed_files_found += 1
             indexpath = report.index and b"/".join(report.index) or b"."
-            indexpath = indexpath.decode(errors="replace")
+            indexpath = indexpath.decode(errors="surrogateescape")
             if parsable:
                 reason_verify_list.append({"reason": report.reason, "path": indexpath})
             else:

--- a/src/rdiffbackup/singletons/log.py
+++ b/src/rdiffbackup/singletons/log.py
@@ -128,7 +128,7 @@ class Logger:
             and self.term_verbosity < DEBUG
             and "\n" not in tmpstr[:-1]
         ):
-            termfp.write(
+            tmpstr = (
                 textwrap.fill(
                     tmpstr,
                     subsequent_indent=" " * 9,
@@ -138,7 +138,14 @@ class Logger:
                 )
                 + "\n"
             )
-        else:
+        try:
+            termfp.write(tmpstr)
+        except UnicodeEncodeError:
+            # In case the terminal output is not configured with surrogateescape
+            # Enforce use of backslashreplace errors to avoid fatal error.
+            tmpstr = tmpstr.encode(errors="surrogateescape").decode(
+                errors="backslashreplace"
+            )
             termfp.write(tmpstr)
 
     def conn(self, direction: str, result: typing.Any, req_num: int) -> None:

--- a/testing/action_compare_test.py
+++ b/testing/action_compare_test.py
@@ -23,7 +23,7 @@ class ActionCompareTest(unittest.TestCase):
         self.from1_struct = {
             "from1": {
                 "contents": {
-                    "fileChanged": {"content": "initial"},
+                    "fileChanged\udcff": {"content": "initial"},
                     "fileOld": {},
                     "fileUnchanged": {"content": "unchanged"},
                 }
@@ -33,7 +33,7 @@ class ActionCompareTest(unittest.TestCase):
         self.from2_struct = {
             "from2": {
                 "contents": {
-                    "fileChanged": {"content": "modified"},
+                    "fileChanged\udcff": {"content": "modified"},
                     "fileNew": {},
                     "fileUnchanged": {"content": "unchanged"},
                 }
@@ -43,7 +43,7 @@ class ActionCompareTest(unittest.TestCase):
         self.from3_struct = {
             "from3": {
                 "contents": {
-                    "fileChanged": {"content": "samesize"},
+                    "fileChanged\udcff": {"content": "samesize"},
                     "fileNew": {},
                     "fileUnchanged": {"content": "unchanged"},
                 }
@@ -170,7 +170,7 @@ class ActionCompareTest(unittest.TestCase):
                 return_stdout=True,
             ),
             b"""---
-- path: fileChanged
+- path: "fileChanged\\uDCFF"
   reason: metadata the same, data changed
 ...
 
@@ -215,7 +215,7 @@ class ActionCompareTest(unittest.TestCase):
                 return_stdout=True,
             ),
             b"""---
-- path: fileChanged
+- path: "fileChanged\\uDCFF"
   reason: metadata the same, data changed
 ...
 

--- a/testing/action_list_test.py
+++ b/testing/action_list_test.py
@@ -259,6 +259,32 @@ deleted fileOld
         # all tests were successful
         self.success = True
 
+    def test_action_listfiles_nonutf8(self):
+        # Given a repository with non-utf8
+        repo = os.path.join(comtst.old_test_dir, b"restoretest5")
+        # When calling rdiff-backup list files
+        output = (
+            comtst.rdiff_backup_action(
+                False,
+                None,
+                repo,
+                None,
+                (
+                    "--api-version",
+                    "201",
+                ),
+                b"list",
+                ("files",),
+                return_stdout=True,
+            ),
+        )
+        output_lines = output[0].split(b"\n")
+        # Then the output make use of surogate escape.
+        self.assertIn(
+            b"\xd8\xab\\xb1Wb\\xae\\xc5]\\x8a\\xbb\x15v*\\xf4\x0f!\\xf9>\\xe2Y\\x86\\xbb\\xab\\xdbp\\xb0\\x84\x13k\x1d\\xc2\\xf1\\xf5e\\xa5U\\x82\\x9aUV\\xa0\\xf4\\xdf4\\xba\\xfdX\x03\\x82\x07s\xce\x9e\\x8b\\xb34\x04\\x9f\x17 \\xf4\\x8f\\xa6\\xfa\\x97\\xab\xd8\xac\xda\x85\\xdcKvC\\xfa#\\x94\\x92\\x9e\xc9\xb7\\xc3_\x0f\\x84g\\x9aB\x11<=^\\xdbM\x13\\x96c\\x8b\\xa7|*\"\\'^$@#!(){}?+ ~` ",
+            output_lines,
+        )
+
     def tearDown(self):
         # we clean-up only if the test was successful
         if self.success:


### PR DESCRIPTION
## Changes done and why

- Change implementation of log.py to send unicode directly to stdout using surrogateescape, fallback to backslashreplace.
- Use surrogateescape in list files output
- Use surrogateescape in compare output

## Self-Checklist

- [ ] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
