### PR TITLE
[DOC] update info on FAQ about regress that now is an official command

### DIFF
--- a/docs/CODING.adoc
+++ b/docs/CODING.adoc
@@ -24,7 +24,7 @@ double quotes but states that triple-quoted strings should use double quotes "to
 * we call items any definition of class, function, member, variable, etc...
 * private items are pre-fixed with an underscore
 * public items are to be defined before private ones.
-Pre-defined functions (generally pre- and post-fixed with two underscores, like `__init__`) are defined before all others.
+Pre-defined functions (generally pre- and post-fixed with two underscores, like `+__init__+`) are defined before all others.
 * the order should be logical (e.g.
 called functions after calling ones) rather than lexical.
 * in class definitions, variables are defined before class methods, before instance methods (each in the order defined above).
@@ -62,7 +62,7 @@ NOTE: one of the main driver for the above recommendations is the possibility to
 == BYTES VS. STR
 
 * Paths and commands are expressed in bytes to avoid issues with cross-platform encoding conversion, any function manipulating such things must return bytes.
-* Only methods creating a Path/Command object (`__init__` and similar) might accept strings as input and convert them internally to bytes.
+* Only methods creating a Path/Command object (`+__init__+` and similar) might accept strings as input and convert them internally to bytes.
 Other functions must make sure that they don't accept strings as input (this is one of the few reasons to use asserts).
 * Any conversion between strings and bytes happens with `os.fsencode/fsdecode`.
 * Messages are to be expressed in strings (log, errors, etc).

--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -405,8 +405,8 @@ CAUTION: remember that you can't change the quoting once a backup repository has
 
 == How to work around the limitation to mix file selection and sub-path restore?
 
-Since rdiff-backup 2.1+, a command like `rdiff-backup restore --include myrestore/subdir/somefile --exclude '**' myrepo/subdir myrestore/subdir` isn't possible anymore, because it could lead to https://github.com/rdiff-backup/rdiff-backup/issues/463[data loss].
-Such calls are anyway equivalent to something like `rdiff-backup restore --include myrestore/subdir/somefile --exclude '**' myrepo myrestore`.
+Since rdiff-backup 2.1+, a command like `+rdiff-backup restore --include myrestore/subdir/somefile --exclude '**' myrepo/subdir myrestore/subdir+` isn't possible anymore, because it could lead to https://github.com/rdiff-backup/rdiff-backup/issues/463[data loss].
+Such calls are anyway equivalent to something like `+rdiff-backup restore --include myrestore/subdir/somefile --exclude '**' myrepo myrestore+`.
 This means that the new limitation doesn't imply a loss in feature, it only enforces a new approach without risk of losing data.
 
 == How can I integrate the rdiff-backup functionality in my own program?
@@ -484,9 +484,9 @@ If this is not possible, you can create a new bigger partition using a _similar_
 
 If this is also not an option, and you have nothing else outside of the repository that you can move away (or remove), then you can try to remove the following files:
 
-- `/mnt/bak/rdiff-backup-data/*.log`
-- `/mnt/bak/rdiff-backup-data/error_log*`
-- `/mnt/bak/rdiff-backup-data/*_statistics.*`
+- `+/mnt/bak/rdiff-backup-data/*.log+`
+- `+/mnt/bak/rdiff-backup-data/error_log*+`
+- `+/mnt/bak/rdiff-backup-data/*_statistics.*+`
 
 === Recovering
 

--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -346,7 +346,7 @@ For more information on this approach, see this mailing list post: https://lists
 
 == What does "`AssertionError: Bad index order`" mean?
 
-If rdiff-backup fails with the message `AssertionError: Bad index order`," it could be because the files in a directory have changed while rdiff-backup is running.
+If rdiff-backup fails with the message `AssertionError: Bad index order`, it could be because the files in a directory have changed while rdiff-backup is running.
 Possible ways of dealing with this situation include implementing filesystem snapshots using the volume manager, excluding the offending directory, or suspending the process that is changing the directory.
 After the text "Bad index order", the error message will indicate which files have caused the problem.
 

