### PR TITLE
Remove global variables only read

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # rdiff-backup build environment (for developers)
 FROM debian:sid
 
-# General Debian build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+# General Debian build dependencies
     devscripts \
     equivs \
     curl \
@@ -12,21 +12,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
     git-buildpackage \
     pristine-tar \
     dh-python \
-    build-essential
-
+    build-essential \
 # Build dependencies specific for rdiff-backup
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
-    apt-get install -y --no-install-recommends \
     librsync-dev \
     python3-all-dev \
     python3-pylibacl \
     python3-yaml \
     python3-pyxattr \
-    asciidoctor
-
+    asciidoctor \
 # Build dependencies specific for rdiff-backup development and testing
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
-    apt-get install -y --no-install-recommends \
     tox \
     rdiff \
     python3-setuptools-scm \
@@ -36,8 +30,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && \
     rsync
 
 # Tests require that there is a regular user
-ENV RDIFF_TEST_UID 1000
-ENV RDIFF_TEST_USER testuser
-ENV RDIFF_TEST_GROUP testuser
+ENV RDIFF_TEST_UID=1000
+ENV RDIFF_TEST_USER=testuser
+ENV RDIFF_TEST_GROUP=testuser
 
 RUN useradd -ms /bin/bash --uid ${RDIFF_TEST_UID} ${RDIFF_TEST_USER}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ RUN_COMMAND ?= docker run --rm -i -v ${PWD}/..:/build/ -w /build/$(shell basenam
 # we set SUDO="sudo -E env PATH=$PATH" if we want to keep the whole environment
 SUDO ?=
 
-all: clean container test build
+.NOTPARALLEL: all test-misc
+
+all: container clean test build
 
 test: test-static test-runtime
 
@@ -37,7 +39,7 @@ test-runtime-slow: test-runtime-files
 	@echo "=== Long running performance tests ==="
 	${RUN_COMMAND} tox -c tox_slow.ini -e py
 
-test-misc: clean build test-static test-runtime-slow
+test-misc: container clean build test-static test-runtime-slow
 
 build:
 	# Build rdiff-backup (assumes src/ is in directory 'rdiff-backup' and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 	'Environment :: Console',
 	'Intended Audience :: End Users/Desktop',
 	'Intended Audience :: System Administrators',
-	'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
 	'Natural Language :: English',
 	'Operating System :: POSIX :: Linux',
 	'Operating System :: POSIX',  # generic because users reported FreeBSD to work

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -506,7 +506,6 @@ class FileStat:
 
 def sum_fst(rp_pairs):
     """Add the file statistics given as list of (session_rp, file_rp) pairs"""
-    global quiet
     n = len(rp_pairs)
     if not quiet:
         log.Log("Processing statistics from session 1 of %d" % (n,), log.NONE)

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -493,7 +493,6 @@ def _list_to_acl(entry_list, map_names=1):
 
     def warn_drop(name):
         """Warn about acl with name getting dropped"""
-        global dropped_acl_names
         if generics.never_drop_acls:
             log.Log.FatalError(
                 "--never-drop-acls specified but cannot map "

--- a/testing/generic_roottest.py
+++ b/testing/generic_roottest.py
@@ -426,7 +426,6 @@ class NonRoot(BaseRootTest):
         return rp, sp
 
     def backup(self, input_rp, output_rp, time):
-        global user
         backup_cmd = b"%s --current-time %i backup --no-compare-inode %b %b" % (
             comtst.RBBin,
             time,


### PR DESCRIPTION
## Changes done and why

Newer versions of flake8 started to complain about global declarations used only read-only.

## Self-Checklist

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
