### PR TITLE
Reduce remote calls in rpath

### DIFF
--- a/src/rdiff_backup/Security.py
+++ b/src/rdiff_backup/Security.py
@@ -223,8 +223,7 @@ def _set_allowed_requests(sec_class, sec_level):
     ):
         requests.update(
             [
-                "rpath.make_file_dict",
-                "rpath.setdata_local",
+                "rpath.get_rpath_data",
                 # API >= 201
                 "_repo_shadow.RepoShadow.get_config",
                 "_repo_shadow.RepoShadow.get_mirror_time",

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -537,7 +537,7 @@ def _test_connection(conn_number, rp):
                 log.ERROR,
             )
             return False
-        data = conn.rpath.get_rpath_data(rp.path, rp.base, rp.data)
+        data = conn.rpath.get_rpath_data(rp)
         if not isinstance(data, dict) or "type" not in data or data["type"] != "dir":
             log.Log(
                 "Connection not listing '{rp}' as directory".format(rp=rp),

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -537,7 +537,7 @@ def _test_connection(conn_number, rp):
                 log.ERROR,
             )
             return False
-        data = conn.rpath.make_file_dict(rp.path)
+        data = conn.rpath.get_rpath_data(rp.path, rp.base, rp.data)
         if not isinstance(data, dict) or "type" not in data or data["type"] != "dir":
             log.Log(
                 "Connection not listing '{rp}' as directory".format(rp=rp),

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -537,7 +537,7 @@ def _test_connection(conn_number, rp):
                 log.ERROR,
             )
             return False
-        data = conn.rpath.get_rpath_data(rp)
+        data = conn.rpath.get_rpath_data(rp.path, rp.base, rp.data)
         if not isinstance(data, dict) or "type" not in data or data["type"] != "dir":
             log.Log(
                 "Connection not listing '{rp}' as directory".format(rp=rp),

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -743,9 +743,7 @@ class RPath(RORPath):
 
     def setdata(self):
         """Set data dictionary using the wrapper"""
-        self.data = self.conn.rpath.make_file_dict(self.path)
-        if self.lstat():
-            self.conn.rpath.setdata_local(self)
+        self.data = self.conn.rpath.get_rpath_data(self.path, self.base, self.index)
 
     def chmod(self, permissions, loglevel=log.WARNING):
         """Wrapper around os.chmod"""
@@ -1704,14 +1702,10 @@ def rename(rp_source, rp_dest):
         rp_source.data = {"type": None}
 
 
-# @API(make_file_dict, 200)
-def make_file_dict(filename):
-    """Generate the data dictionary for the given RPath
-
-    This is a global function so that os.name can be called locally,
-    thus avoiding network lag and so that we only need to send the
-    filename over the network, thus avoiding the need to pickle an
-    (incomplete) rpath object.
+# @API(get_rpath_data, 300)
+def get_rpath_data(filename, base, index):
+    """
+    Generate and return the data dictionary for the given path
     """
 
     try:
@@ -1756,6 +1750,10 @@ def make_file_dict(filename):
     data["devloc"] = statblock[stat.ST_DEV]
     data["nlink"] = statblock[stat.ST_NLINK]
 
+    # Map user and group IDs to names
+    data["uname"] = usrgrp.uid2uname(data["uid"])
+    data["gname"] = usrgrp.gid2gname(data["gid"])
+
     if os.name == "nt":
         try:
             attribs = win32api.GetFileAttributes(os.fsdecode(filename))
@@ -1779,20 +1777,16 @@ def make_file_dict(filename):
         data["mtime"] = int(statblock[stat.ST_MTIME])
         data["atime"] = int(statblock[stat.ST_ATIME])
         data["ctime"] = int(statblock[stat.ST_CTIME])
-    return data
+    return _add_rpath_metadata(base, index, data)
 
 
-# @API(setdata_local, 200)
-def setdata_local(rp):
+def _add_rpath_metadata(base, index, data):
     """
     Set eas/acls, uid/gid, resource fork in data dictionary
 
-    This is a global function because it must be called locally, since
-    these features may exist or not depending on the connection.
+    Return the data dictionary completed with this information
     """
-    assert (
-        rp.conn is specifics.local_connection
-    ), "Function must be called locally not over {conn}.".format(conn=rp.conn)
+    rp = RPath(specifics.local_connection, base, index=index, data=data)
     reset_perms = False
     if specifics.process_uid != 0 and not rp.readable() and rp.isowner():
         if rp.lstat() == "sym":
@@ -1801,19 +1795,17 @@ def setdata_local(rp):
             # Neither Windows nor Linux support chmod without following
             # symlinks, so we would anyway try to chmod the file pointed at,
             # not the symlink itself
-            rp.data["type"] = None
             log.ErrorLog(
                 "ListError",
                 rp,
                 OSError("[Errno n/a] Ignoring strange unreadable symlink"),
             )
-            return
+            rp.data["type"] = None
+            return rp.data
         else:
             reset_perms = True
             rp.chmod(0o400 | rp.getperms())
 
-    rp.data["uname"] = usrgrp.uid2uname(rp.data["uid"])
-    rp.data["gname"] = usrgrp.gid2gname(rp.data["gid"])
     if specifics.eas_conn:
         rp.data["ea"] = ea.get_meta(rp)
     if specifics.acls_conn:
@@ -1827,6 +1819,8 @@ def setdata_local(rp):
 
     if reset_perms:
         rp.chmod(rp.getperms() & ~0o400)
+
+    return rp.data
 
 
 def _carbonfile_get(rp):

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -743,7 +743,7 @@ class RPath(RORPath):
 
     def setdata(self):
         """Set data dictionary using the wrapper"""
-        self.data = self.conn.rpath.get_rpath_data(self.path, self.base, self.index)
+        self.data = self.conn.rpath.get_rpath_data(self)
 
     def chmod(self, permissions, loglevel=log.WARNING):
         """Wrapper around os.chmod"""
@@ -1703,21 +1703,20 @@ def rename(rp_source, rp_dest):
 
 
 # @API(get_rpath_data, 300)
-def get_rpath_data(filename, base, index):
+def get_rpath_data(rp):
     """
     Generate and return the data dictionary for the given path
     """
 
     try:
-        statblock = os.lstat(filename)
+        statblock = os.lstat(rp)
     except (FileNotFoundError, NotADirectoryError, PermissionError):
         # FIXME not sure if this shouldn't trigger a warning but doing it
         # generates (too) many messages during the tests
         # log.Log("Missing file '{mf}' couldn't be assessed".format(
-        #             mf=filename), log.WARNING)
+        #             mf=rp), log.WARNING)
         # FIXME perhaps we should have a different type/flag for this case?
         return {"type": None}
-    data = {}
     mode = statblock[stat.ST_MODE]
 
     if stat.S_ISREG(mode):
@@ -1727,36 +1726,36 @@ def get_rpath_data(filename, base, index):
     elif stat.S_ISCHR(mode):
         type_ = "dev"
         s = statblock.st_rdev
-        data["devnums"] = ("c", os.major(s), os.minor(s))
+        rp.data["devnums"] = ("c", os.major(s), os.minor(s))
     elif stat.S_ISBLK(mode):
         type_ = "dev"
         s = statblock.st_rdev
-        data["devnums"] = ("b", os.major(s), os.minor(s))
+        rp.data["devnums"] = ("b", os.major(s), os.minor(s))
     elif stat.S_ISFIFO(mode):
         type_ = "fifo"
     elif stat.S_ISLNK(mode):
         type_ = "sym"
-        data["linkname"] = os.readlink(filename)
+        rp.data["linkname"] = os.readlink(rp)
     elif stat.S_ISSOCK(mode):
         type_ = "sock"
     else:
-        raise C.UnknownFileError(filename)
-    data["type"] = type_
-    data["size"] = statblock[stat.ST_SIZE]
-    data["perms"] = stat.S_IMODE(mode)
-    data["uid"] = statblock[stat.ST_UID]
-    data["gid"] = statblock[stat.ST_GID]
-    data["inode"] = statblock[stat.ST_INO]
-    data["devloc"] = statblock[stat.ST_DEV]
-    data["nlink"] = statblock[stat.ST_NLINK]
+        raise C.UnknownFileError(rp)
+    rp.data["type"] = type_
+    rp.data["size"] = statblock[stat.ST_SIZE]
+    rp.data["perms"] = stat.S_IMODE(mode)
+    rp.data["uid"] = statblock[stat.ST_UID]
+    rp.data["gid"] = statblock[stat.ST_GID]
+    rp.data["inode"] = statblock[stat.ST_INO]
+    rp.data["devloc"] = statblock[stat.ST_DEV]
+    rp.data["nlink"] = statblock[stat.ST_NLINK]
 
     # Map user and group IDs to names
-    data["uname"] = usrgrp.uid2uname(data["uid"])
-    data["gname"] = usrgrp.gid2gname(data["gid"])
+    rp.data["uname"] = usrgrp.uid2uname(rp.data["uid"])
+    rp.data["gname"] = usrgrp.gid2gname(rp.data["gid"])
 
     if os.name == "nt":
         try:
-            attribs = win32api.GetFileAttributes(os.fsdecode(filename))
+            attribs = win32api.GetFileAttributes(os.fsdecode(rp))
         except pywintypes.error as exc:
             if exc.args[0] == 32:  # file in use
                 # we could also ignore with: return {'type': None}
@@ -1766,27 +1765,26 @@ def get_rpath_data(filename, base, index):
                 # we replace the specific Windows exception by a generic
                 # one also understood by a potential Linux client/server
                 raise OSError(
-                    None, exc.args[1] + " - " + exc.args[2], filename, exc.args[0]
+                    None, exc.args[1] + " - " + exc.args[2], rp.path, exc.args[0]
                 ) from None
         if attribs & win32con.FILE_ATTRIBUTE_REPARSE_POINT:
-            data["type"] = "sym"
-            data["linkname"] = None
+            rp.data["type"] = "sym"
+            rp.data["linkname"] = None
 
     if not (type_ == "sym" or type_ == "dev"):
         # mtimes on symlinks and dev files don't work consistently
-        data["mtime"] = int(statblock[stat.ST_MTIME])
-        data["atime"] = int(statblock[stat.ST_ATIME])
-        data["ctime"] = int(statblock[stat.ST_CTIME])
-    return _add_rpath_metadata(base, index, data)
+        rp.data["mtime"] = int(statblock[stat.ST_MTIME])
+        rp.data["atime"] = int(statblock[stat.ST_ATIME])
+        rp.data["ctime"] = int(statblock[stat.ST_CTIME])
+    return _add_rpath_metadata(rp)
 
 
-def _add_rpath_metadata(base, index, data):
+def _add_rpath_metadata(rp):
     """
     Set eas/acls, uid/gid, resource fork in data dictionary
 
     Return the data dictionary completed with this information
     """
-    rp = RPath(specifics.local_connection, base, index=index, data=data)
     reset_perms = False
     if specifics.process_uid != 0 and not rp.readable() and rp.isowner():
         if rp.lstat() == "sym":

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -743,7 +743,7 @@ class RPath(RORPath):
 
     def setdata(self):
         """Set data dictionary using the wrapper"""
-        self.data = self.conn.rpath.get_rpath_data(self)
+        self.data = self.conn.rpath.get_rpath_data(self.path, self.base, self.index)
 
     def chmod(self, permissions, loglevel=log.WARNING):
         """Wrapper around os.chmod"""
@@ -1703,20 +1703,21 @@ def rename(rp_source, rp_dest):
 
 
 # @API(get_rpath_data, 300)
-def get_rpath_data(rp):
+def get_rpath_data(filename, base, index):
     """
     Generate and return the data dictionary for the given path
     """
 
     try:
-        statblock = os.lstat(rp)
+        statblock = os.lstat(filename)
     except (FileNotFoundError, NotADirectoryError, PermissionError):
         # FIXME not sure if this shouldn't trigger a warning but doing it
         # generates (too) many messages during the tests
         # log.Log("Missing file '{mf}' couldn't be assessed".format(
-        #             mf=rp), log.WARNING)
+        #             mf=filename), log.WARNING)
         # FIXME perhaps we should have a different type/flag for this case?
         return {"type": None}
+    data = {}
     mode = statblock[stat.ST_MODE]
 
     if stat.S_ISREG(mode):
@@ -1726,36 +1727,36 @@ def get_rpath_data(rp):
     elif stat.S_ISCHR(mode):
         type_ = "dev"
         s = statblock.st_rdev
-        rp.data["devnums"] = ("c", os.major(s), os.minor(s))
+        data["devnums"] = ("c", os.major(s), os.minor(s))
     elif stat.S_ISBLK(mode):
         type_ = "dev"
         s = statblock.st_rdev
-        rp.data["devnums"] = ("b", os.major(s), os.minor(s))
+        data["devnums"] = ("b", os.major(s), os.minor(s))
     elif stat.S_ISFIFO(mode):
         type_ = "fifo"
     elif stat.S_ISLNK(mode):
         type_ = "sym"
-        rp.data["linkname"] = os.readlink(rp)
+        data["linkname"] = os.readlink(filename)
     elif stat.S_ISSOCK(mode):
         type_ = "sock"
     else:
-        raise C.UnknownFileError(rp)
-    rp.data["type"] = type_
-    rp.data["size"] = statblock[stat.ST_SIZE]
-    rp.data["perms"] = stat.S_IMODE(mode)
-    rp.data["uid"] = statblock[stat.ST_UID]
-    rp.data["gid"] = statblock[stat.ST_GID]
-    rp.data["inode"] = statblock[stat.ST_INO]
-    rp.data["devloc"] = statblock[stat.ST_DEV]
-    rp.data["nlink"] = statblock[stat.ST_NLINK]
+        raise C.UnknownFileError(filename)
+    data["type"] = type_
+    data["size"] = statblock[stat.ST_SIZE]
+    data["perms"] = stat.S_IMODE(mode)
+    data["uid"] = statblock[stat.ST_UID]
+    data["gid"] = statblock[stat.ST_GID]
+    data["inode"] = statblock[stat.ST_INO]
+    data["devloc"] = statblock[stat.ST_DEV]
+    data["nlink"] = statblock[stat.ST_NLINK]
 
     # Map user and group IDs to names
-    rp.data["uname"] = usrgrp.uid2uname(rp.data["uid"])
-    rp.data["gname"] = usrgrp.gid2gname(rp.data["gid"])
+    data["uname"] = usrgrp.uid2uname(data["uid"])
+    data["gname"] = usrgrp.gid2gname(data["gid"])
 
     if os.name == "nt":
         try:
-            attribs = win32api.GetFileAttributes(os.fsdecode(rp))
+            attribs = win32api.GetFileAttributes(os.fsdecode(filename))
         except pywintypes.error as exc:
             if exc.args[0] == 32:  # file in use
                 # we could also ignore with: return {'type': None}
@@ -1765,26 +1766,27 @@ def get_rpath_data(rp):
                 # we replace the specific Windows exception by a generic
                 # one also understood by a potential Linux client/server
                 raise OSError(
-                    None, exc.args[1] + " - " + exc.args[2], rp.path, exc.args[0]
+                    None, exc.args[1] + " - " + exc.args[2], filename, exc.args[0]
                 ) from None
         if attribs & win32con.FILE_ATTRIBUTE_REPARSE_POINT:
-            rp.data["type"] = "sym"
-            rp.data["linkname"] = None
+            data["type"] = "sym"
+            data["linkname"] = None
 
     if not (type_ == "sym" or type_ == "dev"):
         # mtimes on symlinks and dev files don't work consistently
-        rp.data["mtime"] = int(statblock[stat.ST_MTIME])
-        rp.data["atime"] = int(statblock[stat.ST_ATIME])
-        rp.data["ctime"] = int(statblock[stat.ST_CTIME])
-    return _add_rpath_metadata(rp)
+        data["mtime"] = int(statblock[stat.ST_MTIME])
+        data["atime"] = int(statblock[stat.ST_ATIME])
+        data["ctime"] = int(statblock[stat.ST_CTIME])
+    return _add_rpath_metadata(base, index, data)
 
 
-def _add_rpath_metadata(rp):
+def _add_rpath_metadata(base, index, data):
     """
     Set eas/acls, uid/gid, resource fork in data dictionary
 
     Return the data dictionary completed with this information
     """
+    rp = RPath(specifics.local_connection, base, index=index, data=data)
     reset_perms = False
     if specifics.process_uid != 0 and not rp.readable() and rp.isowner():
         if rp.lstat() == "sym":

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -106,6 +106,14 @@ class QuotedRPath(increment.StoredRPath):
         dirname, basename = super().dirsplit()
         return (dirname, unquote(basename))
 
+    def __fspath__(self):
+        """
+        Just a getter to return the path unquoted
+
+        Fulfills the os.PathLike interface
+        """
+        return unquote(self.path)
+
 
 def quote(path):
     """

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -106,14 +106,6 @@ class QuotedRPath(increment.StoredRPath):
         dirname, basename = super().dirsplit()
         return (dirname, unquote(basename))
 
-    def __fspath__(self):
-        """
-        Just a getter to return the path unquoted
-
-        Fulfills the os.PathLike interface
-        """
-        return unquote(self.path)
-
 
 def quote(path):
     """


### PR DESCRIPTION
## Changes done and why

`make_file_dict` becomes `get_rpath_data` and is the only one being called remotely, whereas `setdata_local` becomes `_add_rpath_metadata` called locally to improve performance when gathering metadata.
Note that the __fspath__ for QuotedRPath was wrong as it should represent the (quoted) path on the file system.

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
