### PR TITLE
WIP: Refactor tox files

### DIFF
--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -765,7 +765,15 @@ probably isn't what you meant""".format(se=self.selection_functions[-1].name))
         """Return list of regexps equivalent to prefixes of glob_str"""
 
         glob_parts = glob_str.split(b"/")
-        if b"" in glob_parts[1:-1]:  # "" OK if comes first or last, as in /foo/
+
+        # Allow a leading empty part for UNC paths like //server/share/foo
+        # on Windows, but still catch consecutive slashes anywhere else.
+        if os.name == "nt" and glob_str.startswith(b"//"):
+            check_parts = glob_parts[2:-1]
+        else:
+            check_parts = glob_parts[1:-1]
+
+        if b"" in check_parts:  # "" OK if comes first or last, as in /foo/
             raise GlobbingError(
                 "Consecutive '/'s found in globbing string {gs}".format(
                     gs=convert.to_safe_str(glob_str)

--- a/testing/selection_test.py
+++ b/testing/selection_test.py
@@ -3,6 +3,7 @@ Test selection aspects of rdiff-backup
 """
 
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -1132,6 +1133,43 @@ class CommandTest(unittest.TestCase):
         )
 
         self.success = True
+
+    @unittest.skipUnless(
+        sys.platform.startswith("win"), "UNC path only work on Windows"
+    )
+    def test_with_unc_path(self):
+        """
+        Test if we can backup a directory using UNC path on Windows.
+        """
+        # Replace C:/ by //localhost/C$
+        unc_base_dir = re.sub(rb"^([A-Za-z]):/", rb"//localhost/\1$/", self.base_dir)
+
+        testrp = rpath.RPath(specifics.local_connection, unc_base_dir)
+        comtst.re_init_rpath_dir(testrp)
+        # Given a data source with data
+        sourcerp = testrp.append("source")
+        sourcerp.mkdir()
+        includerp = sourcerp.append("dir1")
+        includerp.mkdir()
+        sourcerp.append("dir2").mkdir()
+        # Given an empty destination
+        destrp = testrp.append("dest")
+        destrp.mkdir()
+        # When backup run with UNC path
+        self.assertEqual(
+            comtst.rdiff_backup_action(
+                True,
+                True,
+                sourcerp.path,
+                destrp.path,
+                (),
+                b"backup",
+                ("--include", includerp.path, "--exclude", "**"),
+            ),
+            consts.RET_CODE_OK,
+        )
+        # Then backup is sucessful.
+        self.assertTrue(destrp.append("dir1").isdir())
 
     def tearDown(self):
         # we clean-up only if the test was successful


### PR DESCRIPTION
## Changes done and why

To follow a more conventional approach, I want to reduce duplication in our tox.ini files. The target is to use more conventional target names like "lint", "format", "test", etc. And also get rid of the makefile which essentially only call tox.

## Self-Checklist

- [ ] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:
