### PR TITLE
Avoid remote system and rpath calls

### DIFF
--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -74,7 +74,6 @@ _file_requests = {
     "os.unlink": 0,
     "os.utime": 0,
     "rpath.make_file_dict": 0,
-    "rpath.delete_dir_no_files": 0,
     "shutil.rmtree": 0,
     "_repo_shadow.RepoShadow.init": 0,
     "_dir_shadow.ReadDirShadow.init": 0,
@@ -303,7 +302,6 @@ def _set_allowed_requests(sec_class, sec_level):
     if sec_level == "read-write":
         requests.update(
             [
-                "rpath.delete_dir_no_files",
                 "rpath.copy_reg_file",  # FIXME really needed?
                 "rpath.make_socket_local",  # FIXME really needed?
                 "rpath.RPath.fsync_local",  # FIXME really needed?

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -59,12 +59,8 @@ _disallowed_server_globals = ["server"]
 # taking a file.
 _file_requests = {
     "os.chmod": 0,
-    "os.chown": 0,
-    "os.lchown": 0,
     "os.link": 1,
     "os.listdir": 0,
-    "os.makedirs": 0,
-    "os.mkdir": 0,
     "os.mkfifo": 0,
     "os.mknod": 0,
     "os.remove": 0,
@@ -307,12 +303,8 @@ def _set_allowed_requests(sec_class, sec_level):
                 "rpath.RPath.fsync_local",  # FIXME really needed?
                 # System
                 "os.chmod",
-                "os.chown",
-                "os.lchown",
                 "os.link",
                 "os.makedev",
-                "os.makedirs",
-                "os.mkdir",
                 "os.mkfifo",
                 "os.mknod",
                 "os.remove",

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -58,17 +58,7 @@ _disallowed_server_globals = ["server"]
 # The keys are files request, the value is the index of the argument
 # taking a file.
 _file_requests = {
-    "os.chmod": 0,
-    "os.link": 1,
     "os.listdir": 0,
-    "os.mkfifo": 0,
-    "os.mknod": 0,
-    "os.remove": 0,
-    "os.rename": 0,
-    "os.rmdir": 0,
-    "os.symlink": 1,
-    "os.unlink": 0,
-    "os.utime": 0,
     "rpath.make_file_dict": 0,
     "shutil.rmtree": 0,
     "_repo_shadow.RepoShadow.init": 0,
@@ -235,9 +225,7 @@ def _set_allowed_requests(sec_class, sec_level):
     ):
         requests.update(
             [
-                "rpath.gzip_open_local_read",
                 "rpath.make_file_dict",
-                "rpath.open_local_read",
                 "rpath.setdata_local",
                 # System
                 "os.getuid",
@@ -298,22 +286,6 @@ def _set_allowed_requests(sec_class, sec_level):
     if sec_level == "read-write":
         requests.update(
             [
-                "rpath.copy_reg_file",  # FIXME really needed?
-                "rpath.make_socket_local",  # FIXME really needed?
-                "rpath.RPath.fsync_local",  # FIXME really needed?
-                # System
-                "os.chmod",
-                "os.link",
-                "os.makedev",
-                "os.mkfifo",
-                "os.mknod",
-                "os.remove",
-                "os.rename",
-                "os.rmdir",
-                "os.symlink",
-                "os.unlink",
-                "os.utime",
-                "shutil.rmtree",
                 # API >= 201
                 "_repo_shadow.RepoShadow.regress",
                 "_repo_shadow.RepoShadow.remove_increments_older_than",

--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -58,9 +58,7 @@ _disallowed_server_globals = ["server"]
 # The keys are files request, the value is the index of the argument
 # taking a file.
 _file_requests = {
-    "os.listdir": 0,
     "rpath.make_file_dict": 0,
-    "shutil.rmtree": 0,
     "_repo_shadow.RepoShadow.init": 0,
     "_dir_shadow.ReadDirShadow.init": 0,
     "_dir_shadow.WriteDirShadow.init": 0,
@@ -227,11 +225,7 @@ def _set_allowed_requests(sec_class, sec_level):
             [
                 "rpath.make_file_dict",
                 "rpath.setdata_local",
-                # System
-                "os.getuid",
-                "os.listdir",
                 # API >= 201
-                "platform.system",
                 "_repo_shadow.RepoShadow.get_config",
                 "_repo_shadow.RepoShadow.get_mirror_time",
                 "_repo_shadow.RepoShadow.needs_regress",

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -537,9 +537,10 @@ def _test_connection(conn_number, rp):
                 log.ERROR,
             )
             return False
-        if type(conn.os.listdir(rp.path)) is not list:
+        data = conn.rpath.make_file_dict(rp.path)
+        if not isinstance(data, dict) or "type" not in data or data["type"] != "dir":
             log.Log(
-                "Connection not listing directory '{rp}'".format(rp=rp),
+                "Connection not listing '{rp}' as directory".format(rp=rp),
                 log.ERROR,
             )
             return False

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -558,6 +558,8 @@ class PipeConnection(LowLevelPipeConnection):
             )
             argument_list.append(arg)
         try:
+            # For specific debugging purposes
+            # print(f"REQUEST: {request} <<{argument_list}>>", file=sys.stderr)
             Security.vet_request(request, argument_list)
             result = self._eval(request.function_string)(*argument_list)
         except BaseException:

--- a/src/rdiff_backup/connection.py
+++ b/src/rdiff_backup/connection.py
@@ -559,7 +559,7 @@ class PipeConnection(LowLevelPipeConnection):
             argument_list.append(arg)
         try:
             # For specific debugging purposes
-            # print(f"REQUEST: {request} <<{argument_list}>>", file=sys.stderr)
+            # print(f"REQUEST: {request}", file=sys.stderr) #COMMENTME
             Security.vet_request(request, argument_list)
             result = self._eval(request.function_string)(*argument_list)
         except BaseException:

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -1842,16 +1842,6 @@ def open_local_read(rpath):
     return open(rpath.path, "rb")
 
 
-# @API(delete_dir_no_files, 200)
-def delete_dir_no_files(rp):
-    """Deletes the directory at rp.path if empty. Raises if the
-    directory contains files."""
-    assert rp.isdir(), "Path '{rp}' must be a directory to be deleted.".format(rp=rp)
-    if rp.contains_files():
-        raise RPathException("Directory contains files.")
-    rp.delete()
-
-
 # @API(setdata_local, 200)
 def setdata_local(rp):
     """

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -762,9 +762,7 @@ class RPath(RORPath):
                     ),
                     loglevel,
                 )
-                os.chmod(
-                    self.path, permissions & 0o6777 & generics.permission_mask
-                )
+                os.chmod(self.path, permissions & 0o6777 & generics.permission_mask)
             else:
                 raise
         self.data["perms"] = permissions
@@ -816,9 +814,7 @@ class RPath(RORPath):
         except OSError:
             # It's not possible to set a modification time for
             # directories on Windows.
-            if not self.isdir():
-                raise
-            if self.conn.platform.system() != "Windows":
+            if not (self.isdir() and os.name == "nt"):
                 raise
         else:
             self.data["mtime"] = modtime
@@ -872,8 +868,7 @@ class RPath(RORPath):
 
     def listdir(self):
         """Return list of string paths returned by os.listdir"""
-        path = self.path
-        return self.conn.os.listdir(path)
+        return os.listdir(self.path)
 
     def symlink(self, linktext):
         """Make symlink at self.path pointing to linktext"""
@@ -952,17 +947,13 @@ class RPath(RORPath):
 
     def isowner(self):
         """Return true if current process is owner of rp or root"""
-        try:
-            uid = self.conn.os.getuid()
-        except AttributeError:
-            return True  # Windows doesn't have getuid(), so hope for the best
+        uid = self.conn.specifics.get("process_uid")
         return uid == 0 or ("uid" in self.data and uid == self.data["uid"])
 
     def isgroup(self):
         """Return true if process has group of rp"""
-        return "gid" in self.data and self.data["gid"] in self.conn.specifics.get(
-            "process_groups"
-        )
+        groups = self.conn.specifics.get("process_groups")
+        return "gid" in self.data and self.data["gid"] in groups
 
     def delete(self):
         """Delete file at self.path.  Recursively deletes directories."""
@@ -973,7 +964,7 @@ class RPath(RORPath):
             except os.error:
                 if generics.fsync_directories:
                     self.fsync()
-                self.conn.shutil.rmtree(self.path)
+                shutil.rmtree(self.path)
         else:
             try:
                 os.unlink(self.path)
@@ -1494,7 +1485,8 @@ def copy(rpin: RORPath, rpout: RPath, compress=0):
     """
     assert (
         rpout.conn == specifics.local_connection
-        and not hasattr(rpin, "conn") or rpin.conn == specifics.local_connection
+        and not hasattr(rpin, "conn")
+        or rpin.conn == specifics.local_connection
     ), "Function copy works locally not over '{conn}'.".format(conn=rpout.conn)
     log.Log(
         "Regular copying input path {ip} to output path {op}".format(ip=rpin, op=rpout),

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -825,9 +825,12 @@ class RPath(RORPath):
 
     def chown(self, uid, gid):
         """Set file's uid and gid"""
+        assert (
+            self.conn is specifics.local_connection
+        ), "Function chown works locally not over '{conn}'.".format(conn=self.conn)
         if self.issym():
             try:
-                self.conn.os.lchown(self.path, uid, gid)
+                os.lchown(self.path, uid, gid)
             except AttributeError:
                 log.Log(
                     "Function lchown missing, cannot change ownership "
@@ -835,7 +838,7 @@ class RPath(RORPath):
                     log.WARNING,
                 )
         else:
-            self.conn.os.chown(self.path, uid, gid)
+            os.chown(self.path, uid, gid)
         # uid/gid equal to -1 is ignored by chown/lchown
         if uid >= 0:
             self.data["uid"] = uid
@@ -843,19 +846,28 @@ class RPath(RORPath):
             self.data["gid"] = gid
 
     def mkdir(self):
+        assert (
+            self.conn is specifics.local_connection
+        ), "Function mkdir works locally not over '{conn}'.".format(conn=self.conn)
         log.Log("Making directory {di}".format(di=self), log.DEBUG)
-        self.conn.os.mkdir(self.path)
+        os.mkdir(self.path)
         self.setdata()
 
     def makedirs(self):
+        assert (
+            self.conn is specifics.local_connection
+        ), "Function makedirs works locally not over '{conn}'.".format(conn=self.conn)
         log.Log("Making directory path {dp}".format(dp=self), log.DEBUG)
-        self.conn.os.makedirs(self.path)
+        os.makedirs(self.path)
         self.setdata()
 
     def rmdir(self):
+        assert (
+            self.conn is specifics.local_connection
+        ), "Function rmdir works locally not over '{conn}'.".format(conn=self.conn)
         log.Log("Removing directory {di}".format(di=self), log.DEBUG)
-        self.conn.os.chmod(self.path, 0o700)
-        self.conn.os.rmdir(self.path)
+        os.chmod(self.path, 0o700)
+        os.rmdir(self.path)
         self.data = {"type": None}
 
     def listdir(self):

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -750,7 +750,7 @@ class RPath(RORPath):
     def chmod(self, permissions, loglevel=log.WARNING):
         """Wrapper around os.chmod"""
         try:
-            self.conn.os.chmod(self.path, permissions & generics.permission_mask)
+            os.chmod(self.path, permissions & generics.permission_mask)
         except OSError as e:
             if e.strerror == "Inappropriate file type or format" and not self.isdir():
                 # Some systems throw this error if try to set sticky bit
@@ -762,7 +762,7 @@ class RPath(RORPath):
                     ),
                     loglevel,
                 )
-                self.conn.os.chmod(
+                os.chmod(
                     self.path, permissions & 0o6777 & generics.permission_mask
                 )
             else:
@@ -778,7 +778,7 @@ class RPath(RORPath):
             log.DEBUG,
         )
         try:
-            self.conn.os.utime(self.path, (accesstime, modtime))
+            os.utime(self.path, (accesstime, modtime))
         except OverflowError:
             log.Log(
                 "Cannot change times of path {pa} to times {ti} - "
@@ -806,7 +806,7 @@ class RPath(RORPath):
                 log.WARNING,
             )
         try:
-            self.conn.os.utime(self.path, (int(time.time()), modtime))
+            os.utime(self.path, (int(time.time()), modtime))
         except OverflowError:
             log.Log(
                 "Cannot change path {pa} to modified time {mt} - "
@@ -877,7 +877,7 @@ class RPath(RORPath):
 
     def symlink(self, linktext):
         """Make symlink at self.path pointing to linktext"""
-        self.conn.os.symlink(linktext, self.path)
+        os.symlink(linktext, self.path)
         self.setdata()
         if not self.issym():
             raise RPathException(
@@ -892,12 +892,12 @@ class RPath(RORPath):
             ),
             log.DEBUG,
         )
-        self.conn.os.link(linkpath, self.path)
+        os.link(linkpath, self.path)
         self.setdata()
 
     def mkfifo(self):
         """Make a fifo at self.path"""
-        self.conn.os.mkfifo(self.path)
+        os.mkfifo(self.path)
         self.setdata()
         if not self.isfifo():
             raise RPathException(
@@ -906,7 +906,7 @@ class RPath(RORPath):
 
     def mksock(self):
         """Make a socket at self.path"""
-        self.conn.rpath.make_socket_local(self)
+        os.mknod(self.path, stat.S_IFSOCK)
         self.setdata()
         if not self.issock():
             raise RPathException(
@@ -976,13 +976,13 @@ class RPath(RORPath):
                 self.conn.shutil.rmtree(self.path)
         else:
             try:
-                self.conn.os.unlink(self.path)
+                os.unlink(self.path)
             except OSError as error:
                 if error.errno in (errno.EPERM, errno.EACCES):
                     # On Windows, read-only files cannot be deleted.
                     # Remove the read-only attribute and try again.
                     self.chmod(0o700)
-                    self.conn.os.unlink(self.path)
+                    os.unlink(self.path)
                 else:
                     raise
 
@@ -1106,30 +1106,19 @@ class RPath(RORPath):
                 return tf
 
     def open(self, mode, compress=None):
-        """Return open file.  Supports modes "w" and "r".
+        """
+        Return open file.  Supports modes "w" and "r".
 
         If compress is true, data written/read will be gzip
-        compressed/decompressed on the fly.  The extra complications
-        below are for security reasons - try to make the extent of the
-        risk apparent from the remote call.
-
+        compressed/decompressed on the fly.
         """
-        if self.conn is specifics.local_connection:
-            if compress:
-                return gzip.GzipFile(self.path, mode)
-            else:
-                return open(self.path, mode)
-
+        assert (
+            self.conn is specifics.local_connection
+        ), "Function open must be called locally not over {co}.".format(co=self.conn)
         if compress:
-            if mode == "r" or mode == "rb":
-                return self.conn.rpath.gzip_open_local_read(self)
-            else:
-                return self.conn.gzip.GzipFile(self.path, mode)
+            return gzip.GzipFile(self.path, mode)
         else:
-            if mode == "r" or mode == "rb":
-                return self.conn.rpath.open_local_read(self)
-            else:
-                return self.conn.open(self.path, mode)
+            return open(self.path, mode)
 
     def write_from_fileobj(self, fp, compress=None):
         """Reads fp and writes to self.path.  Closes both when done
@@ -1172,7 +1161,7 @@ class RPath(RORPath):
         else:
             raise RPathException
         try:
-            self.conn.os.mknod(self.path, mode, self.conn.os.makedev(major, minor))
+            os.mknod(self.path, mode, os.makedev(major, minor))
         except OSError as exc:
             log.Log(
                 "Unable to mknod device file '{df}' due to "
@@ -1183,22 +1172,21 @@ class RPath(RORPath):
         self.setdata()
 
     def fsync(self, fp=None):
-        """fsync the current file or directory
+        """
+        fsync the current file or directory
 
         If fp is none, get the file description by opening the file.
         This can be useful for directories.
-
         """
         if generics.do_fsync:
             if not fp:
-                self.conn.rpath.RPath.fsync_local(self)
+                self.fsync_open()
             else:
                 os.fsync(fp.fileno())
 
-    # @API(RPath.fsync_local, 200)
-    def fsync_local(self):
+    def fsync_open(self):
         """
-        fsync current file, run locally
+        fsync current file, trying to open it
         """
         assert (
             self.conn is specifics.local_connection
@@ -1498,12 +1486,16 @@ def copyfileobj(inputfp, outputfp):
         outputfp.write(b"\x00")
 
 
-def copy(rpin, rpout, compress=0):
+def copy(rpin: RORPath, rpout: RPath, compress=0):
     """Copy RPath or RORPath rpin to rpout.  Works for symlinks, dirs, etc.
 
     Returns close value of input for regular file, which can be used
     to pass hashes on.
     """
+    assert (
+        rpout.conn == specifics.local_connection
+        and not hasattr(rpin, "conn") or rpin.conn == specifics.local_connection
+    ), "Function copy works locally not over '{conn}'.".format(conn=rpout.conn)
     log.Log(
         "Regular copying input path {ip} to output path {op}".format(ip=rpin, op=rpout),
         log.DEBUG,
@@ -1520,7 +1512,7 @@ def copy(rpin, rpout, compress=0):
             return
 
     if rpin.isreg():
-        return copy_reg_file(rpin, rpout, compress)
+        return rpout.write_from_fileobj(rpin.open("rb"), compress=compress)
     elif rpin.isdir():
         rpout.mkdir()
     elif rpin.issym():
@@ -1540,31 +1532,6 @@ def copy(rpin, rpout, compress=0):
         rpout.mksock()
     else:
         raise RPathException("File '{rp!r}' has unknown type.".format(rp=rpin))
-
-
-# @API(copy_reg_file, 200)
-def copy_reg_file(rpin, rpout, compress=0):
-    """Copy regular file rpin to rpout, possibly avoiding connection"""
-    try:
-        if rpout.conn is rpin.conn and rpout.conn is not specifics.local_connection:
-            v = rpout.conn.rpath.copy_reg_file(rpin.path, rpout.path, compress)
-            rpout.setdata()
-            return v
-    except AttributeError:
-        pass
-    try:
-        return rpout.write_from_fileobj(rpin.open("rb"), compress=compress)
-    except OSError as e:
-        if e.errno == errno.ERANGE:
-            log.Log.FatalError(
-                "'OSError - Result too large' while reading file {fi}. "
-                "If you are using a Mac, this is probably "
-                "the result of HFS+ filesystem corruption. "
-                "Please exclude this file from your backup "
-                "before proceeding".format(fi=rpin)
-            )
-        else:
-            raise
 
 
 def cmp(rpin, rpout):
@@ -1716,7 +1683,7 @@ def rename(rp_source, rp_dest):
             rp_source.delete()
         else:
             try:
-                rp_source.conn.os.rename(rp_source.path, rp_dest.path)
+                os.rename(rp_source.path, rp_dest.path)
             except OSError as error:
                 # XXX errno.EINVAL and len(rp_dest.path) >= 260 indicates
                 # pathname too long on Windows
@@ -1730,9 +1697,9 @@ def rename(rp_source, rp_dest):
                     return
                 elif error.errno == errno.EEXIST:
                     # On Windows, files can't be renamed on top of an existing file
-                    rp_source.conn.os.chmod(rp_dest.path, 0o700)
-                    rp_source.conn.os.unlink(rp_dest.path)
-                    rp_source.conn.os.rename(rp_source.path, rp_dest.path)
+                    os.chmod(rp_dest.path, 0o700)
+                    os.unlink(rp_dest.path)
+                    os.rename(rp_source.path, rp_dest.path)
                 else:
                     log.Log(
                         "Exception '{ex}' while renaming from path {fp} "
@@ -1821,37 +1788,6 @@ def make_file_dict(filename):
         data["atime"] = int(statblock[stat.ST_ATIME])
         data["ctime"] = int(statblock[stat.ST_CTIME])
     return data
-
-
-# @API(make_socket_local, 200)
-def make_socket_local(rpath):
-    """Make a local socket at the given path
-
-    This takes an rpath so that it will be checked by Security.
-    (Miscellaneous strings will not be.)
-    """
-    assert (
-        rpath.conn is specifics.local_connection
-    ), "Function works locally not over '{conn}'.".format(conn=rpath.conn)
-    rpath.conn.os.mknod(rpath.path, stat.S_IFSOCK)
-
-
-# @API(gzip_open_local_read, 200)
-def gzip_open_local_read(rpath):
-    """Return open GzipFile.  See security note directly above"""
-    assert (
-        rpath.conn is specifics.local_connection
-    ), "Function works locally not over '{conn}'.".format(conn=rpath.conn)
-    return gzip.GzipFile(rpath.path, "rb")
-
-
-# @API(open_local_read, 200)
-def open_local_read(rpath):
-    """Return open file (provided for security reasons)"""
-    assert (
-        rpath.conn is specifics.local_connection
-    ), "Function works locally not over '{conn}'.".format(conn=rpath.conn)
-    return open(rpath.path, "rb")
 
 
 # @API(setdata_local, 200)

--- a/testing/security_test.py
+++ b/testing/security_test.py
@@ -25,7 +25,7 @@ class SecurityTest(unittest.TestCase):
             b"%s server --restrict-path foo --restrict-mode read-only" % comtst.RBBin
         )
         conn = SetConnections._init_connection(remote_cmd)
-        self.assertIsInstance(conn.os.getuid(), int)
+        self.assertIsInstance(conn.specifics.get("process_uid"), int)
         with self.assertRaises(Security.Violation):
             conn.os.remove(b"/tmp/foobar")
         SetConnections.CloseConnections()
@@ -36,7 +36,7 @@ class SecurityTest(unittest.TestCase):
             b"%s server --restrict-path foo --restrict-mode update-only" % comtst.RBBin
         )
         conn = SetConnections._init_connection(remote_cmd)
-        self.assertIsInstance(conn.os.getuid(), int)
+        self.assertIsInstance(conn.specifics.get("process_uid"), int)
         with self.assertRaises(Security.Violation):
             conn.os.remove(b"/tmp/foobar")
         SetConnections.CloseConnections()


### PR DESCRIPTION
## Changes done and why

All system and most rpath functions are now called locally, not through the connection.
I didn't have to do a lot, most calls were unnecessarily remote, as showed by a (now commented) debug message.
It definitely makes the code simpler and should slightly improve performance.

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
