### PR TITLE
FIX: log level in fs_abilities chmod() calls

### DIFF
--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -535,7 +535,7 @@ class FSAbilities:
         test_rp = rp.append("dir_inc_check")
         test_rp.touch()
         try:
-            test_rp.chmod(0o7777, 4)
+            test_rp.chmod(0o7777, log.INFO)
         except OSError:
             test_rp.delete()
             self.dir_inc_perms = False
@@ -620,10 +620,10 @@ class FSAbilities:
         tmpd_rp = dir_rp.append(b"high_perms_dir")
         tmpd_rp.touch()
         try:
-            tmpf_rp.chmod(0o7000, 4)
-            tmpf_rp.chmod(0o7777, 4)
-            tmpd_rp.chmod(0o7000, 4)
-            tmpd_rp.chmod(0o7777, 4)
+            tmpf_rp.chmod(0o7000, log.INFO)
+            tmpf_rp.chmod(0o7777, log.INFO)
+            tmpd_rp.chmod(0o7000, log.INFO)
+            tmpd_rp.chmod(0o7777, log.INFO)
         except OSError:
             self.high_perms = False
         else:


### PR DESCRIPTION
Calls to chmod() specified loglevel "4," which is not a valid log level, so logging caused an exception in _format() when it tried to access _LOG_PREFIX[4].

This fix replaces instances of "4" with "log.INFO"

- [*] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [*] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
