### PR TITLE
allow UNC-style double slash prefix in glob paths

### DIFF
--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -765,7 +765,15 @@ probably isn't what you meant""".format(se=self.selection_functions[-1].name))
         """Return list of regexps equivalent to prefixes of glob_str"""
 
         glob_parts = glob_str.split(b"/")
-        if b"" in glob_parts[1:-1]:  # "" OK if comes first or last, as in /foo/
+
+        # Allow a leading empty part for UNC paths like //server/share/foo
+        # on Windows, but still catch consecutive slashes anywhere else.
+        if os.name == "nt" and glob_str.startswith(b"//"):
+            check_parts = glob_parts[2:-1]
+        else:
+            check_parts = glob_parts[1:-1]
+
+        if b"" in check_parts:  # "" OK if comes first or last, as in /foo/
             raise GlobbingError(
                 "Consecutive '/'s found in globbing string {gs}".format(
                     gs=convert.to_safe_str(glob_str)

--- a/testing/selection_test.py
+++ b/testing/selection_test.py
@@ -3,6 +3,7 @@ Test selection aspects of rdiff-backup
 """
 
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -1132,6 +1133,43 @@ class CommandTest(unittest.TestCase):
         )
 
         self.success = True
+
+    @unittest.skipUnless(
+        sys.platform.startswith("win"), "UNC path only work on Windows"
+    )
+    def test_with_unc_path(self):
+        """
+        Test if we can backup a directory using UNC path on Windows.
+        """
+        # Replace C:/ by //localhost/C$
+        unc_base_dir = re.sub(rb"^([A-Za-z]):/", rb"//localhost/\1$/", self.base_dir)
+
+        testrp = rpath.RPath(specifics.local_connection, unc_base_dir)
+        comtst.re_init_rpath_dir(testrp)
+        # Given a data source with data
+        sourcerp = testrp.append("source")
+        sourcerp.mkdir()
+        includerp = sourcerp.append("dir1")
+        includerp.mkdir()
+        sourcerp.append("dir2").mkdir()
+        # Given an empty destination
+        destrp = testrp.append("dest")
+        destrp.mkdir()
+        # When backup run with UNC path
+        self.assertEqual(
+            comtst.rdiff_backup_action(
+                True,
+                True,
+                sourcerp.path,
+                destrp.path,
+                (),
+                b"backup",
+                ("--include", includerp.path, "--exclude", "**"),
+            ),
+            consts.RET_CODE_OK,
+        )
+        # Then backup is sucessful.
+        self.assertTrue(destrp.append("dir1").isdir())
 
     def tearDown(self):
         # we clean-up only if the test was successful


### PR DESCRIPTION
PR created as replacement for #1114 which has strange conflicts.

FIX: include/exclude with UNC-style path

<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [ ] changes to the code have been reflected in the documentation
- [ ] changes to the code have been covered by new/modified tests
- [ ] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