--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -369,7 +369,10 @@ If you want to use a different timezone than UTC, you can refer to the https://d
 If you've done something wrong in your last back-up, you have potentially two solutions to get rid of it.
 If you've backed-up a file or directory you shouldn't have backed-up, you can remove it again using `rdiff-backup-delete <repo>/<file-or-dir>`;
 beware that _all_ files, including all earlier versions, will be removed without any question back!
-If the situation is more complicated, you might want to have a look at https://www.timedicer.co.uk/programs/help/rdiff-backup-regress.sh.php[rdiff-backup-regress] which completely removes the last made backup, but beware that regression takes a long time.
+
+If the situation is more complicated, you might want to do a regression. On version 2.2.0 (December 2022) and later, you can use the command xref:rdiff-backup.1.adoc[`rdiff-backup regress`] with the `--force` option.
+
+For earlier versions (before version 2.2), have a look at https://www.timedicer.co.uk/programs/help/rdiff-b.ackup-regress.sh.php[rdiff-backup-regress] which completely removes the last made backup, but beware that regression takes a long time.
 Note that we made a copy of this nice utility, placed under `tools/misc` in our Git repo, just to be sure it doesn't get lost.
 
 == Backup on my file-system XYZ fails, can you support it?

--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -134,11 +134,6 @@ You will wind up with only one file (!) since HFS+ doesn't distinguish between t
 Therefore, when rdiff-backup copies files from case-sensitive to case-insensitive filesystems, it escapes the uppercase characters (eg, "M" is replaced with ";077", and "F" with ";070") so that no filename conflicts occur.
 Upon restore (from the Mac backup server to the Linux system), the filenames are unquoted and you will get "MyFile" back.
 
-== My backup set contains some files that I just realized I don't want/need backed up.  How do I remove them from the backup volume to save space?
-
-The only official way to remove files from an rdiff-backup repository is by letting them expire using the --remove-older-than option.
-Deleting increments from the rdiff-backup-data directory will prevent you from recovering those files, but shouldn't prevent the rest of the repository from being restored.
-
 == Does rdiff-backup work under Solaris?
 
 There may be a problem with rdiff-backup and Solaris' libthread.
@@ -364,9 +359,10 @@ On Unix, for UTC, simply set `TZ=UTC` in your shell, or prepend ``TZ=UTC `` to t
 On Windows, set the `TZ` environment variable with the `set TZ=UTC` command in the `Cmd.exe` command interpreter (or in a batch script), or with `$env:TZ='UTC'` in PowerShell.
 If you want to use a different timezone than UTC, you can refer to the https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/tzset#remarks[`_tzset` CRT documentation] which describes in detail the format Windows expects for the value of the `TZ` variable.
 
-== I've done a blunder in my last backup, how to roll-back?
+== I've done a blunder in my last backup, how to roll-back? _Or_ my backup set contains some files that I just realized I don't want/need backed up. How do I remove them from the backup volume to save space?
 
 If you've done something wrong in your last back-up, you have potentially two solutions to get rid of it.
+
 If you've backed-up a file or directory you shouldn't have backed-up, you can remove it again using `rdiff-backup-delete <repo>/<file-or-dir>`;
 beware that _all_ files, including all earlier versions, will be removed without any question back!
 

--- a/docs/FAQ.adoc
+++ b/docs/FAQ.adoc
@@ -108,15 +108,15 @@ Under both Linux and Mac OS X, smbfs seems to be working quite well.
 However, it has a 2 GB file limit and is deprecated on Linux.
 CIFS users sometimes experience one of these common errors:
 
