### PR TITLE
Use sys.platform instead of os.name to help mypy

### DIFF
--- a/docs/CODING.adoc
+++ b/docs/CODING.adoc
@@ -92,3 +92,4 @@ In the meantime, consider the following:
 * don't introduce imports only for typing purposes.
 Introduce such imports only depending on the statement `if typing.TYPE_CHECKING:`.
 Also double-quote type hints requiring such an additional import.
+* Use `sys.version_info` and `sys.platform` to differentiate respectively Python versions and operating systems because this is what https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks[Mypy understands].

--- a/src/rdiff_backup/SetConnections.py
+++ b/src/rdiff_backup/SetConnections.py
@@ -27,6 +27,7 @@ the related connections.
 import os
 import re
 import subprocess
+import sys
 from rdiff_backup import connection, rpath
 from rdiffbackup.singletons import consts, generics, log, specifics
 from rdiffbackup.utils import convert
@@ -326,7 +327,7 @@ def _init_connection(remote_cmd):
         log.INFO,
     )
     # Windows doesn't support bytes for command string
-    if os.name == "nt":
+    if sys.platform.startswith("win"):
         exec_cmd = os.fsdecode(remote_cmd)
     else:
         exec_cmd = remote_cmd

--- a/src/rdiff_backup/rpath.py
+++ b/src/rdiff_backup/rpath.py
@@ -40,6 +40,7 @@ import os
 import re
 import shutil
 import stat
+import sys
 import tempfile
 import time
 from rdiff_backup import C
@@ -804,7 +805,7 @@ class RPath(RORPath):
         except OSError:
             # It's not possible to set a modification time for
             # directories on Windows.
-            if not (self.isdir() and os.name == "nt"):
+            if not (self.isdir() and sys.platform.startswith("win")):
                 raise
         else:
             self.data["mtime"] = modtime
@@ -1746,7 +1747,7 @@ def get_rpath_data(filename, base, index):
     data["uname"] = usrgrp.uid2uname(data["uid"])
     data["gname"] = usrgrp.gid2gname(data["gid"])
 
-    if os.name == "nt":
+    if sys.platform.startswith("win"):
         try:
             attribs = win32api.GetFileAttributes(os.fsdecode(filename))
         except pywintypes.error as exc:

--- a/src/rdiff_backup/selection.py
+++ b/src/rdiff_backup/selection.py
@@ -25,6 +25,7 @@ documentation on what this code does can be found on the man page.
 
 import os
 import re
+import sys
 import typing
 
 from rdiff_backup import robust, rorpiter, rpath
@@ -768,7 +769,7 @@ probably isn't what you meant""".format(se=self.selection_functions[-1].name))
 
         # Allow a leading empty part for UNC paths like //server/share/foo
         # on Windows, but still catch consecutive slashes anywhere else.
-        if os.name == "nt" and glob_str.startswith(b"//"):
+        if sys.platform.startswith("win") and glob_str.startswith(b"//"):
             check_parts = glob_parts[2:-1]
         else:
             check_parts = glob_parts[1:-1]

--- a/src/rdiffbackup/locations/_dir_shadow.py
+++ b/src/rdiffbackup/locations/_dir_shadow.py
@@ -24,7 +24,7 @@ it has no real life of itself, i.e. it has only class methods and can't
 be instantiated.
 """
 
-import os
+import sys
 
 from rdiff_backup import (
     hash,
@@ -72,7 +72,6 @@ class ReadDirShadow(location.LocationShadow):
             base_rp = cls._base_dir
         if select_opts is None:
             select_opts = cls._values.get("selections") or []
-        is_windows = os.name == "nt"
 
         # FIXME not sure we couldn't support symbolic links nowadays on Windows
         # knowing that it would require specific handling when reading the link:
@@ -80,7 +79,10 @@ class ReadDirShadow(location.LocationShadow):
         #   TypeError: symlink: src should be string, bytes or os.PathLike,
         #                       not NoneType
         # I suspect that not all users can read symlinks with os.readlink
-        if is_windows and ("exclude-symbolic-links", None) not in select_opts:
+        if (
+            sys.platform.startswith("win")
+            and ("exclude-symbolic-links", None) not in select_opts
+        ):
             log.Log("Symbolic links excluded on Windows", log.NOTE)
             select_opts.insert(0, ("exclude-symbolic-links", None))
         sel = selection.Select(base_rp)

--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -29,6 +29,7 @@ import io
 import os
 import re
 import socket
+import sys
 import tempfile
 import yaml
 from rdiff_backup import (
@@ -1759,7 +1760,7 @@ information in it.
         def pid_running(pid):
             """Return True if we know if process with pid is currently running,
             False if it isn't running, and None if we don't know for sure."""
-            if os.name == "nt":
+            if sys.platform.startswith("win"):
                 import win32api
                 import win32con
                 import pywintypes

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -28,6 +28,7 @@ FSAbilities object describing it.
 
 import errno
 import os
+import sys
 from rdiff_backup import robust, selection, Time
 from rdiffbackup.meta import acl_win  # FIXME there should be no dependency
 from rdiffbackup.locations.map import filenames as map_filenames
@@ -210,7 +211,7 @@ class FSAbilities:
         """
         Set self.hardlinks to true if hard linked files can be created
         """
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             log.Log("Hardlinks disabled on Windows", log.INFO)
             self.hardlinks = None
             return
@@ -665,7 +666,7 @@ class FSAbilities:
         Cygwin/FAT32 |  -success-   -HANGS-
         Native Win   |  WinError,2  WinError,87 WinError,87
         """
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             self.escape_dos_devices = True
             return
 

--- a/src/rdiffbackup/locations/fs_abilities.py
+++ b/src/rdiffbackup/locations/fs_abilities.py
@@ -655,7 +655,7 @@ class FSAbilities:
         This test must detect if the underlying OS is Windows, whether we are
         running under Cygwin or natively. Cygwin allows these special files to
         be stat'd from any directory. Native Windows returns OSError (like
-        non-Cygwin POSIX), but we can check for that using os.name.
+        non-Cygwin POSIX), but we can check for that using sys.platform.
 
         Note that 'con' and 'aux' have some unusual behaviors as shown below.
 

--- a/src/rdiffbackup/run.py
+++ b/src/rdiffbackup/run.py
@@ -23,12 +23,12 @@ import sys
 from rdiffbackup import arguments, actions_mgr
 from rdiffbackup.singletons import consts, generics, log, specifics
 
-if os.name == "nt":
+if sys.platform.startswith("win"):
     import msvcrt
 
 
 def main():
-    if os.name == "nt":
+    if sys.platform.startswith("win"):
         # make sure line endings are kept under Windows like under Linux
         msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
         msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)

--- a/src/rdiffbackup/singletons/generics.py
+++ b/src/rdiffbackup/singletons/generics.py
@@ -21,7 +21,7 @@ A variety of variables which need to have the same value across connections.
 They are generic to all instances of rdiff-backup involved.
 """
 
-import os
+import sys
 import typing
 
 from rdiffbackup.singletons import specifics
@@ -76,8 +76,8 @@ chars_to_quote_unregexp: typing.Optional["re.Pattern[bytes]"] = None
 # evaluate if DOS device names (AUX, PRN, CON, NUL, COM, LPT) should be quoted
 # or spaces at the end of file and directory names.
 # The default is based on the operating system type (nt or posix).
-escape_dos_devices: bool = os.name == "nt"
-escape_trailing_spaces: bool = os.name == "nt"
+escape_dos_devices: bool = sys.platform.startswith("win")
+escape_trailing_spaces: bool = sys.platform.startswith("win")
 
 # If true, the timestamps use the following format: "2008-09-01T04-49-04-07-00"
 # (instead of "2008-09-01T04:49:04-07:00"). This creates timestamps which

--- a/src/rdiffbackup/singletons/specifics.py
+++ b/src/rdiffbackup/singletons/specifics.py
@@ -23,6 +23,7 @@ They are specific to each instance of rdiff-backup involved.
 
 import builtins
 import os
+import sys
 import typing
 import yaml
 from importlib import metadata
@@ -56,12 +57,17 @@ server: bool = False
 # vary depending on the connection.
 process_uid: int
 process_groups: builtins.set[int]
-try:
-    process_uid = os.getuid()
-    process_groups = builtins.set(os.getgroups())
-except AttributeError:
+
+if sys.platform.startswith("win"):
     process_uid = 0
     process_groups = {0}
+else:
+    try:
+        process_uid = os.getuid()
+        process_groups = builtins.set(os.getgroups())
+    except AttributeError:
+        process_uid = 0
+        process_groups = {0}
 
 # The following three attributes represent whether extended attributes
 # are supported.  If eas_active is true, then the current session

--- a/src/rdiffbackup/utils/locking.py
+++ b/src/rdiffbackup/utils/locking.py
@@ -24,11 +24,11 @@ Portable locking utilities, defining lock and unlock functions
 # by Jonathan Feinberg, John Nielsen:
 # https://www.oreilly.com/library/view/python-cookbook/0596001673/ch04s25.html
 
-import os
+import sys
 import typing
 
 # needs win32all to work on Windows
-if os.name == "nt":
+if sys.platform.startswith("win"):
     import pywintypes
     import win32con
     import win32file
@@ -52,7 +52,7 @@ if os.name == "nt":
         hfile = win32file._get_osfhandle(file.fileno())
         win32file.UnlockFileEx(hfile, 0, 0xFFFF0000, __overlapped)
 
-elif os.name == "posix":
+else:
     from fcntl import LOCK_EX, LOCK_SH, LOCK_NB  # noqa: F401 implicitly used
     import fcntl
 
@@ -61,6 +61,3 @@ elif os.name == "posix":
 
     def unlock(file: typing.IO) -> None:
         fcntl.flock(file, fcntl.LOCK_UN | fcntl.LOCK_NB)
-
-else:  # pragma: no cover  # we will never test on other platforms
-    raise RuntimeError("Portable locking only defined for nt and posix platforms")

--- a/src/rdiffbackup/utils/simpleps.py
+++ b/src/rdiffbackup/utils/simpleps.py
@@ -22,8 +22,8 @@ and also because, under Windows, it doesn't act as always expected.
 """
 
 import collections.abc as abc
-import os
 import subprocess
+import sys
 import typing
 
 
@@ -50,7 +50,7 @@ def _get_pid_name_ps(pid: typing.Union[int, str]) -> typing.Optional[str]:
 
     The function uses the ps utility or tasklist (under Windows)
     """
-    if os.name == "nt":
+    if sys.platform.startswith("win"):
         cmd = ["tasklist", "/nh", "/fi", "pid eq {pp}".format(pp=pid)]
     else:
         cmd = ["ps", "-p", str(pid), "-o", "comm=,pid="]

--- a/src/rdiffbackup/utils/usrgrp.py
+++ b/src/rdiffbackup/utils/usrgrp.py
@@ -24,6 +24,7 @@ gids, and possibly vice-versa.  So maintain a separate dictionary for
 this.
 """
 
+import sys
 import typing
 
 try:
@@ -49,14 +50,16 @@ def uid2uname(uid: int) -> typing.Optional[str]:
     """
     if uid in _uid2uname:
         return _uid2uname[uid]
+    elif sys.platform.startswith("win"):
+        uname = None
     else:
         try:
             uname = pwd.getpwuid(uid).pw_name
             _uname2uid[uname] = uid
         except (KeyError, OverflowError, NameError):
             uname = None
-        _uid2uname[uid] = uname
-        return uname
+    _uid2uname[uid] = uname
+    return uname
 
 
 def gid2gname(gid: int) -> typing.Optional[str]:
@@ -65,14 +68,16 @@ def gid2gname(gid: int) -> typing.Optional[str]:
     """
     if gid in _gid2gname:
         return _gid2gname[gid]
+    elif sys.platform.startswith("win"):
+        gname = None
     else:
         try:
             gname = grp.getgrgid(gid).gr_name
             _gname2gid[gname] = gid
         except (KeyError, OverflowError, NameError):
             gname = None
-        _gid2gname[gid] = gname
-        return gname
+    _gid2gname[gid] = gname
+    return gname
 
 
 def uname2uid(uname: str) -> typing.Optional[int]:
@@ -81,14 +86,16 @@ def uname2uid(uname: str) -> typing.Optional[int]:
     """
     if uname in _uname2uid:
         return _uname2uid[uname]
+    elif sys.platform.startswith("win"):
+        uid = None
     else:
         try:
             uid = pwd.getpwnam(uname).pw_uid
             _uid2uname[uid] = uname
         except (KeyError, NameError):
             uid = None
-        _uname2uid[uname] = uid
-        return uid
+    _uname2uid[uname] = uid
+    return uid
 
 
 def gname2gid(gname: str) -> typing.Optional[int]:
@@ -97,11 +104,13 @@ def gname2gid(gname: str) -> typing.Optional[int]:
     """
     if gname in _gname2gid:
         return _gname2gid[gname]
+    elif sys.platform.startswith("win"):
+        gid = None
     else:
         try:
             gid = grp.getgrnam(gname).gr_gid
             _gid2gname[gid] = gname
         except (KeyError, NameError):
             gid = None
-        _gname2gid[gname] = gid
-        return gid
+    _gname2gid[gname] = gid
+    return gid

--- a/testing/action_backuprestore_test.py
+++ b/testing/action_backuprestore_test.py
@@ -4,6 +4,7 @@ Test the basic backup and restore actions
 
 import glob
 import os
+import sys
 import unittest
 
 import commontest as comtst
@@ -20,7 +21,7 @@ class ActionBackupRestoreTest(unittest.TestCase):
     def setUp(self):
         self.base_dir = os.path.join(TEST_BASE_DIR, b"action_backup_restore")
         # Windows can't handle too long filenames, FIXME issue #782
-        long_multi = 5 if os.name == "nt" else 25
+        long_multi = 5 if sys.platform.startswith("win") else 25
         self.from1_struct = {
             "from1": {
                 "contents": {
@@ -51,7 +52,7 @@ class ActionBackupRestoreTest(unittest.TestCase):
             }
         }
         self.from2_path = os.path.join(self.base_dir, b"from2")
-        if os.name != "nt":
+        if sys.platform.startswith("win"):
             # rdiff-backup can't handle (yet) hardlinks under Windows
             self.from1_struct["from1"]["contents"]["somehardlink"] = {"inode": "fileA"}
             self.from2_struct["from2"]["contents"]["somehardlink"] = {"inode": "fileA"}

--- a/testing/action_backuprestore_test.py
+++ b/testing/action_backuprestore_test.py
@@ -52,7 +52,7 @@ class ActionBackupRestoreTest(unittest.TestCase):
             }
         }
         self.from2_path = os.path.join(self.base_dir, b"from2")
-        if sys.platform.startswith("win"):
+        if not sys.platform.startswith("win"):
             # rdiff-backup can't handle (yet) hardlinks under Windows
             self.from1_struct["from1"]["contents"]["somehardlink"] = {"inode": "fileA"}
             self.from2_struct["from2"]["contents"]["somehardlink"] = {"inode": "fileA"}

--- a/testing/action_calculate_test.py
+++ b/testing/action_calculate_test.py
@@ -4,6 +4,7 @@ Test the calculate action
 
 import glob
 import os
+import sys
 import unittest
 
 from rdiffbackup.singletons import consts
@@ -22,7 +23,7 @@ class ActionCalculateTest(unittest.TestCase):
     def setUp(self):
         self.base_dir = os.path.join(TEST_BASE_DIR, b"action_calculate")
         # Windows can't handle too long filenames
-        long_multi = 10 if os.name == "nt" else 25
+        long_multi = 10 if sys.platform.startswith("win") else 25
         self.from1_struct = {
             "from1": {
                 "contents": {
@@ -53,7 +54,7 @@ class ActionCalculateTest(unittest.TestCase):
             }
         }
         self.from2_path = os.path.join(self.base_dir, b"from2")
-        if os.name != "nt":
+        if sys.platform.startswith("win"):
             # rdiff-backup can't handle (yet) hardlinks under Windows
             self.from1_struct["from1"]["contents"]["somehardlink"] = {"inode": "fileA"}
             self.from2_struct["from2"]["contents"]["somehardlink"] = {"inode": "fileA"}

--- a/testing/action_calculate_test.py
+++ b/testing/action_calculate_test.py
@@ -54,7 +54,7 @@ class ActionCalculateTest(unittest.TestCase):
             }
         }
         self.from2_path = os.path.join(self.base_dir, b"from2")
-        if sys.platform.startswith("win"):
+        if not sys.platform.startswith("win"):
             # rdiff-backup can't handle (yet) hardlinks under Windows
             self.from1_struct["from1"]["contents"]["somehardlink"] = {"inode": "fileA"}
             self.from2_struct["from2"]["contents"]["somehardlink"] = {"inode": "fileA"}

--- a/testing/action_test_test.py
+++ b/testing/action_test_test.py
@@ -2,7 +2,7 @@
 Test the "test" action
 """
 
-import os
+import sys
 import unittest
 
 import commontest as comtst
@@ -14,7 +14,7 @@ class ActionTestTest(unittest.TestCase):
     """Test the test action (!)"""
 
     def setUp(self):
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             self.dir1 = b"C:\\"
             self.dir2 = b"C:\\"
         else:

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -9,6 +9,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 
 from rdiff_backup import (
     hash,
@@ -44,7 +45,7 @@ abs_testing_dir = os.path.dirname(os.path.abspath(os.fsencode(__file__)))
 
 __no_execute__ = 1  # Keeps the actual rdiff-backup program from running
 
-if os.name == "nt":
+if sys.platform.startswith("win"):
     generics.set("use_compatible_timestamps", True)
     CMD_SEP = b" & "
 else:
@@ -72,7 +73,7 @@ def re_init_rpath_dir(rp, uid=-1, gid=-1):
         remove_dir(rp.path)
         rp.setdata()
     rp.makedirs()
-    if os.name != "nt":
+    if sys.platform.startswith("win"):
         rp.chown(uid, gid)
 
 
@@ -224,7 +225,7 @@ def rdiff_backup_action(
         except subprocess.CalledProcessError as exc:
             ret_val = exc.output
         # normalize line endings under Windows
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             ret_val = ret_val.replace(b"\r\n", b"\n")
     else:
         ret_val = os_system(cmdargs, input=std_input, universal_newlines=False)
@@ -235,7 +236,7 @@ def _get_locations(src_local, dest_local, src_dir, dest_dir):
     """
     Return a tuple of remote or local source and destination locations
     """
-    if os.name == "nt":
+    if sys.platform.startswith("win"):
         remote_location = "cd {rdir} & {tdir}\\server.py::{dir}"
     else:
         remote_location = "cd {rdir}; {tdir}/server.py::{dir}"
@@ -510,7 +511,7 @@ def _files_rorp_eq(
     """Combined eq func returns true if two files compare same"""
     # default value depends on OS, symlinks aren't supported under Windows
     if compare_symlinks is None:
-        compare_symlinks = os.name != "nt"
+        compare_symlinks = sys.platform.startswith("win")
     if not compare_symlinks:
         if src_rorp and src_rorp.issym() or dest_rorp and dest_rorp.issym():
             return True

--- a/testing/commontest.py
+++ b/testing/commontest.py
@@ -73,7 +73,7 @@ def re_init_rpath_dir(rp, uid=-1, gid=-1):
         remove_dir(rp.path)
         rp.setdata()
     rp.makedirs()
-    if sys.platform.startswith("win"):
+    if not sys.platform.startswith("win"):
         rp.chown(uid, gid)
 
 
@@ -511,7 +511,7 @@ def _files_rorp_eq(
     """Combined eq func returns true if two files compare same"""
     # default value depends on OS, symlinks aren't supported under Windows
     if compare_symlinks is None:
-        compare_symlinks = sys.platform.startswith("win")
+        compare_symlinks = not sys.platform.startswith("win")
     if not compare_symlinks:
         if src_rorp and src_rorp.issym() or dest_rorp and dest_rorp.issym():
             return True

--- a/testing/connection_test.py
+++ b/testing/connection_test.py
@@ -236,7 +236,9 @@ class RedirectedConnectionTest(unittest.TestCase):
         SetConnections.CloseConnections()
 
 
-@unittest.skipIf(os.name == "nt", "No way to prolongate a Windows command")
+@unittest.skipIf(
+    sys.platform.startswith("win"), "No way to prolongate a Windows command"
+)
 class LengthyConnectionTest(unittest.TestCase):
     """Test what happens if a server process takes too long to quit"""
 

--- a/testing/fs_abilities_test.py
+++ b/testing/fs_abilities_test.py
@@ -3,6 +3,7 @@ Test file system abilities gathering
 """
 
 import os
