### PR TITLE
Use rpath's PathLike interface in system functions

### DIFF
--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -748,7 +748,7 @@ class RPath(RORPath):
     def chmod(self, permissions, loglevel=log.WARNING):
         """Wrapper around os.chmod"""
         try:
-            os.chmod(self.path, permissions & generics.permission_mask)
+            os.chmod(self, permissions & generics.permission_mask)
         except OSError as e:
             if e.strerror == "Inappropriate file type or format" and not self.isdir():
                 # Some systems throw this error if try to set sticky bit
@@ -760,7 +760,7 @@ class RPath(RORPath):
                     ),
                     loglevel,
                 )
-                os.chmod(self.path, permissions & 0o6777 & generics.permission_mask)
+                os.chmod(self, permissions & 0o6777 & generics.permission_mask)
             else:
                 raise
         self.data["perms"] = permissions
@@ -774,7 +774,7 @@ class RPath(RORPath):
             log.DEBUG,
         )
         try:
-            os.utime(self.path, (accesstime, modtime))
+            os.utime(self, (accesstime, modtime))
         except OverflowError:
             log.Log(
                 "Cannot change times of path {pa} to times {ti} - "
@@ -802,7 +802,7 @@ class RPath(RORPath):
                 log.WARNING,
             )
         try:
-            os.utime(self.path, (int(time.time()), modtime))
+            os.utime(self, (int(time.time()), modtime))
         except OverflowError:
             log.Log(
                 "Cannot change path {pa} to modified time {mt} - "
@@ -824,7 +824,7 @@ class RPath(RORPath):
         ), "Function chown works locally not over '{conn}'.".format(conn=self.conn)
         if self.issym():
             try:
-                os.lchown(self.path, uid, gid)
+                os.lchown(self, uid, gid)
             except AttributeError:
                 log.Log(
                     "Function lchown missing, cannot change ownership "
@@ -832,7 +832,7 @@ class RPath(RORPath):
                     log.WARNING,
                 )
         else:
-            os.chown(self.path, uid, gid)
+            os.chown(self, uid, gid)
         # uid/gid equal to -1 is ignored by chown/lchown
         if uid >= 0:
             self.data["uid"] = uid
@@ -844,7 +844,7 @@ class RPath(RORPath):
             self.conn is specifics.local_connection
         ), "Function mkdir works locally not over '{conn}'.".format(conn=self.conn)
         log.Log("Making directory {di}".format(di=self), log.DEBUG)
-        os.mkdir(self.path)
+        os.mkdir(self)
         self.setdata()
 
     def makedirs(self):
@@ -852,7 +852,7 @@ class RPath(RORPath):
             self.conn is specifics.local_connection
         ), "Function makedirs works locally not over '{conn}'.".format(conn=self.conn)
         log.Log("Making directory path {dp}".format(dp=self), log.DEBUG)
-        os.makedirs(self.path)
+        os.makedirs(self)
         self.setdata()
 
     def rmdir(self):
@@ -860,17 +860,17 @@ class RPath(RORPath):
             self.conn is specifics.local_connection
         ), "Function rmdir works locally not over '{conn}'.".format(conn=self.conn)
         log.Log("Removing directory {di}".format(di=self), log.DEBUG)
-        os.chmod(self.path, 0o700)
-        os.rmdir(self.path)
+        os.chmod(self, 0o700)
+        os.rmdir(self)
         self.data = {"type": None}
 
     def listdir(self):
         """Return list of string paths returned by os.listdir"""
-        return os.listdir(self.path)
+        return os.listdir(self)
 
     def symlink(self, linktext):
         """Make symlink at self.path pointing to linktext"""
-        os.symlink(linktext, self.path)
+        os.symlink(linktext, self)
         self.setdata()
         if not self.issym():
             raise RPathException(
@@ -885,12 +885,12 @@ class RPath(RORPath):
             ),
             log.DEBUG,
         )
-        os.link(linkpath, self.path)
+        os.link(linkpath, self)
         self.setdata()
 
     def mkfifo(self):
         """Make a fifo at self.path"""
