### PR TITLE
Centralize all conversations between bytes and str

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -46,7 +46,7 @@ from rdiff_backup import C, Time
 from rdiffbackup.locations.map import owners as map_owners
 from rdiffbackup.meta import acl_posix, acl_win, ea
 from rdiffbackup.singletons import consts, generics, log, specifics
-from rdiffbackup.utils import usrgrp
+from rdiffbackup.utils import convert, usrgrp
 
 try:
     import win32api
@@ -197,7 +197,7 @@ class RORPath:
 
         For instance, if the index is ("a", "b"), return "'a/b'".
         """
-        return self.get_indexpath().decode(errors="replace")
+        return convert.to_safe_str(self.get_indexpath())
 
     def __getstate__(self):
         """Return picklable state
@@ -412,7 +412,7 @@ class RORPath:
 
         For instance, if the index is (b"a", b"b"), return ("a", "b")
         """
-        return tuple(map(lambda f: f.decode(errors="replace"), self.index))
+        return tuple(map(lambda f: convert.to_safe_str(f), self.index))
 
     def get_indexpath(self):
         """Return path of index portion
@@ -717,9 +717,9 @@ class RPath(RORPath):
             if isinstance(somepath, str):
                 return somepath
             else:
-                return somepath.decode(errors="replace")
+                return convert.to_safe_str(somepath)
         else:
-            return self.path.decode(errors="replace")
+            return convert.to_safe_str(self.path)
 
     def __getstate__(self):
         """Return picklable state

--- a/src/rdiff_backup/run_stats.py
+++ b/src/rdiff_backup/run_stats.py
@@ -254,7 +254,7 @@ class FileStatisticsTree:
             percentage = float(val) / fs_func(self.fs_root) * 100
             path = fs.nametuple and b"/".join(fs.nametuple) or b"."
             log.Log(
-                "%s (%02.1f%%)" % (path.decode(errors="replace"), percentage),
+                "%s (%02.1f%%)" % (convert.to_safe_str(path), percentage),
                 log.NONE,
             )
 

--- a/src/rdiffbackup/actions/compare.py
+++ b/src/rdiffbackup/actions/compare.py
@@ -27,6 +27,7 @@ import yaml
 from rdiffbackup import actions
 from rdiffbackup.locations import directory, repository
 from rdiffbackup.singletons import consts, log, specifics
+from rdiffbackup.utils import convert
 
 
 class CompareAction(actions.BaseAction):
@@ -171,7 +172,7 @@ class CompareAction(actions.BaseAction):
         for report in report_iter:
             changed_files_found += 1
             indexpath = report.index and b"/".join(report.index) or b"."
-            indexpath = indexpath.decode(errors="replace")
+            indexpath = convert.to_safe_str(indexpath)
             if parsable:
                 reason_verify_list.append({"reason": report.reason, "path": indexpath})
             else:

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -1051,7 +1051,7 @@ class RepoShadow(location.LocationShadow):
             {
                 "time": inc.getinctime(),
                 "type": cls._get_inc_type(inc),
-                "base": inc.dirsplit()[1].decode(errors="replace"),
+                "base": convert.to_safe_str(inc.dirsplit()[1]),
             }
             for inc in incs_list
         ]
@@ -1062,7 +1062,7 @@ class RepoShadow(location.LocationShadow):
             {
                 "time": mirror_time,
                 "type": cls._get_file_type(cls._ref_path),
-                "base": cls._ref_path.dirsplit()[1].decode(errors="replace"),
+                "base": convert.to_safe_str(cls._ref_path.dirsplit()[1]),
             }
         )
 


### PR DESCRIPTION
## Changes done and why

Addresses #1050 in a first step to centralize all relevant conversions in rdiffbackup.utils.convert so that there is only one place to adapt. Obsoletes #1068 (PR)
This should make it easier to play around with different handlers.

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
