### PR TITLE
Handle NotImplementedError raised by acl_win

### DIFF
--- a/src/rdiffbackup/meta/acl_win.py
+++ b/src/rdiffbackup/meta/acl_win.py
@@ -117,7 +117,16 @@ class ACL:
                 # traverse the ACL in reverse, so the indices stay correct
                 while n:
                     n -= 1
-                    ace_flags = acl.GetAce(n)[0][1]
+                    try:
+                        ace_flags = acl.GetAce(n)[0][1]
+                    except NotImplementedError:
+                        log.Log(
+                            "Unable to read ACE {idx} of DACL from path {pa}, "
+                            "ACE type not supported, "
+                            "skipping it".format(idx=n, pa=rp),
+                            log.INFO,
+                        )
+                        continue
                     if ace_flags & INHERIT_ONLY_ACE:
                         acl.DeleteAce(n)
             sd.SetSecurityDescriptorDacl(1, acl, 0)
@@ -129,7 +138,16 @@ class ACL:
                     # traverse the ACL in reverse, so the indices stay correct
                     while n:
                         n -= 1
-                        ace_flags = acl.GetAce(n)[0][1]
+                        try:
+                            ace_flags = acl.GetAce(n)[0][1]
+                        except NotImplementedError:
+                            log.Log(
+                                "Unable to read ACE {idx} of SACL from path "
+                                "{pa}, ACE type not supported, "
+                                "skipping it".format(idx=n, pa=rp),
+                                log.INFO,
+                            )
+                            continue
                         if ace_flags & INHERIT_ONLY_ACE:
                             acl.DeleteAce(n)
                     sd.SetSecurityDescriptorSacl(1, acl, 0)


### PR DESCRIPTION
## Changes done and why

Change error handling arround acl_win.py to catch `NotImplementedError` that get raised by `acl.GetAce()` when the ACL type is not supported.

This issue was repported by a Minarca User.
https://gitlab.com/ikus-soft/minarca/-/issues/324

## Self-Checklist

- [-] changes to the code have been reflected in the documentation
- [-] changes to the code have been covered by new/modified tests
- [-] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
