### PR TITLE
fix: preserve backslash in file paths on non-Windows platforms

### DIFF
--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -262,7 +262,10 @@ def parse_location(file_desc):
     file_path = sbs.join([x.replace(sbs + b":", b":") for x in file_path.split(dbs)])
     # And then we make sure that paths under Windows use / instead of \
     # (we don't do it for the host part because it could be a shell command)
-    file_path = file_path.replace(b"\\", b"/")
+    # On non-Windows platforms, backslash is a valid filename character and
+    # must not be converted to forward slash (fixes #1040).
+    if os.name == "nt":
+        file_path = file_path.replace(b"\\", b"/")
     if is_unc_path:
         file_path = b"/" + file_path
 

--- a/testing/setconnections_test.py
+++ b/testing/setconnections_test.py
@@ -2,6 +2,7 @@
 Test the setup of connections
 """
 
+import os
 import unittest
 
 from rdiff_backup import SetConnections
@@ -27,14 +28,18 @@ class SetConnectionsTest(unittest.TestCase):
         self.assertEqual(pl(b"foobar"), (None, b"foobar", None))
         self.assertEqual(
             pl(rb"test\\ing\::more::and more\\.."),
-            (b"test\\ing::more", b"and more/..", None),
+            (b"test\\ing::more", b"and more\\.." if os.name != "nt" else b"and more/..", None),
         )
         self.assertEqual(
             pl(rb"strangely named\::file"), (None, b"strangely named::file", None)
         )
-        self.assertEqual(pl(rb"foobar\\"), (None, b"foobar/", None))
         self.assertEqual(
-            pl(rb"not\::too::many\\\::paths"), (b"not::too", b"many/::paths", None)
+            pl(rb"foobar\\"),
+            (None, b"foobar\\" if os.name != "nt" else b"foobar/", None),
+        )
+        self.assertEqual(
+            pl(rb"not\::too::many\\\::paths"),
+            (b"not::too", b"many\\::paths" if os.name != "nt" else b"many/::paths", None),
         )
         self.assertEqual(
             pl(rb"\\hostname\unc\path"), (None, b"//hostname/unc/path", None)
@@ -48,6 +53,12 @@ class SetConnectionsTest(unittest.TestCase):
         self.assertIsNotNone(pl(rb"a host without\:path::")[2])
         self.assertIsNotNone(pl(b"::some/path/without/host")[2])
         self.assertIsNotNone(pl(b"too::many::paths")[2])
+
+        # test that backslash is preserved in file paths on non-Windows (fixes #1040)
+        if os.name != "nt":
+            self.assertEqual(
+                pl(b"/tmp/bak/bla\\blup"), (None, b"/tmp/bak/bla\\blup", None)
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1040

Restoring files/folders with a backslash in their name (e.g. `bla\blup`) silently fails on Linux — the restore exits with code 0 but nothing is restored. This worked correctly in v2.0.5.

## Root Cause

In `parse_location()` (SetConnections.py:265), backslashes are unconditionally converted to forward slashes:

```python
file_path = file_path.replace(b"\\", b"/")
```

This is correct on Windows (where backslash is the path separator) but wrong on Linux/Unix, where backslash is a valid character in filenames. The converted path (e.g. `bla/blup`) doesn't match the actual file (`bla\blup`) in the backup, so nothing gets restored.

## Changes

- **src/rdiff_backup/SetConnections.py**: Wrap the backslash-to-slash conversion in `if os.name == "nt"` — only apply on Windows
- **testing/setconnections_test.py**: Update existing tests to expect platform-correct behavior, add new test case for backslash preservation

## Test Plan

- [x] Manual verification: backslash in paths is preserved on Linux
- [x] Existing tests updated for both platforms
- [ ] CI: verify tests pass on Linux runners
- [ ] CI: verify tests still pass on Windows runners