+import sys
 import time
 import unittest
 
@@ -48,7 +49,7 @@ try:
 except (ImportError, AttributeError):
     carbon_type = type(None)
 
-if os.name == "nt":  # because we ignore hardlinks under Windows
+if sys.platform.startswith("win"):  # because we ignore hardlinks under Windows
     hardlinks_type = type(None)
 else:
     hardlinks_type = bool

--- a/testing/increment_test.py
+++ b/testing/increment_test.py
@@ -3,6 +3,7 @@ Test increment functions
 """
 
 import os
+import sys
 import unittest
 
 import commontest as comtst
@@ -36,7 +37,7 @@ out_gz = rpath.RPath(lc, os.path.join(TEST_BASE_DIR, b"out.gz"))
 
 Time.set_current_time(1000000000)
 prevtime = 999424113
-if os.name == "nt":
+if sys.platform.startswith("win"):
     prevtimestr = b"2001-09-02T02-48-33-07-00"
 else:
     prevtimestr = b"2001-09-02T02:48:33-07:00"
@@ -79,7 +80,9 @@ class IncrementTest(unittest.TestCase):
         self.assertEqual(missing_rp.getinctype(), b"missing")
         missing_rp.delete()
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "Symlinks not supported under Windows"
+    )
     def testsnapshot(self):
         """Test making of a snapshot"""
         increment.init(False, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
@@ -95,7 +98,9 @@ class IncrementTest(unittest.TestCase):
         self.assertTrue(rpath.cmp(snap_rp2, rf))
         snap_rp2.delete()
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "Symlinks not supported under Windows"
+    )
     def testGzipsnapshot(self):
         """Test making a compressed snapshot"""
         increment.init(True, actions.DEFAULT_NOT_COMPRESSED_REGEXP)
@@ -113,7 +118,9 @@ class IncrementTest(unittest.TestCase):
         self.assertTrue(rp.isinccompressed())
         rp.delete()
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "Symlinks not supported under Windows"
+    )
     def testdir(self):
         """Test increment on base_dir"""
         rp = increment.make_increment(sym, base_dir, target, prevtime)

--- a/testing/iterfile_test.py
+++ b/testing/iterfile_test.py
@@ -136,7 +136,7 @@ class testMiscIters(unittest.TestCase):
         next(i_out)
         self.assertRaises(StopIteration, i_out.__next__)
 
-    @unittest.skipIf(os.name == "nt", "FIXME fails under Windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "FIXME fails under Windows")
     def testMix(self):
         """Test a mix of RPs and ordinary objects"""
         filelist = [5, self.regfile3, "hello"]
@@ -171,7 +171,7 @@ class testMiscIters(unittest.TestCase):
         self.assertEqual(next(i_out2), self.outputrp)
         self.assertRaises(StopIteration, i_out2.__next__)
 
-    @unittest.skipIf(os.name == "nt", "FIXME fails under Windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "FIXME fails under Windows")
     def testFlushRepeat(self):
         """Test flushing like above, but have Flush obj emerge from iter"""
         rplist = [self.outputrp, iterfile.MiscIterFlushRepeat, self.outputrp]

--- a/testing/location_map_filenames_test.py
+++ b/testing/location_map_filenames_test.py
@@ -3,6 +3,7 @@ Test the quoting of characters in filenames
 """
 
 import os
+import sys
 import unittest
 
 import commontest as comtst
@@ -21,7 +22,7 @@ class LocationMapFilenamesTest(unittest.TestCase):
     def setUp(self):
         self.base_dir = os.path.join(TEST_BASE_DIR, b"location_map_filenames")
         # Windows can't handle too long filenames, FIXME issue #782
-        long_multi = 3 if os.name == "nt" else 25
+        long_multi = 3 if sys.platform.startswith("win") else 25
         self.from1_struct = {
             "from1": {
                 "contents": {

--- a/testing/longname_test.py
+++ b/testing/longname_test.py
@@ -4,6 +4,7 @@ Test handling of long names
 
 import errno
 import os
+import sys
 import unittest
 
 import commontest as comtst
@@ -13,7 +14,7 @@ from rdiffbackup.singletons import specifics
 
 TEST_BASE_DIR = comtst.get_test_base_dir(__file__)
 
-if os.name == "nt":
+if sys.platform.startswith("win"):
     NAME_MAX_LEN = 255
 else:
     NAME_MAX_LEN = os.pathconf(TEST_BASE_DIR, "PC_NAME_MAX")

--- a/testing/rdiff_test.py
+++ b/testing/rdiff_test.py
@@ -4,6 +4,7 @@ Compare results with call to rdiff utility
 
 import os
 import random
+import sys
 import unittest
 
 import commontest as comtst
@@ -97,7 +98,7 @@ class RdiffTest(unittest.TestCase):
         )
         self.assertTrue(self.delta.lstat())
         gzip_path = self.delta.path + b".gz"
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             # simulate gzip using 7z on Windows
             comtst.os_system(
                 (
@@ -149,7 +150,7 @@ class RdiffTest(unittest.TestCase):
 
         Rdiff.write_delta(self.basis, self.new, delta_gz, 1)
         self.assertTrue(delta_gz.lstat())
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             # simulate gunzip using 7z on Windows
             comtst.os_system(
                 (
@@ -171,7 +172,7 @@ class RdiffTest(unittest.TestCase):
         self.assertTrue(rpath.cmp(self.new, self.output))
         list(map(rpath.RPath.delete, rplist))
 
-    @unittest.skipIf(os.name == "nt", "FIXME fails under Windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "FIXME fails under Windows")
     def testRdiffRename(self):
         """Rdiff replacing original file with patch outfile"""
         rplist = [self.basis, self.new, self.delta, self.signature]

--- a/testing/robust_test.py
+++ b/testing/robust_test.py
@@ -3,6 +3,7 @@ Test making the code robust against specific exceptions
 """
 
 import os
+import sys
 import unittest
 
 import commontest as comtst
@@ -33,7 +34,9 @@ class RobustTest(unittest.TestCase):
         with self.assertRaises(NameError):
             robust.check_common_error(None, cause_uncatchable_error)
 
-    @unittest.skipIf(os.name == "nt", "Test is meaningless under Windows")
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "Test is meaningless under Windows"
+    )
     def test_check_failed_errorlog(self):
         """
         Validate that one unreadable file doesn't fail the whole backup

--- a/testing/rpath_test.py
+++ b/testing/rpath_test.py
@@ -299,7 +299,7 @@ class FilenameOps(RPathTest):
         b"//host/share": b"//host/share",
         b"//host//share/": b"//host/share",
     }
-    if sys.platform.startswith("win"):  # Windows doesn't like double slashes
+    if not sys.platform.startswith("win"):  # Windows doesn't like double slashes
         normdict[b"//"] = b"/"
     dirsplitdict = {
         b"/": (b"", b""),
@@ -619,7 +619,7 @@ class FileAttributes(FileBasis):
             self.hl1,
             self.dir,
         ]
-        if sys.platform.startswith("win"):  # symlinks not supported under Windows
+        if not sys.platform.startswith("win"):  # symlinks not supported under Windows
             copy_list.append(self.sym)
         for rp in copy_list:
             rpath.copy_with_attribs(rp, out)

--- a/testing/rpath_test.py
+++ b/testing/rpath_test.py
@@ -64,7 +64,7 @@ class CheckTypes(RPathTest):
         self.assertTrue(rpath.RPath(self.lc, self.prefix, ("regular_file",)).isreg())
         self.assertFalse(rpath.RPath(self.lc, self.prefix, ("symbolic_link",)).isreg())
 
-    @unittest.skipIf(os.name == "nt", "Fifo don't exist under Windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "Fifo don't exist under Windows")
     def testFifo(self):
         """Fifo's identified"""
         self.assertTrue(rpath.RPath(self.lc, self.prefix, ("fifo",)).isfifo())
@@ -103,7 +103,7 @@ class CheckTypes(RPathTest):
         )
 
 
-@unittest.skipIf(os.name == "nt", "Windows doesn't handle well rights")
+@unittest.skipIf(sys.platform.startswith("win"), "Windows doesn't handle well rights")
 class CheckPerms(RPathTest):
     """Check to see if permissions are reported and set accurately"""
 
@@ -154,7 +154,9 @@ class CheckTimes(RPathTest):
         self.assertEqual(rp.getmtime(), 20000)
         rp.delete()
 
-    @unittest.skipIf(os.name == "nt", "Windows doesn't handle ctime correctly")
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "Windows doesn't handle ctime correctly"
+    )
     def testCtime(self):
         """Check to see if ctime read, compared"""
         rp = rpath.RPath(self.lc, self.prefix, ("ctimetest.1",))
@@ -201,7 +203,7 @@ class CheckDir(RPathTest):
         self.assertEqual(dirlist, [b"1", b"2", b"3", b"4"])
 
 
-@unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
+@unittest.skipIf(sys.platform.startswith("win"), "Symlinks not supported under Windows")
 class CheckSyms(RPathTest):
     """Check symlinking and reading"""
 
@@ -222,7 +224,7 @@ class CheckSyms(RPathTest):
         link.delete()
 
 
-@unittest.skipIf(os.name == "nt", "Sockets don't exist under Windows")
+@unittest.skipIf(sys.platform.startswith("win"), "Sockets don't exist under Windows")
 class CheckSockets(RPathTest):
     """Check reading and making sockets"""
 
@@ -297,7 +299,7 @@ class FilenameOps(RPathTest):
         b"//host/share": b"//host/share",
         b"//host//share/": b"//host/share",
     }
-    if os.name != "nt":  # Windows doesn't like double slashes
+    if sys.platform.startswith("win"):  # Windows doesn't like double slashes
         normdict[b"//"] = b"/"
     dirsplitdict = {
         b"/": (b"", b""),
@@ -374,7 +376,7 @@ class FileIO(RPathTest):
 
         with rp_gz.open("wb", compress=1) as fp_out:
             fp_out.write(s)
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             self.assertEqual(
                 comtst.os_system((b"7z", b"x", b"-o%s" % self.out_dir, file_gz)), 0
             )
@@ -403,7 +405,7 @@ class FileIO(RPathTest):
         rp_nogz.setdata()
         self.assertTrue(rp_nogz.lstat())
 
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             self.assertEqual(
                 comtst.os_system(
                     (b"7z", b"a", b"-tgzip", b"-sdel", file_gz, file_nogz)
@@ -445,7 +447,9 @@ class FileCopying(FileBasis):
         self.assertFalse(rpath.cmp(self.rf, self.hl1))
         self.assertFalse(rpath.cmp(self.dir, self.rf))
 
-    @unittest.skipIf(os.name == "nt", "Symlinks not supported under Windows")
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "Symlinks not supported under Windows"
+    )
     def testCompMisc(self):
         """Test miscellaneous comparisons"""
         self.assertTrue(rpath.cmp(self.dir, rpath.RPath(self.lc, self.mainprefix, ())))
@@ -479,7 +483,7 @@ class FileCopying(FileBasis):
 
     def testCopy(self):
         """Test copy of various files"""
-        if os.name == "nt":
+        if sys.platform.startswith("win"):
             comp_list = [self.rf, self.dir]
         else:
             comp_list = [self.sl, self.rf, self.fifo, self.dir]
@@ -491,7 +495,9 @@ class FileCopying(FileBasis):
             self.dest.delete()
 
     @unittest.mock.patch("os.rename", side_effect=OSError(errno.EXDEV, "strerror"))
-    @unittest.skipIf(os.name == "nt", "Symlinks And Fifo not supported under Windows")
+    @unittest.skipIf(
+        sys.platform.startswith("win"), "Symlinks And Fifo not supported under Windows"
+    )
     def testRenameCrossDeviceLink(self, mock_rename):
         # Create fifo
         fifo = rpath.RPath(self.lc, self.mainprefix, ("fifo",))
@@ -613,7 +619,7 @@ class FileAttributes(FileBasis):
             self.hl1,
             self.dir,
         ]
-        if os.name != "nt":  # symlinks not supported under Windows
+        if sys.platform.startswith("win"):  # symlinks not supported under Windows
             copy_list.append(self.sym)
         for rp in copy_list:
             rpath.copy_with_attribs(rp, out)


### PR DESCRIPTION

<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

Use sys.version_info and sys.platform to differentiate respectively Python versions and operating systems because this is what Mypy understands according to https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
The trigger for this was that check-static fails under Windows.

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