-        os.mkfifo(self.path)
+        os.mkfifo(self)
         self.setdata()
         if not self.isfifo():
             raise RPathException(
@@ -899,7 +899,7 @@ class RPath(RORPath):
 
     def mksock(self):
         """Make a socket at self.path"""
-        os.mknod(self.path, stat.S_IFSOCK)
+        os.mknod(self, stat.S_IFSOCK)
         self.setdata()
         if not self.issock():
             raise RPathException(
@@ -954,7 +954,7 @@ class RPath(RORPath):
         return "gid" in self.data and self.data["gid"] in groups
 
     def delete(self):
-        """Delete file at self.path.  Recursively deletes directories."""
+        """Delete itself, recursively if necessary."""
         log.Log("Deleting (recursively) path {pa}".format(pa=self), log.DEBUG)
         if self.isdir():
             try:
@@ -962,16 +962,16 @@ class RPath(RORPath):
             except os.error:
                 if generics.fsync_directories:
                     self.fsync()
-                shutil.rmtree(self.path)
+                shutil.rmtree(self.path)  # rmtree doesn't support PathLike as bytes
         else:
             try:
-                os.unlink(self.path)
+                os.unlink(self)
             except OSError as error:
                 if error.errno in (errno.EPERM, errno.EACCES):
                     # On Windows, read-only files cannot be deleted.
                     # Remove the read-only attribute and try again.
                     self.chmod(0o700)
-                    os.unlink(self.path)
+                    os.unlink(self)
                 else:
                     raise
 
@@ -1080,7 +1080,7 @@ class RPath(RORPath):
         # is (almost) full and when the --tempdir flag is defined,
         # attempt to save temporary files on a different path and
         # hopefully file system.
-        if tempfile.tempdir and shutil.disk_usage(self.path).free < 0:  # 1048576):
+        if tempfile.tempdir and shutil.disk_usage(self).free < 0:  # 1048576):
             # FIXME disabled because os.rename between file systems fails
             tempdir = self.newpath(tempfile.tempdir)
         else:
@@ -1105,9 +1105,9 @@ class RPath(RORPath):
             self.conn is specifics.local_connection
         ), "Function open must be called locally not over {co}.".format(co=self.conn)
         if compress:
-            return gzip.GzipFile(self.path, mode)
+            return gzip.GzipFile(self, mode)
         else:
-            return open(self.path, mode)
+            return open(self, mode)
 
     def write_from_fileobj(self, fp, compress=None):
         """Reads fp and writes to self.path.  Closes both when done
@@ -1150,7 +1150,7 @@ class RPath(RORPath):
         else:
             raise RPathException
         try:
-            os.mknod(self.path, mode, os.makedev(major, minor))
+            os.mknod(self, mode, os.makedev(major, minor))
         except OSError as exc:
             log.Log(
                 "Unable to mknod device file '{df}' due to "
@@ -1181,7 +1181,7 @@ class RPath(RORPath):
             self.conn is specifics.local_connection
         ), "Function must be called locally not over {conn}.".format(conn=self.conn)
         try:
-            fd = os.open(self.path, os.O_RDONLY)
+            fd = os.open(self, os.O_RDONLY)
             os.fsync(fd)
             os.close(fd)
         except OSError as e:
@@ -1203,7 +1203,7 @@ class RPath(RORPath):
                     self.setdata()
                     oldperms = self.getperms()
                 self.chmod(0o700)
-            fd = os.open(self.path, os.O_RDWR)
+            fd = os.open(self, os.O_RDWR)
             if oldperms is not None:
                 self.chmod(oldperms)
             os.fsync(fd)  # Sync after we switch back permissions!
@@ -1298,7 +1298,7 @@ class RPath(RORPath):
         except KeyError:
             try:
                 rfork_fp = self.conn.open(
-                    os.path.join(self.path, b"..namedfork", b"rsrc"), "rb"
+                    os.path.join(self, b"..namedfork", b"rsrc"), "rb"
                 )
                 rfork = rfork_fp.read()
                 rfork_fp.close()
@@ -1310,7 +1310,7 @@ class RPath(RORPath):
     def write_resource_fork(self, rfork_data):
         """Write new resource fork to self"""
         log.Log("Writing resource fork to path {pa}".format(pa=self), log.DEBUG)
-        fp = self.conn.open(os.path.join(self.path, b"..namedfork", b"rsrc"), "wb")
+        fp = self.conn.open(os.path.join(self, b"..namedfork", b"rsrc"), "wb")
         fp.write(rfork_data)
         fp.close()
         self.set_resource_fork(rfork_data)
@@ -1673,7 +1673,7 @@ def rename(rp_source, rp_dest):
             rp_source.delete()
         else:
             try:
-                os.rename(rp_source.path, rp_dest.path)
+                os.rename(rp_source, rp_dest)
             except OSError as error:
                 # XXX errno.EINVAL and len(rp_dest.path) >= 260 indicates
                 # pathname too long on Windows
@@ -1687,9 +1687,9 @@ def rename(rp_source, rp_dest):
                     return
                 elif error.errno == errno.EEXIST:
                     # On Windows, files can't be renamed on top of an existing file
-                    os.chmod(rp_dest.path, 0o700)
-                    os.unlink(rp_dest.path)
-                    os.rename(rp_source.path, rp_dest.path)
+                    os.chmod(rp_dest, 0o700)
+                    os.unlink(rp_dest)
+                    os.rename(rp_source, rp_dest)
                 else:
                     log.Log(
                         "Exception '{ex}' while renaming from path {fp} "

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -220,7 +220,7 @@ class FSAbilities:
         hl_dest = hl_dir.append("hardlinked_file2")
         hl_source.touch()
         try:
-            hl_dest.hardlink(hl_source.path)
+            hl_dest.hardlink(hl_source)
             if hl_source.getinode() != hl_dest.getinode():
                 raise OSError(errno.EOPNOTSUPP, "Hard links don't compare")
         except (OSError, AttributeError):
@@ -335,7 +335,7 @@ class FSAbilities:
             return
 
         try:
-            posix1e.ACL(file=rp.path)
+            posix1e.ACL(file=rp)
         except OSError as exc:
             log.Log(
                 "POSIX ACLs not supported by filesystem at path {pa} "
@@ -444,11 +444,11 @@ class FSAbilities:
 
         test_ea = b"test val"
         try:
-            xattr.list(rp.path)
+            xattr.list(rp)
             if write:
-                xattr.set(rp.path, b"user.test", test_ea)
-                read_ea = xattr.get(rp.path, b"user.test")
-                xattr.remove(rp.path, b"user.test")
+                xattr.set(rp, b"user.test", test_ea)
+                read_ea = xattr.get(rp, b"user.test")
+                xattr.remove(rp, b"user.test")
         except OSError as exc:
             log.Log(
                 "Extended attributes not supported by filesystem at "
@@ -487,7 +487,7 @@ class FSAbilities:
             return
         try:
             sd = win32security.GetNamedSecurityInfo(
-                os.fsdecode(dir_rp.path),
+                os.fsdecode(dir_rp),
                 win32security.SE_FILE_OBJECT,
                 win32security.OWNER_SECURITY_INFORMATION
                 | win32security.GROUP_SECURITY_INFORMATION
@@ -497,7 +497,7 @@ class FSAbilities:
             acl.GetAceCount()  # to verify that it works
             if write:
                 win32security.SetNamedSecurityInfo(
-                    os.fsdecode(dir_rp.path),
+                    os.fsdecode(dir_rp),
                     win32security.SE_FILE_OBJECT,
                     win32security.OWNER_SECURITY_INFORMATION
                     | win32security.GROUP_SECURITY_INFORMATION
@@ -576,11 +576,11 @@ class FSAbilities:
 
         s = b"test string---this should end up in resource fork"
         try:
-            fp_write = open(os.path.join(reg_rp.path, b"..namedfork", b"rsrc"), "wb")
+            fp_write = open(os.path.join(reg_rp, b"..namedfork", b"rsrc"), "wb")
             fp_write.write(s)
             fp_write.close()
 
-            fp_read = open(os.path.join(reg_rp.path, b"..namedfork", b"rsrc"), "rb")
+            fp_read = open(os.path.join(reg_rp, b"..namedfork", b"rsrc"), "rb")
             s_back = fp_read.read()
             fp_read.close()
         except OSError:

--- a/src/rdiffbackup/locations/map/filenames.py
+++ b/src/rdiffbackup/locations/map/filenames.py
@@ -82,7 +82,7 @@ class QuotedRPath(increment.StoredRPath):
         We want them unquoted so that the results can be sorted
         correctly and append()ed to the current QuotedRPath.
         """
-        return list(map(unquote, self.conn.os.listdir(self.path)))
+        return list(map(unquote, self.conn.os.listdir(self)))
 
     def isincfile(self):
         """
@@ -105,14 +105,6 @@ class QuotedRPath(increment.StoredRPath):
         """
         dirname, basename = super().dirsplit()
         return (dirname, unquote(basename))
-
-    def __fspath__(self):
-        """
-        Just a getter to return the path unquoted
-
-        Fulfills the os.PathLike interface
-        """
-        return unquote(self.path)
 
 
 def quote(path):

--- a/src/rdiffbackup/locations/map/hardlinks.py
+++ b/src/rdiffbackup/locations/map/hardlinks.py
@@ -187,7 +187,7 @@ def link_rp(diff_rorp, dest_rpath, dest_root=None):
         dest_root = dest_rpath  # use base of dest_rpath
     dest_link_rpath = dest_root.new_index(diff_rorp.get_link_flag())
     try:
-        dest_rpath.hardlink(dest_link_rpath.path)
+        dest_rpath.hardlink(dest_link_rpath)
     except OSError as exc:
         # This can happen if the source of dest_link_rpath was deleted
         # after it's linking info was recorded but before
@@ -196,8 +196,9 @@ def link_rp(diff_rorp, dest_rpath, dest_root=None):
             dest_rpath.touch()  # This will cause an UpdateError later
         else:
             raise Exception(
-                "OS error '%s' linking %s to %s"
-                % (exc, dest_rpath.path, dest_link_rpath.path)
+                "OS error '{ex}' linking {dp} to {dl}".format(
+                    ex=exc, dp=dest_rpath, dl=dest_link_rpath
+                )
             )
 
 

--- a/src/rdiffbackup/meta/acl_posix.py
+++ b/src/rdiffbackup/meta/acl_posix.py
@@ -343,7 +343,7 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
         acl = posix1e.ACL()
 
     try:
-        acl.applyto(rp.path)
+        acl.applyto(rp)
     except OSError as exc:
         log.Log(
             "Unable to set ACL on path {pa} due to exception '{ex}'".format(
@@ -358,7 +358,7 @@ def set_rp_acl(rp, entry_list=None, default_entry_list=None, map_names=1):
             def_acl = _list_to_acl(default_entry_list, map_names)
         else:
             def_acl = posix1e.ACL()
-        def_acl.applyto(rp.path, posix1e.ACL_TYPE_DEFAULT)
+        def_acl.applyto(rp, posix1e.ACL_TYPE_DEFAULT)
 
 
 def get_acl_lists_from_rp(rp):
@@ -369,7 +369,7 @@ def get_acl_lists_from_rp(rp):
         conn=rp.conn
     )
     try:
-        acl = posix1e.ACL(file=rp.path)
+        acl = posix1e.ACL(file=rp)
     except (FileNotFoundError, UnicodeEncodeError) as exc:
         log.Log(
             "Unable to read ACL from path {pa} due to exception '{ex}'".format(
@@ -392,7 +392,7 @@ def get_acl_lists_from_rp(rp):
             raise
     if rp.isdir():
         try:
-            def_acl = posix1e.ACL(filedef=os.fsdecode(rp.path))
+            def_acl = posix1e.ACL(filedef=os.fsdecode(rp))
         except (FileNotFoundError, UnicodeEncodeError) as exc:
             log.Log(
                 "Unable to read default ACL from path {pa} due to "

--- a/src/rdiffbackup/meta/acl_win.py
+++ b/src/rdiffbackup/meta/acl_win.py
@@ -100,7 +100,7 @@ class ACL:
             return
 
         try:
-            sd = GetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
+            sd = GetNamedSecurityInfo(os.fsdecode(rp), SE_FILE_OBJECT, ACL.flags)
         except (OSError, pywintypes.error) as exc:
             log.Log(
                 "Unable to read ACL from path {pa} due to "
@@ -197,7 +197,7 @@ class ACL:
 
         try:
             SetNamedSecurityInfo(
-                os.fsdecode(rp.path),
+                os.fsdecode(rp),
                 SE_FILE_OBJECT,
                 ACL.flags,
                 sd.GetSecurityDescriptorOwner(),
@@ -231,9 +231,9 @@ class ACL:
 
     def _clear_rp(self, rp):
         # not sure how to interpret this
-        # I'll just clear all acl-s from rp.path
+        # I'll just clear all acl-s from rp
         try:
-            sd = GetNamedSecurityInfo(os.fsdecode(rp.path), SE_FILE_OBJECT, ACL.flags)
+            sd = GetNamedSecurityInfo(os.fsdecode(rp), SE_FILE_OBJECT, ACL.flags)
         except (OSError, pywintypes.error) as exc:
             log.Log(
                 "Unable to read ACL from path {pa} for clearing them "
@@ -263,7 +263,7 @@ class ACL:
 
         try:
             SetNamedSecurityInfo(
-                os.fsdecode(rp.path),
+                os.fsdecode(rp),
                 SE_FILE_OBJECT,
                 ACL.flags,
                 sd.GetSecurityDescriptorOwner(),

--- a/src/rdiffbackup/meta/ea.py
+++ b/src/rdiffbackup/meta/ea.py
@@ -85,7 +85,7 @@ class ExtendedAttributes:
     def read_from_rp(self, rp):
         """Set the extended attributes from an rpath"""
         try:
-            attr_list = xattr.list(rp.path, rp.issym())
+            attr_list = xattr.list(rp, rp.issym())
         except OSError as exc:
             if exc.errno in (errno.EOPNOTSUPP, errno.EPERM, errno.ETXTBSY):
                 return  # if not supported, consider empty
@@ -106,7 +106,7 @@ class ExtendedAttributes:
                 # Resource Fork handled elsewhere, except for directories
                 continue
             try:
-                self.attr_dict[attr] = xattr.get(rp.path, attr, rp.issym())
+                self.attr_dict[attr] = xattr.get(rp, attr, rp.issym())
             except OSError as exc:
                 # File probably modified while reading, just continue
                 if exc.errno == errno.ENODATA:
@@ -132,7 +132,7 @@ class ExtendedAttributes:
         self._clear_rp(rp)
         for name, value in self.attr_dict.items():
             try:
-                xattr.set(rp.path, name, value, 0, rp.issym())
+                xattr.set(rp, name, value, 0, rp.issym())
             except OSError as exc:
                 # Mac and Linux attributes have different namespaces, so
                 # fail gracefully if can't call xattr.set
@@ -168,9 +168,9 @@ class ExtendedAttributes:
     def _clear_rp(self, rp):
         """Delete all the extended attributes in rpath"""
         try:
-            for name in xattr.list(rp.path, rp.issym()):
+            for name in xattr.list(rp, rp.issym()):
                 try:
-                    xattr.remove(rp.path, name, rp.issym())
+                    xattr.remove(rp, name, rp.issym())
                 except PermissionError:  # errno.EACCES
                     # SELinux attributes cannot be removed, and we don't want
                     # to bail out or be too noisy at low log levels.

--- a/testing/cmdline_test.py
+++ b/testing/cmdline_test.py
@@ -151,7 +151,7 @@ class PathSetter(unittest.TestCase):
 
         # Getting restore rps
         inc_paths = self.getinc_paths(
-            b"increments.", os.path.join(Local.rpout.path, b"rdiff-backup-data")
+            b"increments.", os.path.join(Local.rpout, b"rdiff-backup-data")
         )
         self.assertEqual(len(inc_paths), 3)
 
@@ -188,7 +188,7 @@ class PathSetter(unittest.TestCase):
         # Test restoration of a few random files
         vft_paths = self.getinc_paths(
             b"various_file_types.",
-            os.path.join(Local.rpout.path, b"rdiff-backup-data", b"increments"),
+            os.path.join(Local.rpout, b"rdiff-backup-data", b"increments"),
         )
         comtst.rdiff_backup(
             from_local,
@@ -202,7 +202,7 @@ class PathSetter(unittest.TestCase):
 
         timbar_paths = self.getinc_paths(
             b"timbar.pyc.",
-            os.path.join(Local.rpout.path, b"rdiff-backup-data", b"increments"),
+            os.path.join(Local.rpout, b"rdiff-backup-data", b"increments"),
         )
         comtst.rdiff_backup(
             from_local,
@@ -229,7 +229,7 @@ class PathSetter(unittest.TestCase):
             len(
                 self.getinc_paths(
                     b"nochange.",
-                    os.path.join(Local.rpout.path, b"rdiff-backup-data", b"increments"),
+                    os.path.join(Local.rpout, b"rdiff-backup-data", b"increments"),
                 )
             ),
             0,
@@ -379,7 +379,7 @@ class Final(PathSetter):
         # remove mirror_metadata files to simulate old style backups
         # pathlib.Path doesn't work with bytes hence need to work with str path
         for mirror_file in pathlib.Path(
-            os.fsdecode(Local.rpout.append(b"rdiff-backup-data").path)
+            os.fsdecode(Local.rpout.append(b"rdiff-backup-data"))
         ).glob("mirror_metadata*"):
             mirror_file.unlink()
         comtst.rdiff_backup(
@@ -629,9 +629,9 @@ class FinalSelection(PathSetter):
         self.delete_tmpdirs()
 
         # create a few relative paths to check a different approach than absolute
-        inc2_rel = os.path.relpath(Local.inc2rp.path)
-        out_rel = os.path.relpath(Local.rpout.path)
-        rest1_rel = os.path.relpath(Local.rpout1.path)
+        inc2_rel = os.path.relpath(Local.inc2rp)
+        out_rel = os.path.relpath(Local.rpout)
+        rest1_rel = os.path.relpath(Local.rpout1)
 
         # Test --include option
         comtst.rdiff_backup(
@@ -751,10 +751,10 @@ class FinalSelection(PathSetter):
             Local.rpout1.path,
             extra_options=(b"restore", b"--at", b"now"),
         )
-        self.assertTrue(os.lstat(Local.rpout1.append("executable").path))
-        self.assertTrue(os.lstat(Local.rpout1.append("symbolic_link").path))
-        self.assertRaises(OSError, os.lstat, Local.rpout1.append("regular_file").path)
-        self.assertRaises(OSError, os.lstat, Local.rpout1.append("executable2").path)
+        self.assertTrue(os.lstat(Local.rpout1.append("executable")))
+        self.assertTrue(os.lstat(Local.rpout1.append("symbolic_link")))
+        self.assertRaises(OSError, os.lstat, Local.rpout1.append("regular_file"))
+        self.assertRaises(OSError, os.lstat, Local.rpout1.append("executable2"))
 
     def testSelRestoreLocal(self):
         """Test selection options when restoring locally"""

--- a/testing/rdiff_test.py
+++ b/testing/rdiff_test.py
@@ -113,7 +113,7 @@ class RdiffTest(unittest.TestCase):
             )
         else:
             comtst.os_system((b"gzip", self.delta.path))
-        os.rename(gzip_path, self.delta.path)
+        os.rename(gzip_path, self.delta)
         self.delta.setdata()
 
         Rdiff.patch_local(self.basis, self.delta, self.output, delta_compressed=1)

--- a/testing/rpath_test.py
+++ b/testing/rpath_test.py
@@ -494,13 +494,13 @@ class FileCopying(RPathTest):
         fifo = rpath.RPath(self.lc, self.mainprefix, ("fifo",))
         if fifo.lstat():
             fifo.delete()
-        os.mkfifo(fifo.path)
+        os.mkfifo(fifo)
         fifo.setdata()
         # Create symlink
         sl = rpath.RPath(self.lc, self.mainprefix, ("symbolic_link",))
         if sl.lstat():
             sl.delete()
-        os.symlink(self.rf.path, sl.path)
+        os.symlink(self.rf, sl)
         sl.setdata()
         # Test rename with EXDEV error.
         for rp in [fifo, sl]:


### PR DESCRIPTION


<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

This is a simple PR:

* Simplify more functions using PathLike interface of RPath
* Fix __fspath__ to use it on QuotedRPath

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