- ** rdiff-backup fails to run, printing an exception about "`assert not upper_a.lstat()`" failing.
-This can be resolved by unmounting the share, running the following command as root:\ `$ echo 0 > /proc/fs/cifs/LookupCacheEnabled`\ and then remounting the CIFS share.\ \
+ ** rdiff-backup fails to run, printing an exception about `assert not upper_a.lstat()` failing.
+This can be resolved by unmounting the share, running the following command as root: `$ echo 0 > /proc/fs/cifs/LookupCacheEnabled` and then remounting the CIFS share.
  ** If filenames in the mirror directory have some characters transformed to a '?' instead of remaining the expected Unicode character, you will need to adjust the `iocharset=` mount option.
 This happens because the server is using a codepage with only partial Unicode support and is not translating characters correctly.
 See the mount.cifs man page for more information.
 Using smbfs can also improve this situation since it has both an `iocharset=` and a `codepage=` option.
  ** If you have trouble with filenames containing a colon ':', or another reserved Windows character, try using the `mapchars` option to the CIFS mount.
 At least one user has reported success when using this option while mounting a NAS system via CIFS.
-See the mount.cifs man page for more information.\ \
+See the mount.cifs man page for more information.
  ** Other CIFS mount options which may be helpful include `nocase`, `directio`, and `sfu`.
 Also, try changing the value of `/proc/fs/cifs/LinuxExtensionsEnabled` (requires remount).
 A user with a DroboShare reported that `-o mapchars,nocase,directio` worked for that NAS appliance.
@@ -335,9 +335,9 @@ Simply add `/sw/bin` to your path manually, or copy rdiff-backup to a directory 
 
 == What does "`tuple index out of range`" mean?
 
-If you see the error "`tuple index out of range`" after running a command like:\ \ `$ rdiff-backup -l /path/to/backup/rdiff-backup-data/`\ \ then the solution is to simply remove the extra "rdiff-backup-data" from the end of the path.
+If you see the error `tuple index out of range` after running a command like: `$ rdiff-backup -l /path/to/backup/rdiff-backup-data/` then the solution is to simply remove the extra "rdiff-backup-data" from the end of the path.
 The list increments option, and others like it, take the path to the repository, not the path to the rdiff-backup-data directory.
-In the above example, you should run again with:\ \ `$ rdiff-backup -l /path/to/backup`\ \ If you get this error message for an unrelated reason, try contacting the mailing list.
+In the above example, you should run again with: `$ rdiff-backup -l /path/to/backup`. If you get this error message for an unrelated reason, try contacting the mailing list.
 
 == What does "`IO Error: CRC check failed`" mean?
 
@@ -346,12 +346,12 @@ Possible causes of this error include an incomplete gzip operation, and hardware
 A brute-force way to recover from this error is to remove the rdiff-backup-data directory.
 However, this will remove all of your past increments.
 A better approach may be to delete the particular file that is causing the problem.
-A command like:\ \ `$ find rdiff-backup-data -type f -name \*.gz -print0 | xargs -0r gzip --test`\ \ will find the failing file.
+A command like: `$ find rdiff-backup-data -type f -name \*.gz -print0 | xargs -0r gzip --test` will find the failing file.
 For more information on this approach, see this mailing list post: https://lists.nongnu.org/archive/html/rdiff-backup-users/2007-11/msg00008.html.
 
 == What does "`AssertionError: Bad index order`" mean?
 
-If rdiff-backup fails with the message "`AssertionError: Bad index order`," it could be because the files in a directory have changed while rdiff-backup is running.
+If rdiff-backup fails with the message `AssertionError: Bad index order`," it could be because the files in a directory have changed while rdiff-backup is running.
 Possible ways of dealing with this situation include implementing filesystem snapshots using the volume manager, excluding the offending directory, or suspending the process that is changing the directory.
 After the text "Bad index order", the error message will indicate which files have caused the problem.
 

--- a/docs/arch/locations.adoc
+++ b/docs/arch/locations.adoc
@@ -17,7 +17,7 @@ It can either be a simple directory from which to backup, or to which to restore
 A location has a base_dir represented by an _rpath.RPath_ object.
 
 NOTE: an idea could be to make Location a child class of rpath.RPath, so that it represents its own `base_dir`.
