### PR TITLE
[DOC] fix successful spelling in docs

### DIFF
--- a/docs/DEVELOP.adoc
+++ b/docs/DEVELOP.adoc
@@ -594,7 +594,7 @@ We use https://docs.github.com/en/actions[GitHub Actions] to release automatical
 
 The following rules apply:
 
-* each modification to master happens through a Pull Request (PR) which triggers a pipeline job, which must be succesful for the merge to have a chance to happen.
+* each modification to master happens through a Pull Request (PR) which triggers a pipeline job, which must be successful for the merge to have a chance to happen.
 Such PR jobs will _not_ trigger a release.
 * GitHub releases are generated as draft only on Git tags looking like a release.
 The release manager reviews then the draft release, names and describes it before they makes it visible.


### PR DESCRIPTION
Changes:
- `succesful` -> `successful` in `docs/DEVELOP.adoc` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
