### PR TITLE
Graciously fail when removing since a wrong date

### DIFF
--- a/src/rdiffbackup/locations/_repo_shadow.py
+++ b/src/rdiffbackup/locations/_repo_shadow.py
@@ -1228,7 +1228,13 @@ class RepoShadow(location.LocationShadow):
             show_sizes = cls._values.get("size")
         removal_time = cls._get_removal_time(time_string, show_sizes)
 
-        if removal_time < 0:  # no increment is old enough
+        if removal_time is None:  # time couldn't be parsed
+            log.Log(
+                "Can't parse time of removal '{tr}'".format(tr=time_string),
+                log.ERROR,
+            )
+            return consts.RET_CODE_ERR
+        elif removal_time < 0:  # no increment is old enough
             log.Log(
                 "No increment is older than '{ot}'".format(ot=time_string),
                 log.WARNING,

--- a/testing/action_remove_test.py
+++ b/testing/action_remove_test.py
@@ -133,6 +133,19 @@ class ActionRemoveIncsTest(ActionRemoveTest):
 
     def test_action_removeincsolderthan(self):
         """test different ways of removing increments"""
+        # Removing fails cleanly if the date can't be parsed
+        self.assertEqual(
+            comtst.rdiff_backup_action(
+                False,
+                None,
+                self.bak_path,
+                None,
+                (),
+                b"remove",
+                ("increments", "--older-than", "not-a-date"),
+            ),
+            consts.RET_CODE_ERR,
+        )
         # removing multiple increments fails without --force
         self.assertNotEqual(
             comtst.rdiff_backup_action(


### PR DESCRIPTION
<!--
    check our development guide
    https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc

    You can remove those kind of comments once you're done with them
-->

<!-- TIP: add `[DOC]` at the beginning of the subject for documentation-only
     pull requests -->

## Changes done and why

FIX: graciously fail when removing increments since a wrongly formatted date instead of raising a confusing TypeError

This is an issue discovered while reviewing PR #1101 

<!--
    In the best case, move the commit message included by GitHub above to here.

    If your explanation needs to be (very) different from your Git commit
    message, your Git commit might be insufficient,
    please re-think it and amend it!

    Your message must contain `Closes #NNN` if it [closes an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Self-Checklist

<!--
    It is the responsibility of the author of the pull request (PR) to go
    through this checklist and tick all points off.
    PRs won't be reviewed before all points have been ticked off.

    It is valid to:

    1. leave at first a point unticked and ask questions in the comments
       if you're unsure, PRs can be amended and checks can be ticked once
       the point has been cleared
    2. to tick the point without doing anything, because it is irrelevant
       (e.g. code bug fix seldomly require changes to the documentation,
       and pure documentation changes don't need tests). In doubtful cases
       add a short explanation why nothing was done, but tick the box.
-->

- [x] changes to the code have been reflected in the documentation
- [x] changes to the code have been covered by new/modified tests
- [x] commit contains a description of changes relevant to users prefixed by DOC:, FIX:, NEW: and/or CHG:

<!--
    for details on this last point, check the [developer documentation](https://github.com/rdiff-backup/rdiff-backup/blob/master/docs/DEVELOP.adoc#commits)
-->