-An alternative idea could to use `__getattr__` to delegate attributes to `base_dir`...
+An alternative idea could to use `+__getattr__+` to delegate attributes to `base_dir`...
 The author of those lines is still thinking about pros and cons of these options.
 
 The ultimate idea would be to have all client/server communications go through the location because, at the end, it's what is present remotely, and the whole actions only act against those locations, potentially transferring data from one location to the next.

--- a/docs/arch/plugins/actions.adoc
+++ b/docs/arch/plugins/actions.adoc
@@ -39,13 +39,13 @@ The Action class has the following interface, in addition to the generic plugin 
 A security class of `None` is only applicable to actions without client/server context (e.g.
 `info`).
 * the class method `cls.add_action_subparser(sub_handler)` returns a subparser as returned by argparse's `sub_handler.add_parser` function, so that the sub-options of the action can be parsed by the `rdiffbackup.arguments.parse` function.
-* the method `self.__init__(args, log, errlog)` initializes the class as object, based on the namespace returned by argparse, a Log and an ErrorLog object.
+* the method `+self.__init__(args, log, errlog)+` initializes the class as object, based on the namespace returned by argparse, a Log and an ErrorLog object.
 * the method `self.pre_check()` just validates that the arguments passed were correct, beyond what argparse could do, and shouldn't try to connect yet to any remote location.
 A return value unequal 0 means an error, which can be used as exit code.
 * the method `self.connect()` returns a https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers[context manager object] which can be used in a `with action.connect() as conn_act:` construct.
 It is expected that the action object itself is the context manager, but it isn't absolutely necessary (but the default implementation offered by the BaseAction).
-The returned class must hence have two methods `self.__enter__()` and `self.__exit__(self, exc_type, exc_value, traceback)` (closing the connections).
-Again, it is expected that the runtime context object returned by `__enter__` is the same action object (aka `return self`), but it isn't an obligation.
+The returned class must hence have two methods `+self.__enter__()+` and `+self.__exit__(self, exc_type, exc_value, traceback)+` (closing the connections).
+Again, it is expected that the runtime context object returned by `+__enter__+` is the same action object (aka `return self`), but it isn't an obligation.
 +
 This context object has the following interface, usable through the connection(s) started by `connect()`:
 
@@ -59,7 +59,7 @@ It returns 0 in case of success, else an integer to be used as exit code.
 It might return 0 in case of success, else an integer to be used as exit code.
 It is the only function that might exit directly instead, even though it isn't the recommended approach (but a matter of fact for most existing actions).
 
-NOTE: the context object doesn't need a "cleanup" action as clean-up is to   be done as part of the `__exit__` method provided by the context manager.
+NOTE: the context object doesn't need a "cleanup" action as clean-up is to   be done as part of the `+__exit__+` method provided by the context manager.
 
 Of course, action classes inheriting from the BaseAction class don't need to define all aspects themselves, making the life of plug-in developers easier.
 

--- a/docs/arch/plugins/meta.adoc
+++ b/docs/arch/plugins/meta.adoc
@@ -52,7 +52,7 @@ Also note that the carbon files and resource forks attributes are also still han
 
 * the class method `cls.join_iter()` (not required to be implemented by the main class), allows to intermangle an iterator of `RORPath` objects with the corresponding iterator of metadata.
 This allows to handle all metadata in one iterator.
-* the class can be instantiated (through the `__init__` class), effectively opening the underlying metadata-file.
+* the class can be instantiated (through the `+__init__+` class), effectively opening the underlying metadata-file.
 * the method `self.write_object()` can then be used to write an object representing the metadata.
 The metadata-class is also defined within the plugin-module but must be stable because it is transferred through the connection!
 * the method `self.get_objects()` returns an iterator of objects read from the underlying file.


### PR DESCRIPTION
## Changes done and why
Update FAQ about regress that was not updated to the inclusion of the regress action.

## Self-Checklist

- [X] changes to the code have been reflected in the documentation
- [X] changes to the code have been covered by new/modified tests
- [X] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
