### PR TITLE
Remove spurious warning when attempting to delete non-existing increment.

### DIFF
--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -1230,7 +1230,7 @@ class RepoShadow(location.LocationShadow):
         if removal_time < 0:  # no increment is old enough
             log.Log(
                 "No increment is older than '{ot}'".format(ot=time_string),
-                log.WARNING,
+                log.NOTE,
             )
             return consts.RET_CODE_WARN
 
@@ -1411,12 +1411,6 @@ class RepoShadow(location.LocationShadow):
             ]
         times_in_secs = [t for t in times_in_secs if t < action_time]
         if not times_in_secs:
-            log.Log(
-                "No increments older than {at} found, exiting.".format(
-                    at=Time.timetopretty(action_time)
-                ),
-                log.NOTE,
-            )
             return -1
 
         times_in_secs.sort()

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -206,7 +206,7 @@ class ActionRemoveIncsTest(ActionRemoveTest):
                 b"remove",
                 ("increments", "--older-than", "30000"),
             ),
-            consts.RET_CODE_WARN,
+            consts.RET_CODE_OK,
         )
         self.assertRegex(
             comtst.rdiff_backup_action(


### PR DESCRIPTION
Both `RepoShadow._get_removal_time` and `RepoShadow.remove_increments_older_than` emit similar messages when attempting to delete an increment that does not exist. The former is only ever called by the latter. In one case it's a WARNING and in the other a NOTE.

## Changes done and why

Removes the NOTE from `RepoShadow._get_removal_time` and turns the WARNING from `RepoShadow.remove_increments_older_than` into a NOTE as requested in https://github.com/rdiff-backup/rdiff-backup/issues/1071
This is normal operation and is not worthy of a WARNING, let alone a WARNING and a NOTE.

AFAICT the return value or log messages in this situation are not documented so I have not modified the documentation but I have ticked the relevant box in this PR description as per developer documentation.

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
